### PR TITLE
docs: mark agent_definition_url and endpoints optional; document Additional Security

### DIFF
--- a/docs/api/04-agents.md
+++ b/docs/api/04-agents.md
@@ -33,7 +33,7 @@ agents_api = payments.agents
 Register an agent and associate it with existing payment plans:
 
 ```python
-from payments_py.common.types import AgentMetadata, AgentAPIAttributes
+from payments_py.common.types import AgentMetadata, AgentAPIAttributes, AuthType
 
 # Define agent metadata
 agent_metadata = AgentMetadata(
@@ -43,13 +43,12 @@ agent_metadata = AgentMetadata(
     author="Your Company"
 )
 
-# Define API configuration
+# Define API configuration. All AgentAPIAttributes fields are optional —
+# most builders only need to set authentication. See
+# "AgentAPIAttributes Fields" below for opt-in Additional Security.
 agent_api = AgentAPIAttributes(
-    endpoints=[
-        {"POST": "https://your-api.com/api/v1/agents/:agentId/tasks"},
-        {"GET": "https://your-api.com/api/v1/agents/:agentId/tasks/:taskId"}
-    ],
-    agent_definition_url="https://your-api.com/api/v1/openapi.json"
+    auth_type=AuthType.BEARER,
+    token=os.environ["AGENT_BEARER_TOKEN"],
 )
 
 # List of plan IDs that grant access to this agent
@@ -80,8 +79,8 @@ agent_metadata = AgentMetadata(
 )
 
 agent_api = AgentAPIAttributes(
-    endpoints=[{"POST": "https://your-api.com/api/v1/review"}],
-    agent_definition_url="https://your-api.com/openapi.json"
+    auth_type=AuthType.BEARER,
+    token=os.environ["AGENT_BEARER_TOKEN"],
 )
 
 # Plan configuration
@@ -129,29 +128,42 @@ print(f"Transaction: {result['txHash']}")
 
 ### AgentAPIAttributes Fields
 
+All fields are optional. Provide only what your integration needs.
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `endpoints` | `list[dict]` | Yes | List of endpoint configurations |
-| `agent_definition_url` | `str` | Yes | URL to OpenAPI/MCP/A2A spec |
-| `open_endpoints` | `list[str]` | No | Endpoints without auth |
-| `auth_type` | `AuthType` | No | Authentication type |
+| `auth_type` | `AuthType` | No | Authentication type (default: `AuthType.NONE`) |
+| `token` | `str` | No | Bearer token (when `auth_type` is `BEARER` or `OAUTH`) |
+| `username` | `str` | No | Basic-auth username |
+| `password` | `str` | No | Basic-auth password |
+| `endpoints` | `list[Endpoint]` | No | **Additional Security** allowlist — see below |
+| `open_endpoints` | `list[str]` | No | Public endpoints (no subscription required) |
+| `agent_definition_url` | `str` | No | Discoverable agent definition (OpenAPI / MCP / A2A) |
 
-### Endpoint Configuration
+### Additional Security: Endpoint Allowlist (opt-in)
 
-Endpoints are defined as dictionaries with HTTP verb as key and URL as value:
+Setting `endpoints` opts the agent into a platform-enforced allowlist. When set, only requests matching one of the registered URLs are accepted by x402 verify; mismatches reject with `BCK.PROTOCOL.0031`. When omitted, the platform performs no route-level allowlist check — your Payments library middleware (`PaymentMiddleware`, `@requires_payment`) remains the sole gate.
 
 ```python
