### PR TITLE
docs: fix x402 header from Authorization/X-Payment to payment-signature

### DIFF
--- a/docs/api/05-publishing-static-resources.md
+++ b/docs/api/05-publishing-static-resources.md
@@ -176,29 +176,7 @@ software_result = payments.agents.register_agent(
 
 ## Accessing Static Resources
 
-Subscribers can access static resources using the x402 access token:
-
-```python
-# As a subscriber, get access token
-access_result = payments.x402.get_x402_access_token(
-    plan_id=plan_id,
-    agent_id=resource_id
-)
-access_token = access_result['accessToken']
-
-# Download a file
-import requests
-
-response = requests.get(
-    "https://storage.example.com/datasets/training-data.csv",
-    headers={"Authorization": f"Bearer {access_token}"}
-)
-
-if response.status_code == 200:
-    with open("training-data.csv", "wb") as f:
-        f.write(response.content)
-    print("File downloaded successfully")
-```
+For details on how subscribers access static resources using x402 access tokens, see [Request Validation](08-validation-of-requests.md).
 
 ## Best Practices
 

--- a/docs/api/06-payments-and-balance.md
+++ b/docs/api/06-payments-and-balance.md
@@ -218,4 +218,4 @@ if final_balance.is_subscriber:
 ## Next Steps
 
 - [Querying an Agent](07-querying-an-agent.md) - Get access tokens and make requests
-- [Validation of Requests](08-validation-of-requests.md) - How agents validate requests
+- [Request Validation](08-validation-of-requests.md) - How agents validate requests

--- a/docs/api/07-querying-an-agent.md
+++ b/docs/api/07-querying-an-agent.md
@@ -58,9 +58,9 @@ result = payments.x402.get_x402_access_token(
 
 ## Make Requests to Agents
 
-### Using the Access Token
+### Using the x402 Payment Header
 
-Include the access token in the `Authorization` header:
+Include the access token in the `payment-signature` header (per [x402 v2 HTTP transport spec](https://github.com/coinbase/x402/blob/main/specs/transports-v2/http.md)):
 
 ```python
 import requests
@@ -76,7 +76,7 @@ access_token = token_result['accessToken']
 response = requests.post(
     f"https://agent-api.example.com/agents/{agent_id}/tasks",
     headers={
-        "Authorization": f"Bearer {access_token}",
+        "payment-signature": access_token,
         "Content-Type": "application/json"
     },
     json={
@@ -92,21 +92,6 @@ elif response.status_code == 402:
     print("Payment required - check plan balance")
 else:
     print(f"Error: {response.status_code}")
-```
-
-### Using the X-Payment Header
-
-Alternative header format used by some agents:
-
-```python
-response = requests.post(
-    agent_endpoint,
-    headers={
-        "X-Payment": access_token,
-        "Content-Type": "application/json"
-    },
-    json=payload
-)
 ```
 
 ## Decode Access Token
@@ -177,7 +162,7 @@ access_token = token_result['accessToken']
 response = requests.post(
     "https://api.example.com/tasks",
     headers={
-        "Authorization": f"Bearer {access_token}",
+        "payment-signature": access_token,
         "Content-Type": "application/json"
     },
     json={"prompt": "Hello, agent!"}
@@ -236,7 +221,7 @@ except requests.HTTPError as e:
        │ ◄───────────────── │                    │
        │   accessToken      │                    │
        │                    │                    │
-       │ POST /tasks (Bearer token)              │
+       │ POST /tasks (payment-signature header)  │
        │ ────────────────────────────────────────►
        │                    │                    │
        │                    │  verify_permissions│
@@ -254,5 +239,5 @@ except requests.HTTPError as e:
 
 ## Next Steps
 
-- [Validation of Requests](08-validation-of-requests.md) - How agents validate incoming requests
+- [Request Validation](08-validation-of-requests.md) - How agents validate incoming requests
 - [x402 Protocol](11-x402.md) - Deep dive into x402 verification and settlement

--- a/docs/api/08-validation-of-requests.md
+++ b/docs/api/08-validation-of-requests.md
@@ -1,4 +1,4 @@
-# Validation of Requests
+# Request Validation
 
 This guide explains how AI agents can validate incoming requests using the Nevermined Payments Python SDK.
 
@@ -14,7 +14,7 @@ The SDK provides the Facilitator API for these operations.
 
 ## Receiving Requests
 
-Agents receive requests with the access token in the `Authorization` or `X-Payment` header:
+Agents receive requests with the x402 access token in the `payment-signature` header (per [x402 v2 HTTP transport spec](https://github.com/coinbase/x402/blob/main/specs/transports-v2/http.md)):
 
 ```python
 from flask import Flask, request, jsonify
@@ -23,15 +23,11 @@ app = Flask(__name__)
 
 @app.route('/tasks', methods=['POST'])
 def handle_task():
-    # Extract token from header
-    auth_header = request.headers.get('Authorization', '')
-    if auth_header.startswith('Bearer '):
-        access_token = auth_header[7:]  # Remove 'Bearer ' prefix
-    else:
-        access_token = request.headers.get('X-Payment', '')
+    # Extract x402 token from payment-signature header
+    x402_token = request.headers.get('payment-signature', '')
 
-    if not access_token:
-        return jsonify({'error': 'Missing access token'}), 401
+    if not x402_token:
+        return jsonify({'error': 'Missing payment-signature header'}), 402
 
     # Validate and process...
 ```
@@ -114,12 +110,10 @@ PLAN_ID = "your-plan-id"
 
 @app.route('/api/tasks', methods=['POST'])
 def create_task():
-    # 1. Extract access token
-    auth_header = request.headers.get('Authorization', '')
-    if not auth_header.startswith('Bearer '):
-        return jsonify({'error': 'Missing Bearer token'}), 401
-
-    access_token = auth_header[7:]
+    # 1. Extract x402 access token from payment-signature header
+    access_token = request.headers.get('payment-signature', '')
+    if not access_token:
+        return jsonify({'error': 'Missing payment-signature header'}), 402
 
     # 2. Build payment required object
     payment_required = build_payment_required(
@@ -170,7 +164,7 @@ if __name__ == '__main__':
     app.run(port=8080)
 ```
 
-## FastAPI Example with Middleware
+## FastAPI Example with Manual Validation
 
 ```python
 from fastapi import FastAPI, Request, HTTPException
@@ -188,11 +182,10 @@ PLAN_ID = "your-plan-id"
 
 async def validate_payment(request: Request) -> dict:
     """Validate payment and return verification result."""
-    auth_header = request.headers.get('Authorization', '')
-    if not auth_header.startswith('Bearer '):
-        raise HTTPException(status_code=401, detail="Missing Bearer token")
-
-    access_token = auth_header[7:]
+    # Extract x402 token from payment-signature header
+    access_token = request.headers.get('payment-signature', '')
+    if not access_token:
+        raise HTTPException(status_code=402, detail="Missing payment-signature header")
 
     payment_required = build_payment_required(
         plan_id=PLAN_ID,

--- a/docs/api/10-a2a-integration.md
+++ b/docs/api/10-a2a-integration.md
@@ -298,4 +298,4 @@ result = payments.a2a["start"](
 ## Next Steps
 
 - [x402 Protocol](11-x402.md) - Deep dive into x402 payment protocol
-- [Validation of Requests](08-validation-of-requests.md) - Manual validation patterns
+- [Request Validation](08-validation-of-requests.md) - Manual validation patterns

--- a/docs/api/11-x402.md
+++ b/docs/api/11-x402.md
@@ -201,12 +201,10 @@ AGENT_ID = "your-agent-id"
 
 @app.route('/api/process', methods=['POST'])
 def process_request():
-    # 1. Extract token
-    auth = request.headers.get('Authorization', '')
-    if not auth.startswith('Bearer '):
-        return jsonify({'error': 'Missing token'}), 401
-
-    token = auth[7:]
+    # 1. Extract x402 token from payment-signature header
+    token = request.headers.get('payment-signature', '')
+    if not token:
+        return jsonify({'error': 'Missing payment-signature header'}), 402
 
     # 2. Build payment requirement
     payment_required = build_payment_required(
@@ -280,7 +278,7 @@ if __name__ == '__main__':
        │ {accessToken: "..."}           │                                │
        │                                │                                │
        │ GET /api/process               │                                │
-       │ Authorization: Bearer <token>  │                                │
+       │ payment-signature: <token>     │                                │
        │ ─────────────────────────────► │                                │
        │                                │                                │
        │                                │ verify_permissions()           │
@@ -326,5 +324,5 @@ if __name__ == '__main__':
 
 ## Next Steps
 
-- [Validation of Requests](08-validation-of-requests.md) - More validation patterns
+- [Request Validation](08-validation-of-requests.md) - More validation patterns
 - [MCP Integration](09-mcp-integration.md) - x402 with MCP servers

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ Step-by-step guides for using the SDK:
 5. [Publishing Static Resources](api/05-publishing-static-resources.md) - Publish files and datasets
 6. [Payments and Balance](api/06-payments-and-balance.md) - Order plans and check balances
 7. [Querying an Agent](api/07-querying-an-agent.md) - Get access tokens and make requests
-8. [Validation of Requests](api/08-validation-of-requests.md) - Validate incoming requests
+8. [Request Validation](api/08-validation-of-requests.md) - Validate incoming requests
 9. [MCP Integration](api/09-mcp-integration.md) - Build MCP servers with payments
 10. [A2A Integration](api/10-a2a-integration.md) - Agent-to-Agent protocol integration
 11. [x402 Protocol](api/11-x402.md) - Payment permissions and settlement

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ nav:
     - 05. Publishing Static Resources: api/05-publishing-static-resources.md
     - 06. Payments and Balance: api/06-payments-and-balance.md
     - 07. Querying an Agent: api/07-querying-an-agent.md
-    - 08. Validation of Requests: api/08-validation-of-requests.md
+    - 08. Request Validation: api/08-validation-of-requests.md
     - 09. MCP Integration: api/09-mcp-integration.md
     - 10. A2A Integration: api/10-a2a-integration.md
     - 11. x402 Protocol: api/11-x402.md

--- a/payments_py/x402/README.md
+++ b/payments_py/x402/README.md
@@ -192,9 +192,9 @@ facilitator = NeverminedFacilitator(
 
 @app.route("/api/data")
 def get_data():
-    x_payment = request.headers.get("X-Payment")
+    payment_token = request.headers.get("payment-signature")
 
-    if not x_payment:
+    if not payment_token:
         # Return 402 Payment Required
         return jsonify({
             "x402Version": 2,
@@ -351,7 +351,7 @@ sequenceDiagram
     BC-->>F: Balance OK
     F-->>C: Access token
 
-    C->>S: GET /api/data<br/>(with X-Payment header)
+    C->>S: GET /api/data<br/>(with payment-signature header)
 
     S->>F: Verify payment
     F->>BC: Check token validity

--- a/payments_py/x402/facilitator_api.py
+++ b/payments_py/x402/facilitator_api.py
@@ -27,8 +27,8 @@ Example usage:
         extensions={}
     )
 
-    # Get X402 access token from subscriber request
-    x402_token = request.headers.get("X-Payment")
+    # Get X402 access token from payment-signature header (x402 v2 spec)
+    x402_token = request.headers.get("payment-signature")
 
     # Verify if subscriber has sufficient permissions/credits
     verification = payments.facilitator.verify_permissions(

--- a/payments_py/x402/types_v2.py
+++ b/payments_py/x402/types_v2.py
@@ -124,7 +124,7 @@ class PaymentPayloadV2(BaseModel):
     """
     x402 v2 Payment Payload with extensions support.
 
-    This is sent by the client in the X-PAYMENT header to pay for a resource.
+    This is sent by the client in the payment-signature header to pay for a resource.
 
     Extends the base x402 PaymentPayload to include the extensions field.
     The client copies extensions from the PaymentRequired response into


### PR DESCRIPTION
## Summary

- Fix x402 documentation to use correct `payment-signature` header per [x402 v2 HTTP transport spec](https://github.com/coinbase/x402/blob/main/specs/transports-v2/http.md)
- Update e2e tests to be consistent with the middleware implementation
- Rename "Validation of Requests" section to "Request Validation"

## Changes

**Documentation (`docs/api/`):**
- `07-querying-an-agent.md` - Updated examples and flow diagram
- `08-validation-of-requests.md` - Renamed title, updated Flask/FastAPI examples
- `11-x402.md` - Updated complete example and HTTP flow diagram
- `05-publishing-static-resources.md` - Simplified with link to Request Validation
- Updated references in `index.md`, `06-payments-and-balance.md`, `10-a2a-integration.md`

**Code:**
- `payments_py/x402/facilitator_api.py` - Updated docstring example
- `payments_py/x402/types_v2.py` - Updated class comment
- `payments_py/x402/README.md` - Updated examples and mermaid diagram

**Tests:**
- `tests/e2e/test_payments_e2e.py` - Updated `MockAgentHandler` and request tests to use `payment-signature`

## Header usage by protocol

| Protocol | Header | Status |
|----------|--------|--------|
| x402 HTTP | `payment-signature` | ✅ Fixed |
| A2A | `Authorization: Bearer` | ✅ Correct (per A2A spec) |
| MCP OAuth | `Authorization: Bearer` | ✅ Correct (per OAuth spec) |

## Test plan

- [x] Unit tests pass (`pytest tests/unit/x402/test_fastapi_middleware.py`)
- [x] Documentation builds (`mkdocs build`)
- [x] Code formatted (`poetry run black .`)
- [ ] E2E tests pass (requires staging environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)