### PR TITLE
feat(a2a): pass agent_request_id through settlement for observability

### DIFF
--- a/tests/integration/a2a/test_complete_message_send_flow.py
+++ b/tests/integration/a2a/test_complete_message_send_flow.py
@@ -75,6 +75,7 @@ class MockFacilitatorAPI:
         payment_required=None,
         max_amount: str = None,
         x402_access_token: str = None,
+        agent_request_id: str = None,
     ):
         """Mock settle_permissions with x402 API."""
         from payments_py.x402.types import SettleResponse

--- a/tests/integration/a2a/test_decorator_integration.py
+++ b/tests/integration/a2a/test_decorator_integration.py
@@ -68,6 +68,7 @@ class MockFacilitatorAPI:
         payment_required=None,
         max_amount: str = None,
         x402_access_token: str = None,
+        agent_request_id: str = None,
     ):
         self.settle_call_count += 1
         self.last_settle_credits = int(max_amount) if max_amount else 0

--- a/tests/unit/a2a/test_payments_request_handler_stream.py
+++ b/tests/unit/a2a/test_payments_request_handler_stream.py
@@ -96,3 +96,156 @@ async def test_streaming_burns_credits():  # noqa: D401
     assert call_kwargs["x402_access_token"] == "TOK"
     assert call_kwargs["max_amount"] == "7"
     assert call_kwargs["payment_required"] is not None
+    assert (
+        call_kwargs["agent_request_id"] is None
+    )  # No agent_request_id in validation or metadata
+
+
+@pytest.mark.asyncio()  # noqa: D401
+async def test_streaming_passes_agent_request_id_from_validation():  # noqa: D401
+    """Test streaming settlement passes agent_request_id from validation context."""
+    settle_mock = Mock(
+        return_value={
+            "success": True,
+            "txHash": "0x123",
+            "data": {"creditsBurned": "3"},
+        }
+    )
+    dummy_payments = SimpleNamespace(
+        facilitator=SimpleNamespace(settle_permissions=settle_mock),
+    )
+
+    async def fake_stream(*_args, **_kwargs):  # noqa: D401
+        yield TaskStatusUpdateEvent(
+            task_id="tid",
+            context_id="ctx-123",
+            final=True,
+            status=TaskStatus(state=TaskState.completed),
+            metadata={"creditsUsed": 3},
+        )
+
+    with patch(
+        "payments_py.a2a.payments_request_handler.DefaultRequestHandler.on_message_send_stream",
+        new=fake_stream,
+    ):
+        task_store = InMemoryTaskStore()
+        test_task = Task(
+            id="tid",
+            context_id="ctx-123",
+            status=TaskStatus(state=TaskState.completed),
+        )
+        await task_store.save(test_task)
+
+        handler = PaymentsRequestHandler(
+            agent_card={
+                "capabilities": {
+                    "extensions": [
+                        {
+                            "uri": "urn:nevermined:payment",
+                            "params": {"agentId": "agent-1", "planId": "plan-123"},
+                        }
+                    ]
+                }
+            },
+            task_store=task_store,
+            agent_executor=DummyExecutor(),
+            payments_service=dummy_payments,  # type: ignore[arg-type]
+            push_config_store=InMemoryPushNotificationConfigStore(),
+        )
+
+        ctx = HttpRequestContext(
+            bearer_token="TOK",
+            url_requested="https://x",
+            http_method_requested="POST",
+            validation={
+                "plan_id": "plan-123",
+                "subscriber_address": "0xSub123",
+                "agent_request_id": "req-stream-abc",
+            },
+        )
+        handler.set_http_ctx_for_task("tid", ctx)
+
+        events = []
+        async for ev in handler.on_message_send_stream(
+            SimpleNamespace(message=SimpleNamespace(task_id="tid", message_id="mid")),
+            None,
+        ):
+            events.append(ev)
+
+    assert len(events) == 1
+    settle_mock.assert_called_once()
+    call_kwargs = settle_mock.call_args.kwargs
+    assert call_kwargs["agent_request_id"] == "req-stream-abc"
+
+
+@pytest.mark.asyncio()  # noqa: D401
+async def test_streaming_passes_agent_request_id_from_event_metadata():  # noqa: D401
+    """Test streaming settlement falls back to agentRequestId from event metadata."""
+    settle_mock = Mock(
+        return_value={
+            "success": True,
+            "txHash": "0x123",
+            "data": {"creditsBurned": "2"},
+        }
+    )
+    dummy_payments = SimpleNamespace(
+        facilitator=SimpleNamespace(settle_permissions=settle_mock),
+    )
+
+    async def fake_stream(*_args, **_kwargs):  # noqa: D401
+        yield TaskStatusUpdateEvent(
+            task_id="tid",
+            context_id="ctx-123",
+            final=True,
+            status=TaskStatus(state=TaskState.completed),
+            metadata={"creditsUsed": 2, "agentRequestId": "req-meta-456"},
+        )
+
+    with patch(
+        "payments_py.a2a.payments_request_handler.DefaultRequestHandler.on_message_send_stream",
+        new=fake_stream,
+    ):
+        task_store = InMemoryTaskStore()
+        test_task = Task(
+            id="tid",
+            context_id="ctx-123",
+            status=TaskStatus(state=TaskState.completed),
+        )
+        await task_store.save(test_task)
+
+        handler = PaymentsRequestHandler(
+            agent_card={
+                "capabilities": {
+                    "extensions": [
+                        {
+                            "uri": "urn:nevermined:payment",
+                            "params": {"agentId": "agent-1", "planId": "plan-123"},
+                        }
+                    ]
+                }
+            },
+            task_store=task_store,
+            agent_executor=DummyExecutor(),
+            payments_service=dummy_payments,  # type: ignore[arg-type]
+            push_config_store=InMemoryPushNotificationConfigStore(),
+        )
+
+        ctx = HttpRequestContext(
+            bearer_token="TOK",
+            url_requested="https://x",
+            http_method_requested="POST",
+            validation={"plan_id": "plan-123", "subscriber_address": "0xSub123"},
+        )
+        handler.set_http_ctx_for_task("tid", ctx)
+
+        events = []
+        async for ev in handler.on_message_send_stream(
+            SimpleNamespace(message=SimpleNamespace(task_id="tid", message_id="mid")),
+            None,
+        ):
+            events.append(ev)
+
+    assert len(events) == 1
+    settle_mock.assert_called_once()
+    call_kwargs = settle_mock.call_args.kwargs
+    assert call_kwargs["agent_request_id"] == "req-meta-456"


### PR DESCRIPTION
## Summary

- `PaymentsRequestHandler.validate_request()` now captures `agent_request` and `agent_request_id` from the `verify_permissions()` result and exposes them as instance attributes (`latest_agent_request`, `latest_agent_request_id`) and in the validation dict
- `_handle_task_finalization_from_event()` and `on_message_send_stream()` now resolve `agent_request_id` (from validation context or event metadata fallback) and pass it to `settle_permissions()`
- Extracted `_resolve_agent_request_id()` helper to DRY the resolution logic across both settlement paths

This enables the Nevermined backend to call `updateObservabilityAndTask` during settlement, populating cost fields in the dashboard that were previously always zero.

## Test plan

- [x] 6 new unit tests covering agent_request_id propagation (validation capture, blocking settlement from validation, blocking settlement from event metadata, streaming from validation, streaming from event metadata, None fallback)
- [x] Updated integration test mocks to accept `agent_request_id` parameter
- [x] Full test suite passes (398 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)