### PR TITLE
fix: update Stripe checkout endpoint from /checkout to /payment

### DIFF
--- a/payments_py/api/nvm_api.py
+++ b/payments_py/api/nvm_api.py
@@ -40,7 +40,7 @@ API_URL_VERIFY_PERMISSIONS = "/api/v1/x402/verify"
 API_URL_SETTLE_PERMISSIONS = "/api/v1/x402/settle"
 
 # Stripe endpoints
-API_URL_STRIPE_CHECKOUT = "/api/v1/stripe/checkout"
+API_URL_STRIPE_CHECKOUT = "/api/v1/stripe/payment"
 
 # Info endpoint
 API_URL_INFO = "/"


### PR DESCRIPTION
## Summary

- Updates the Stripe checkout API endpoint constant `API_URL_STRIPE_CHECKOUT` in `payments_py/api/nvm_api.py`
- Changes path from `/api/v1/stripe/checkout` to `/api/v1/stripe/payment` to match the current backend API

## Test plan

- [ ] Verify Stripe fiat plan checkout works end-to-end against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)