### PR TITLE
feat: make ONLY_SUBSCRIBER the default redemption type

### DIFF
--- a/payments_py/plans.py
+++ b/payments_py/plans.py
@@ -142,7 +142,7 @@ def get_expirable_duration_config(duration_of_plan: int) -> PlanCreditsConfig:
     """
     return PlanCreditsConfig(
         is_redemption_amount_fixed=False,
-        redemption_type=PlanRedemptionType.ONLY_OWNER,
+        redemption_type=PlanRedemptionType.ONLY_SUBSCRIBER,
         proof_required=False,
         duration_secs=duration_of_plan,
         amount="1",
@@ -176,7 +176,7 @@ def get_fixed_credits_config(
     """
     return PlanCreditsConfig(
         is_redemption_amount_fixed=True,
-        redemption_type=PlanRedemptionType.ONLY_OWNER,
+        redemption_type=PlanRedemptionType.ONLY_SUBSCRIBER,
         proof_required=False,
         duration_secs=0,
         amount=str(credits_granted),
@@ -203,7 +203,7 @@ def get_dynamic_credits_config(
     """
     return PlanCreditsConfig(
         is_redemption_amount_fixed=False,
-        redemption_type=PlanRedemptionType.ONLY_OWNER,
+        redemption_type=PlanRedemptionType.ONLY_SUBSCRIBER,
         proof_required=False,
         duration_secs=0,
         amount=str(credits_granted),


### PR DESCRIPTION
## Description

- Makes ONLY_SUBSCRIBER the default redemption type

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/nvm-monorepo/issues/772
Closes #92 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
