### PR TITLE
feat: make agent_definition_url and endpoints optional in AgentAPIAttributes

### DIFF
--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -47,15 +47,25 @@ class AgentAPIAttributes(BaseModel):
     """
     API attributes for an agent.
 
-    Defines the API endpoints and authentication configuration for an agent.
+    All fields are optional. Provide ``endpoints`` and/or
+    ``agent_definition_url`` only when you want the platform to enforce a
+    route-level allowlist as **Additional Security** (defense-in-depth on top
+    of any per-route gating the Payments library applies in your agent), or
+    when you want a discoverable agent definition. Otherwise omit them — your
+    library middleware remains the sole gate.
+
     Used when registering agents with :meth:`payments.agents.register_agent` or
     :meth:`payments.agents.register_agent_and_plan`.
 
     Args:
-        endpoints: List of endpoint dictionaries with HTTP verb as key and URL as value.
-                  URLs can include placeholders like `:agentId` which will be replaced.
-        open_endpoints: List of endpoints that don't require authentication
-        agent_definition_url: URL to the agent definition. Can be an OpenAPI spec, MCP Manifest, or A2A agent card. This field is mandatory.
+        endpoints: Optional allowlist of endpoint dictionaries with HTTP verb
+                  as key and URL as value. When provided, the Nevermined
+                  platform enforces this list as Additional Security on x402
+                  verify. URLs can include placeholders like ``:agentId``.
+        open_endpoints: Optional list of endpoints that don't require subscription.
+        agent_definition_url: Optional URL to a discoverable agent definition
+                  (OpenAPI spec, MCP Manifest, or A2A agent card). Stored as
+                  metadata; not consumed at runtime by the platform.
         auth_type: Authentication type (default: AuthType.NONE)
         username: Username for basic auth (if auth_type is BASIC)
         password: Password for basic auth (if auth_type is BASIC)
@@ -64,19 +74,25 @@ class AgentAPIAttributes(BaseModel):
         headers: Additional headers to include in requests
 
     Example::
+        # Minimal (recommended): your library middleware handles per-route gating
+        agent_api = AgentAPIAttributes(
+            auth_type=AuthType.BEARER,
+            token="sk-test",
+        )
+
+        # With Additional Security: platform enforces a route allowlist
         agent_api = AgentAPIAttributes(
             endpoints=[
                 {"POST": "https://example.com/api/v1/agents/:agentId/tasks"},
-                {"GET": "https://example.com/api/v1/agents/:agentId/tasks/:taskId"}
             ],
-            agent_definition_url="https://example.com/api/v1/openapi.json",  # OpenAPI spec, MCP Manifest, or A2A agent card
-            auth_type=AuthType.BEARER
+            agent_definition_url="https://example.com/api/v1/openapi.json",
+            auth_type=AuthType.BEARER,
         )
     """
 
-    endpoints: List[Endpoint]
+    endpoints: Optional[List[Endpoint]] = None
     open_endpoints: Optional[List[str]] = None
-    agent_definition_url: str
+    agent_definition_url: Optional[str] = None
     auth_type: Optional[AuthType] = AuthType.NONE
     username: Optional[str] = None
     password: Optional[str] = None

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -74,6 +74,7 @@ class AgentAPIAttributes(BaseModel):
         headers: Additional headers to include in requests
 
     Example::