+from payments_py.common.types import AgentAPIAttributes, AuthType, Endpoint
+
 agent_api = AgentAPIAttributes(
+    auth_type=AuthType.BEARER,
+    token=os.environ["AGENT_BEARER_TOKEN"],
+    # Opt-in: route allowlist enforced by x402 verify
     endpoints=[
-        {"POST": "https://api.example.com/agents/:agentId/tasks"},
-        {"GET": "https://api.example.com/agents/:agentId/tasks/:taskId"},
-        {"DELETE": "https://api.example.com/agents/:agentId/tasks/:taskId"}
+        Endpoint(verb="POST", url="https://api.example.com/agents/:agentId/tasks"),
+        Endpoint(verb="GET", url="https://api.example.com/agents/:agentId/tasks/:taskId"),
+        Endpoint(verb="DELETE", url="https://api.example.com/agents/:agentId/tasks/:taskId"),
     ],
-    agent_definition_url="https://api.example.com/openapi.json"
+    open_endpoints=["https://api.example.com/health"],
+    agent_definition_url="https://api.example.com/openapi.json",
 )
 ```
 
 The `:agentId` and `:taskId` placeholders will be replaced with actual values during request validation.
+
+> **Migration note:** existing agents that registered before April 2026 still have these fields populated and continue to enforce the allowlist as before. No migration is needed.
 
 ## Retrieve Agents
 
@@ -179,16 +191,24 @@ print(f"Associated plans: {plans}")
 
 ### Update Agent Metadata
 
+`update_agent_metadata` is also where builders typically opt in to **Additional Security** by adding an `endpoints` allowlist or `agent_definition_url` to an existing agent:
+
 ```python
+from payments_py.common.types import AgentMetadata, AgentAPIAttributes, AuthType, Endpoint
+
 updated_metadata = AgentMetadata(
     name="Updated Agent Name",
     description="Updated description with new features",
     tags=["ai", "updated", "v2"]
 )
 
