### PR TITLE
fix: update starlette to ^0.49.1 for security vulnerabilities

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2568,22 +2568,23 @@ uvicorn = ["uvicorn (>=0.34.0)"]
 
 [[package]]
 name = "starlette"
-version = "0.40.0"
+version = "0.49.3"
 description = "The little ASGI library that shines."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "starlette-0.40.0-py3-none-any.whl", hash = "sha256:c494a22fae73805376ea6bf88439783ecfba9aac88a43911b48c653437e784c4"},
-    {file = "starlette-0.40.0.tar.gz", hash = "sha256:1a3139688fb298ce5e2d661d37046a66ad996ce94be4d4983be019a23a04ea35"},
+    {file = "starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f"},
+    {file = "starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284"},
 ]
 markers = {main = "extra == \"fastapi\""}
 
 [package.dependencies]
-anyio = ">=3.4.0,<5"
+anyio = ">=3.6.2,<5"
+typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
-full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "tomli"
@@ -2962,4 +2963,4 @@ fastapi = ["fastapi", "starlette"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "5cecd63872018c5bc4a94e9e59d5e012c1c8222786f116c43b7f41cb8b3fe1d0"
+content-hash = "9bd6765dc5123b272593d13837fcde13b4da6ece8c70ee65118ae54058b0966c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ helicone-helpers = "^1.1.1"
 jsonschema = "^4.25.1"
 # Optional dependencies
 fastapi = {version = "^0.120.0", optional = true}
-starlette = {version = "^0.40.0", optional = true}
+starlette = {version = "^0.49.1", optional = true}
 
 [tool.poetry.extras]
 fastapi = ["fastapi", "starlette"]


### PR DESCRIPTION
## Summary
- Updates starlette from `^0.40.0` to `^0.49.1` to address security vulnerabilities
- Resolves Dependabot alerts for DoS vulnerabilities in starlette

## Security Issues Addressed
- **High**: DoS via Range header merging in `starlette.responses.FileResponse`
- **Medium**: DoS via large files in multipart forms

## Test plan
- [ ] Verify build succeeds
- [ ] Verify existing tests pass
- [ ] Confirm Dependabot alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)