### PR TITLE
fix(a2a): fix streaming settlement — check TaskStatusUpdateEvent instead of dict

### DIFF
--- a/tests/integration/a2a/test_payments_stream_and_push.py
+++ b/tests/integration/a2a/test_payments_stream_and_push.py
@@ -137,15 +137,14 @@ async def test_stream_and_resubscribe(agent_card, payments_stub):  # noqa: D401
         if http_ctx:
             handler.set_http_ctx_for_task("task-123", http_ctx)
 
-        # Yield a status update event with credits used
-        yield {
-            "kind": "status-update",
-            "taskId": "task-123",
-            "contextId": "ctx-123",
-            "final": True,
-            "status": {"state": "completed"},
-            "metadata": {"creditsUsed": 2},
-        }
+        # Yield a proper Pydantic TaskStatusUpdateEvent (not a dict)
+        yield TaskStatusUpdateEvent(
+            task_id="task-123",
+            context_id="ctx-123",
+            final=True,
+            status=TaskStatus(state=TaskState.completed),
+            metadata={"creditsUsed": 2},
+        )
 
     with unittest.mock.patch.object(
         handler.__class__.__bases__[0],


### PR DESCRIPTION
## Summary

- **Root cause**: `on_message_send_stream` checked `isinstance(event, dict)` but the parent `DefaultRequestHandler` yields Pydantic `TaskStatusUpdateEvent` objects — so the settlement branch was **never reached** and credits were never burned after A2A streaming requests.
- Fixed type checks from `isinstance(event, dict)` → `isinstance(event, TaskStatusUpdateEvent)` and switched from dict `.get()` access to Pydantic attribute access (`.final`, `.metadata`, `.status.state`, `.task_id`)
- Removed debug `print()` statements, replaced with `logger.warning()` for errors
- Updated tests to yield `TaskStatusUpdateEvent` instead of raw dicts

## Test plan

- [x] All 366 tests pass (`poetry run pytest -m "not slow" -v`)
- [x] `black --check` passes
- [ ] Manual test: run a seller agent with payments + buyer agent, verify credits are actually burned after A2A streaming purchase

🤖 Generated with [Claude Code](https://claude.com/claude-code)