+# Adding `endpoints` activates the platform-enforced allowlist for this
+# agent. To return to allow-all, omit it on the next update.
 updated_api = AgentAPIAttributes(
-    endpoints=[{"POST": "https://new-api.com/v2/tasks"}],
-    agent_definition_url="https://new-api.com/v2/openapi.json"
+    auth_type=AuthType.BEARER,
+    token=os.environ["AGENT_BEARER_TOKEN"],
+    endpoints=[Endpoint(verb="POST", url="https://new-api.com/v2/tasks")],
+    agent_definition_url="https://new-api.com/v2/openapi.json",
 )
 
 result = payments.agents.update_agent_metadata(

--- a/docs/api/04-agents.md
+++ b/docs/api/04-agents.md
@@ -33,6 +33,8 @@ agents_api = payments.agents
 Register an agent and associate it with existing payment plans:
 
 ```python
+import os
+
 from payments_py.common.types import AgentMetadata, AgentAPIAttributes, AuthType
 
 # Define agent metadata
@@ -68,7 +70,14 @@ print(f"Agent ID: {result['agentId']}")
 Create both an agent and a payment plan in a single operation:
 
 ```python
-from payments_py.common.types import AgentMetadata, AgentAPIAttributes, PlanMetadata
+import os
+
+from payments_py.common.types import (
+    AgentMetadata,
+    AgentAPIAttributes,
+    AuthType,
+    PlanMetadata,
+)
 from payments_py.plans import get_erc20_price_config, get_fixed_credits_config
 
 # Agent configuration
@@ -142,9 +151,11 @@ All fields are optional. Provide only what your integration needs.
 
 ### Additional Security: Endpoint Allowlist (opt-in)
 
-Setting `endpoints` opts the agent into a platform-enforced allowlist. When set, only requests matching one of the registered URLs are accepted by x402 verify; mismatches reject with `BCK.PROTOCOL.0031`. When omitted, the platform performs no route-level allowlist check — your Payments library middleware (`PaymentMiddleware`, `@requires_payment`) remains the sole gate.
+Setting `endpoints` opts the agent into a platform-enforced allowlist. When set, only requests matching one of the registered URLs are accepted during x402 verification; non-matching requests are rejected. When omitted, the platform performs no route-level allowlist check — your Payments library middleware (`PaymentMiddleware`, `@requires_payment`) remains the sole gate.
 
 ```python
+import os
+
 from payments_py.common.types import AgentAPIAttributes, AuthType, Endpoint
 
 agent_api = AgentAPIAttributes(
@@ -194,7 +205,14 @@ print(f"Associated plans: {plans}")
 `update_agent_metadata` is also where builders typically opt in to **Additional Security** by adding an `endpoints` allowlist or `agent_definition_url` to an existing agent:
 
 ```python
-from payments_py.common.types import AgentMetadata, AgentAPIAttributes, AuthType, Endpoint
+import os
+
+from payments_py.common.types import (
+    AgentMetadata,
+    AgentAPIAttributes,
+    AuthType,
+    Endpoint,
+)
 
 updated_metadata = AgentMetadata(
     name="Updated Agent Name",

--- a/docs/api/07-querying-an-agent.md
+++ b/docs/api/07-querying-an-agent.md
@@ -162,10 +162,10 @@ plan_id = plan_result['planId']
 
 agent_result = builder.agents.register_agent(
     agent_metadata=AgentMetadata(name="Demo Agent"),
-    agent_api=AgentAPIAttributes(
-        endpoints=[{"POST": "https://api.example.com/tasks"}],
-        agent_definition_url="https://api.example.com/openapi.json"
-    ),
+    # AgentAPIAttributes() with no args registers a minimal agent — your
+    # Payments library middleware handles per-route gating. See
+    # docs/api/04-agents.md for opt-in Additional Security.
+    agent_api=AgentAPIAttributes(),
     payment_plans=[plan_id]
 )
 agent_id = agent_result['agentId']

--- a/payments_py/common/data_models.py
+++ b/payments_py/common/data_models.py
@@ -152,8 +152,9 @@ class CreateAgentDto(BaseModel):
             tags=["ai"],
         )
         # All AgentAPIAttributes fields are optional. The minimal form only
-        # configures authentication; `endpoints` and `agent_definition_url`
-        # are opt-in Additional Security.
+        # configures authentication; `endpoints` is opt-in Additional
+        # Security, and `agent_definition_url` is optional discoverable
+        # definition metadata.
         agent_api = AgentAPIAttributes(
             auth_type=AuthType.BEARER,
             token="your-bearer-token",

--- a/payments_py/common/data_models.py
+++ b/payments_py/common/data_models.py
@@ -139,20 +139,30 @@ class CreateAgentDto(BaseModel):
     Create agent data transfer object.
 
     Example::
-        from payments_py.common.types import AgentMetadata, AgentAPIAttributes
+
+        from payments_py.common.types import (
+            AgentMetadata,
+            AgentAPIAttributes,
+            AuthType,
+        )
 
         agent_metadata = AgentMetadata(
             name="Agent",
             description="Agent description",
-            tags=["ai"]
+            tags=["ai"],
         )
+        # All AgentAPIAttributes fields are optional. The minimal form only
+        # configures authentication; `endpoints` and `agent_definition_url`
+        # are opt-in Additional Security.
         agent_api = AgentAPIAttributes(
-            endpoints=[{"POST": "https://example.com/api/v1/agents/:agentId/tasks"}],
-            agent_definition_url="https://example.com/api/v1/openapi.json"  # OpenAPI spec, MCP Manifest, or A2A agent card
+            auth_type=AuthType.BEARER,
+            token="your-bearer-token",
         )
         payment_plans = [plan_id_1, plan_id_2]
 
-        result = payments.agents.register_agent(agent_metadata, agent_api, payment_plans)
+        result = payments.agents.register_agent(
+            agent_metadata, agent_api, payment_plans
+        )
     """
 
     plan_did: str


### PR DESCRIPTION
Implements **Phase 4** (Python SDK docs portion) of [nevermined-io/internal#897](https://github.com/nevermined-io/internal/issues/897).

## Summary

- \`docs/api/04-agents.md\`: replaces the basic registration example with a minimal \`AgentAPIAttributes\` (\`auth_type\` + \`token\` only); rewrites the field table to mark all fields optional; adds a dedicated **"Additional Security: Endpoint Allowlist (opt-in)"** section explaining the platform-enforced allowlist with the correct \`Endpoint(verb=, url=)\` Pydantic shape; reframes "Update Agent Metadata" as the natural opt-in path.
- \`docs/api/07-querying-an-agent.md\`: drops inline \`endpoints\`/\`agent_definition_url\` from the demo flow.
- \`payments_py/common/data_models.py\`: fixes the \`CreateAgentDto\` docstring example which previously used an \`Endpoint\` shape that fails Pydantic validation (flagged in PR #173 review).

## Why

Phase 1 backend + Phase 2 SDK ([PR #173](https://github.com/nevermined-io/payments-py/pull/173)) made these fields optional. The reference docs still showed them as required.

## Test plan

- [x] \`poetry run black --check .\` clean
- [x] \`poetry run mkdocs build\` succeeds (warnings are pre-existing on \`types.py:290\` for an unrelated class)

Refs nevermined-io/internal#897 #913