+
         # Minimal (recommended): your library middleware handles per-route gating
         agent_api = AgentAPIAttributes(
             auth_type=AuthType.BEARER,
@@ -83,7 +84,7 @@ class AgentAPIAttributes(BaseModel):
         # With Additional Security: platform enforces a route allowlist
         agent_api = AgentAPIAttributes(
             endpoints=[
-                {"POST": "https://example.com/api/v1/agents/:agentId/tasks"},
+                {"verb": "POST", "url": "https://example.com/api/v1/agents/:agentId/tasks"},
             ],
             agent_definition_url="https://example.com/api/v1/openapi.json",
             auth_type=AuthType.BEARER,

--- a/tests/unit/test_agent_api_attributes_optional.py
+++ b/tests/unit/test_agent_api_attributes_optional.py
@@ -1,0 +1,56 @@
+"""Unit tests asserting that AgentAPIAttributes accepts payloads with
+``endpoints`` and ``agent_definition_url`` omitted.
+
+These two fields are now opt-in **Additional Security**.
+
+Refs nevermined-io/internal#897 #911.
+"""
+
+from payments_py.common.types import AgentAPIAttributes, AuthType
+
+
+def test_accepts_empty_payload():
+    attrs = AgentAPIAttributes()
+    assert attrs.endpoints is None
+    assert attrs.agent_definition_url is None
+    assert attrs.open_endpoints is None
+
+
+def test_accepts_only_authentication_fields():
+    attrs = AgentAPIAttributes(auth_type=AuthType.BEARER, token="sk-test-abc")
+    assert attrs.auth_type == AuthType.BEARER
+    assert attrs.token == "sk-test-abc"
+    assert attrs.endpoints is None
+    assert attrs.agent_definition_url is None
+
+
+def test_accepts_only_endpoints_for_additional_security_optin():
+    attrs = AgentAPIAttributes(
+        endpoints=[{"verb": "POST", "url": "https://example.com/api/run"}],
+    )
+    assert attrs.endpoints is not None
+    assert len(attrs.endpoints) == 1
+    assert attrs.agent_definition_url is None
+
+
+def test_accepts_only_agent_definition_url():
+    attrs = AgentAPIAttributes(
+        agent_definition_url="https://example.com/openapi.json",
+    )
+    assert attrs.agent_definition_url == "https://example.com/openapi.json"
+    assert attrs.endpoints is None
+
+
+def test_still_accepts_full_shape():
+    attrs = AgentAPIAttributes(
+        endpoints=[{"verb": "POST", "url": "https://example.com/api/run"}],
+        open_endpoints=["https://example.com/health"],
+        agent_definition_url="https://example.com/openapi.json",
+        auth_type=AuthType.BEARER,
+        token="sk-test",
+    )
+    assert attrs.endpoints is not None
+    assert len(attrs.endpoints) == 1
+    assert attrs.open_endpoints == ["https://example.com/health"]
+    assert attrs.agent_definition_url == "https://example.com/openapi.json"
+    assert attrs.auth_type == AuthType.BEARER


### PR DESCRIPTION
Implements **Phase 2** (Python SDK) of [nevermined-io/internal#897](https://github.com/nevermined-io/internal/issues/897) — see also sub-issue [#911](https://github.com/nevermined-io/internal/issues/911).

## Summary

Both fields in \`AgentAPIAttributes\` Pydantic model are now \`Optional\` with \`None\` defaults:

- \`endpoints: Optional[List[Endpoint]] = None\` — opt-in **Additional Security** route allowlist
- \`agent_definition_url: Optional[str] = None\` — optional discovery metadata

Docstring rewritten to reframe \`endpoints\` as defense-in-depth on top of library-level gating, with both a *minimal* and an *Additional Security* example.

## Why

- The Nevermined platform no longer needs an OpenAPI URL at registration time — it's stored as discoverable metadata only.
- Builders integrating via the Payments library declare paid routes via decorators / middleware (\`@requires_payment\`, \`PaymentMiddleware\`), so requiring the allowlist at registration was redundant for the common case.

## Compatibility

No breakage:
- All E2E test fixtures that provide both fields continue to work unchanged.
- Existing apps that pass these fields are unaffected.

## Test plan

- [x] \`poetry run pytest tests/unit/ -m "not slow"\` — **381 unit tests pass** (incl. 5 new in \`test_agent_api_attributes_optional.py\`)
- [x] \`poetry run black --check .\` — clean
- [ ] **After Phase 1 backend lands on staging:** \`poetry run pytest -m slow\` against staging with a registration payload that omits both fields

## Rollout gate

⚠️ **Depends on:** [nvm-monorepo PR #1348](https://github.com/nevermined-io/nvm-monorepo/pull/1348) being merged to staging first, otherwise SDK calls without these fields will be rejected by the API DTO validation.

Closes #911
Refs #897