### PR TITLE
fix: update Stripe checkout route to /api/v1/fiat/stripe/payment

### DIFF
--- a/payments_py/api/nvm_api.py
+++ b/payments_py/api/nvm_api.py
@@ -40,7 +40,7 @@ API_URL_VERIFY_PERMISSIONS = "/api/v1/x402/verify"
 API_URL_SETTLE_PERMISSIONS = "/api/v1/x402/settle"
 
 # Stripe endpoints
-API_URL_STRIPE_CHECKOUT = "/api/v1/stripe/payment"
+API_URL_STRIPE_CHECKOUT = "/api/v1/fiat/stripe/payment"
 
 # Info endpoint
 API_URL_INFO = "/"


### PR DESCRIPTION
## Summary

- Fixes `order_fiat_plan()` returning 404 for all callers
- The backend moved the Stripe payment endpoint from `/api/v1/stripe/payment` to `/api/v1/fiat/stripe/payment`
- One-line change to the `API_URL_STRIPE_CHECKOUT` constant in `nvm_api.py`

## Test plan

- [ ] Call `payments.plans.order_fiat_plan(plan_id)` against sandbox and verify it no longer returns 404
- [ ] Existing unit/integration tests pass (`poetry run pytest -m "not slow" -v -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)