### PR TITLE
fix: don't commit package.json

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Commit version changes
         run: |
           VERSION="${{ steps.version_info.outputs.version }}"
-          git add -A
+          git add pyproject.toml CHANGELOG.md
           git commit -m "chore: bump version to ${VERSION}" || echo "No changes to commit"
 
       - name: Push release branch

--- a/poetry.lock
+++ b/poetry.lock
@@ -2806,4 +2806,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "76bf60c72488b9891528d8c43d525096daa11e65f14f772a068bdabe5443df9f"
+content-hash = "295d7fb895c0b6c1bd001557b10276fbf9fbbec1d9d354b89593823825341e96"


### PR DESCRIPTION
## Description

Small fix to the pre-release workflow so that it does not commit package.json and package-lock.json that are created when installing auto-changelog

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
