### PR TITLE
fix: set default mike version on main branch deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           poetry run mike deploy --push --update-aliases dev latest
+          poetry run mike set-default --push latest
 
       - name: Deploy docs for version tag
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary
- Add `mike set-default --push latest` to main branch deploy step
- This ensures the root index.html redirects to the latest version instead of showing old content

## Test plan
- [ ] After merge, verify https://nevermined-io.github.io/payments-py/ redirects to the Material theme documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)