### PR TITLE
feat(organizations): expose memberships, activity feed, and per-call workspace targeting

### DIFF
--- a/payments_py/__init__.py
+++ b/payments_py/__init__.py
@@ -17,14 +17,22 @@ from payments_py.common.types import (
     AgentAccessCredentials,
     NvmAPIResult,
     PaginationOptions,
+    MyMembership,
+    OrganizationActivityEvent,
+    OrganizationActivityEventType,
+    OrganizationActivityFilters,
+    OrganizationActivityPage,
+    OrganizationMemberRole,
+    OrganizationType,
 )
 from payments_py.common.payments_error import PaymentsError
 from payments_py.api.query_api import AIQueryApi
 from payments_py.api.plans_api import PlansAPI
 from payments_py.api.agents_api import AgentsAPI
 from payments_py.api.requests_api import AgentRequestsAPI
-from payments_py.api.base_payments import BasePaymentsAPI
+from payments_py.api.base_payments import BasePaymentsAPI, CURRENT_ORG_ID_HEADER
 from payments_py.api.observability_api import ObservabilityAPI
+from payments_py.api.organizations_api import OrganizationsAPI
 
 # X402 Payment Protocol Module
 from payments_py.x402 import (
@@ -119,7 +127,16 @@ __all__ = [
     "AgentsAPI",
     "AgentRequestsAPI",
     "BasePaymentsAPI",
+    "CURRENT_ORG_ID_HEADER",
     "ObservabilityAPI",
+    "OrganizationsAPI",
+    "MyMembership",
+    "OrganizationActivityEvent",
+    "OrganizationActivityEventType",
+    "OrganizationActivityFilters",
+    "OrganizationActivityPage",
+    "OrganizationMemberRole",
+    "OrganizationType",
     # X402 APIs
     "FacilitatorAPI",
     "X402TokenAPI",

--- a/payments_py/api/__init__.py
+++ b/payments_py/api/__init__.py
@@ -7,6 +7,7 @@ from payments_py.api.query_api import AIQueryApi
 from payments_py.api.observability_api import ObservabilityAPI
 from payments_py.api.contracts_api import ContractsAPI
 from payments_py.api.base_payments import BasePaymentsAPI
+from payments_py.api.organizations_api import OrganizationsAPI
 
 __all__ = [
     "AgentsAPI",
@@ -16,4 +17,5 @@ __all__ = [
     "ObservabilityAPI",
     "ContractsAPI",
     "BasePaymentsAPI",
+    "OrganizationsAPI",
 ]

--- a/payments_py/api/agents_api.py
+++ b/payments_py/api/agents_api.py
@@ -15,6 +15,7 @@ from payments_py.common.types import (
     PaginationOptions,
 )
 from payments_py.api.base_payments import BasePaymentsAPI
+from payments_py.api.organizations_api import resolve_publication_headers
 from payments_py.api.nvm_api import (
     API_URL_REGISTER_AGENT,
     API_URL_GET_AGENT,
@@ -49,6 +50,7 @@ class AgentsAPI(BasePaymentsAPI):
         agent_metadata: AgentMetadata,
         agent_api: AgentAPIAttributes,
         payment_plans: List[str],
+        organization_id: Optional[str] = None,
     ) -> Dict[str, str]:
         """
         Registers a new AI Agent on Nevermined.
@@ -60,6 +62,10 @@ class AgentsAPI(BasePaymentsAPI):
             agent_metadata: Agent metadata
             agent_api: Agent API attributes
             payment_plans: The list of payment plans giving access to the agent
+            organization_id: Optional org id (e.g. ``"org-..."``) to publish
+                into for this call only. Sends an ``X-Current-Org-Id``
+                header without mutating the instance-level pin (set via
+                :meth:`Payments.set_organization_id`).
 
         Returns:
             The unique identifier of the newly created agent (Agent Id)
@@ -73,7 +79,9 @@ class AgentsAPI(BasePaymentsAPI):
             "plans": payment_plans,
         }
 
-        options = self.get_backend_http_options("POST", body)
+        options = self.get_backend_http_options(
+            "POST", body, extra_headers=resolve_publication_headers(organization_id)
+        )
         url = f"{self.environment.backend}{API_URL_REGISTER_AGENT}"
 
         response = requests.post(url, **options)
@@ -94,6 +102,7 @@ class AgentsAPI(BasePaymentsAPI):
         price_config: PlanPriceConfig,
         credits_config: PlanCreditsConfig,
         access_limit: Optional[Literal["credits", "time"]] = None,
+        organization_id: Optional[str] = None,
     ) -> Dict[str, str]:
         """
         Registers a new AI Agent and a Payment Plan associated to this new agent.
@@ -107,6 +116,9 @@ class AgentsAPI(BasePaymentsAPI):
             price_config: Plan price configuration
             credits_config: Plan credits configuration
             access_limit: Optional access limit for the plan
+            organization_id: Optional org id (e.g. ``"org-..."``) to publish
+                into for this call only. Sends an ``X-Current-Org-Id``
+                header without mutating the instance-level pin.
         Returns:
             Dictionary containing agentId, planId, and txHash
 
@@ -134,7 +146,9 @@ class AgentsAPI(BasePaymentsAPI):
             },
         }
 
-        options = self.get_backend_http_options("POST", body)
+        options = self.get_backend_http_options(
+            "POST", body, extra_headers=resolve_publication_headers(organization_id)
+        )
         url = f"{self.environment.backend}{API_URL_REGISTER_AGENTS_AND_PLAN}"
 
         response = requests.post(url, **options)

--- a/payments_py/api/base_payments.py
+++ b/payments_py/api/base_payments.py
@@ -43,6 +43,11 @@ def _stringify_unsafe_ints(value: Any) -> Any:
     return value
 
 
+# Header used by the Nevermined backend to resolve the active organization
+# context for an authenticated request. See `CurrentOrgContextGuard` in
+# `apps/api/src/common/guards/current-org-context.guard.ts` (nvm-monorepo).
+CURRENT_ORG_ID_HEADER = "X-Current-Org-Id"
+
 class BasePaymentsAPI:
     """
     Base class extended by all Payments API classes.
@@ -65,6 +70,7 @@ class BasePaymentsAPI:
         self.account_address: Optional[str] = None
         self.helicone_api_key: str = None
         self.is_browser_instance = True
+        self.current_organization_id: Optional[str] = options.organization_id
         self._parse_nvm_api_key()
 
     def _parse_nvm_api_key(self) -> None:
@@ -98,6 +104,33 @@ class BasePaymentsAPI:
         """
         return self.account_address
 
+    def get_organization_id(self) -> Optional[str]:
+        """Return the org id pinned for every authenticated backend call.
+
+        ``None`` means no pinned workspace — the backend falls back to the
+        API key's org tag or the caller's most-recent active membership.
+        """
+        return self.current_organization_id
+
+    def set_organization_id(self, organization_id: Optional[str]) -> None:
+        """Pin (or clear) the organization context used for every authenticated request.
+
+        When set, the SDK forwards the value as the
+        ``X-Current-Org-Id`` header so the backend scopes published
+        agents, plans, and other workspace-aware resources to this
+        organization.
+
+        Pass ``None`` to clear the pin and let the backend fall back to
+        the API key's org tag or the caller's most-recent active
+        membership.
+
+        For one-off targeting on publish, prefer the per-call
+        ``organization_id`` argument on
+        :meth:`payments.agents.register_agent` /
+        :meth:`payments.plans.register_plan` / similar.
+        """
+        self.current_organization_id = organization_id
+
     def pydantic_to_dict(self, obj):
         """
         Recursively convert Pydantic models and Enums to serializable dicts.
@@ -120,7 +153,10 @@ class BasePaymentsAPI:
             return obj
 
     def get_backend_http_options(
-        self, method: str, body: Optional[Dict[str, Any]] = None
+        self,
+        method: str,
+        body: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """
         Get HTTP options for backend requests.
@@ -128,6 +164,10 @@ class BasePaymentsAPI:
         Args:
             method: HTTP method
             body: Optional request body
+            extra_headers: Optional per-call header overrides. Use
+                ``{"X-Current-Org-Id": org_id}`` to target a specific
+                workspace for one call without mutating the instance-level
+                pin.
 
         Returns:
             HTTP options object
@@ -137,12 +177,18 @@ class BasePaymentsAPI:
         # self-signed certificates
         verify_ssl = False
 
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.nvm_api_key}",
+        }
+        if self.current_organization_id:
+            headers[CURRENT_ORG_ID_HEADER] = self.current_organization_id
+        if extra_headers:
+            headers.update(extra_headers)
+
         options = {
-            "headers": {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {self.nvm_api_key}",
-            },
+            "headers": headers,
             "verify": verify_ssl,
             "timeout": DEFAULT_HTTP_TIMEOUT,
         }

--- a/payments_py/api/base_payments.py
+++ b/payments_py/api/base_payments.py
@@ -48,6 +48,7 @@ def _stringify_unsafe_ints(value: Any) -> Any:
 # `apps/api/src/common/guards/current-org-context.guard.ts` (nvm-monorepo).
 CURRENT_ORG_ID_HEADER = "X-Current-Org-Id"
 
+
 class BasePaymentsAPI:
     """
     Base class extended by all Payments API classes.

--- a/payments_py/api/base_payments.py
+++ b/payments_py/api/base_payments.py
@@ -48,6 +48,15 @@ def _stringify_unsafe_ints(value: Any) -> Any:
 # `apps/api/src/common/guards/current-org-context.guard.ts` (nvm-monorepo).
 CURRENT_ORG_ID_HEADER = "X-Current-Org-Id"
 
+# Allowlist for the per-call ``extra_headers`` argument on
+# :meth:`get_backend_http_options`. Mirrors the TS source-of-truth
+# (`ALLOWED_EXTRA_HEADERS` in `payments/src/api/base-payments.ts`): without
+# this filter a caller could inject ``Authorization`` / ``Content-Type``
+# through the new per-call header channel and override the SDK's own
+# auth, escalating any per-call workspace targeting path into a
+# header-injection surface.
+ALLOWED_EXTRA_HEADERS = frozenset({CURRENT_ORG_ID_HEADER})
+
 
 class BasePaymentsAPI:
     """
@@ -186,7 +195,13 @@ class BasePaymentsAPI:
         if self.current_organization_id:
             headers[CURRENT_ORG_ID_HEADER] = self.current_organization_id
         if extra_headers:
-            headers.update(extra_headers)
+            # Filter through the allowlist so a per-call header argument
+            # can't override Authorization / Content-Type or otherwise
+            # poison the transport. Mirror of the TS source-of-truth
+            # (`ALLOWED_EXTRA_HEADERS` in `payments/src/api/base-payments.ts`).
+            headers.update(
+                {k: v for k, v in extra_headers.items() if k in ALLOWED_EXTRA_HEADERS}
+            )
 
         options = {
             "headers": headers,

--- a/payments_py/api/nvm_api.py
+++ b/payments_py/api/nvm_api.py
@@ -42,6 +42,10 @@ API_URL_SETTLE_PERMISSIONS = "/api/v1/x402/settle"
 # Stripe endpoints
 API_URL_STRIPE_CHECKOUT = "/api/v1/fiat/stripe/payment"
 
+# Organizations endpoints
+API_URL_MY_MEMBERSHIPS = "/api/v1/organizations/my-memberships"
+API_URL_ORG_ACTIVITY = "/api/v1/organizations/{org_id}/activity"
+
 # Info endpoint
 API_URL_INFO = "/"
 

--- a/payments_py/api/organizations_api.py
+++ b/payments_py/api/organizations_api.py
@@ -44,7 +44,7 @@ class OrganizationsAPI(BasePaymentsAPI):
         payments = Payments.get_instance(options)
         memberships = payments.organizations.get_my_memberships()
         for membership in memberships:
-            print(membership.organization_name, "-", membership.role)
+            print(membership.org_name, "-", membership.role)
     """
 
     @classmethod
@@ -106,9 +106,16 @@ class OrganizationsAPI(BasePaymentsAPI):
         if filters is not None:
             event_type = filters.event_type
             if event_type is not None:
-                query_params["eventType"] = getattr(
-                    event_type, "value", str(event_type)
-                )
+                if isinstance(event_type, list):
+                    joined = ",".join(
+                        getattr(value, "value", str(value)) for value in event_type
+                    )
+                    if joined:
+                        query_params["eventType"] = joined
+                else:
+                    query_params["eventType"] = getattr(
+                        event_type, "value", str(event_type)
+                    )
             if filters.actor_user_id:
                 query_params["actorUserId"] = filters.actor_user_id
             if filters.from_:
@@ -117,8 +124,8 @@ class OrganizationsAPI(BasePaymentsAPI):
                 query_params["to"] = filters.to
             if filters.page is not None:
                 query_params["page"] = str(filters.page)
-            if filters.offset is not None:
-                query_params["offset"] = str(filters.offset)
+            if filters.limit is not None:
+                query_params["limit"] = str(filters.limit)
 
         path = API_URL_ORG_ACTIVITY.format(org_id=org_id)
         query_string = urlencode(query_params)
@@ -140,14 +147,7 @@ class OrganizationsAPI(BasePaymentsAPI):
         data: Dict[str, Any] = response.json() or {}
         items_raw = data.get("items") or []
         items = [OrganizationActivityEvent.model_validate(item) for item in items_raw]
-        return OrganizationActivityPage(
-            items=items,
-            total=int(data.get("total", 0)),
-            page=int(data.get("page", filters.page if filters and filters.page else 1)),
-            offset=int(
-                data.get("offset", filters.offset if filters and filters.offset else 10)
-            ),
-        )
+        return OrganizationActivityPage(items=items, total=int(data.get("total", 0)))
 
 
 def resolve_publication_headers(

--- a/payments_py/api/organizations_api.py
+++ b/payments_py/api/organizations_api.py
@@ -1,0 +1,163 @@
+"""Organizations API — workspace memberships and activity feed.
+
+Wraps the multi-organization endpoints exposed by the Nevermined backend
+(see ``apps/api/src/organizations/`` in nvm-monorepo):
+
+- ``GET /api/v1/organizations/my-memberships`` — every organization the
+  caller is an active member of, with their role.
+- ``GET /api/v1/organizations/{org_id}/activity`` — paginated activity
+  feed (member events, customer events, subscription transitions,
+  webhook deliveries).
+
+The active workspace for write operations (publishing agents, plans, …)
+is selected via the inherited ``X-Current-Org-Id`` header plumbing on
+:class:`BasePaymentsAPI`. Pin it instance-wide via
+:meth:`Payments.set_organization_id` or pass ``organization_id=`` on the
+relevant publish method for a one-off override.
+"""
+
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
+
+import requests
+
+from payments_py.api.base_payments import (
+    CURRENT_ORG_ID_HEADER,
+    BasePaymentsAPI,
+)
+from payments_py.api.nvm_api import API_URL_MY_MEMBERSHIPS, API_URL_ORG_ACTIVITY
+from payments_py.common.payments_error import PaymentsError
+from payments_py.common.types import (
+    MyMembership,
+    OrganizationActivityEvent,
+    OrganizationActivityFilters,
+    OrganizationActivityPage,
+    PaymentOptions,
+)
+
+
+class OrganizationsAPI(BasePaymentsAPI):
+    """Workspace memberships and organization activity feed.
+
+    Example::
+
+        payments = Payments.get_instance(options)
+        memberships = payments.organizations.get_my_memberships()
+        for membership in memberships:
+            print(membership.organization_name, "-", membership.role)
+    """
+
+    @classmethod
+    def get_instance(cls, options: PaymentOptions) -> "OrganizationsAPI":
+        """Get a singleton-like instance of :class:`OrganizationsAPI`."""
+        return cls(options)
+
+    def get_my_memberships(self) -> List[MyMembership]:
+        """List every organization the authenticated user is an active member of.
+
+        Returns:
+            A list of :class:`MyMembership` — empty when the user has no
+            active memberships and operates as a personal account.
+
+        Raises:
+            PaymentsError: If the backend call fails.
+        """
+        url = f"{self.environment.backend}{API_URL_MY_MEMBERSHIPS}"
+        options = self.get_backend_http_options("GET")
+        response = requests.get(url, **options)
+        if not response.ok:
+            try:
+                error = response.json()
+            except (ValueError, requests.exceptions.JSONDecodeError):
+                error = {"message": response.text, "code": response.status_code}
+            raise PaymentsError.from_backend("Unable to fetch memberships", error)
+
+        data = response.json()
+        if not isinstance(data, list):
+            return []
+        return [MyMembership.model_validate(item) for item in data]
+
+    def get_organization_activity(
+        self,
+        org_id: str,
+        filters: Optional[OrganizationActivityFilters] = None,
+    ) -> OrganizationActivityPage:
+        """List activity events for an organization the caller is a member of.
+
+        Requires Member or Admin membership on ``org_id``; Premium-tier
+        entitlement is enforced server-side. The backend returns 403
+        otherwise.
+
+        Args:
+            org_id: Organization id (e.g. ``"org-..."``) whose feed to read.
+            filters: Optional :class:`OrganizationActivityFilters` filter
+                set (event type, actor, date range, pagination).
+
+        Returns:
+            A paginated :class:`OrganizationActivityPage`.
+
+        Raises:
+            PaymentsError: If ``org_id`` is missing or the backend call fails.
+        """
+        if not org_id:
+            raise PaymentsError.validation("org_id is required")
+
+        query_params: Dict[str, str] = {}
+        if filters is not None:
+            event_type = filters.event_type
+            if event_type is not None:
+                query_params["eventType"] = getattr(
+                    event_type, "value", str(event_type)
+                )
+            if filters.actor_user_id:
+                query_params["actorUserId"] = filters.actor_user_id
+            if filters.from_:
+                query_params["from"] = filters.from_
+            if filters.to:
+                query_params["to"] = filters.to
+            if filters.page is not None:
+                query_params["page"] = str(filters.page)
+            if filters.offset is not None:
+                query_params["offset"] = str(filters.offset)
+
+        path = API_URL_ORG_ACTIVITY.format(org_id=org_id)
+        query_string = urlencode(query_params)
+        url = f"{self.environment.backend}{path}"
+        if query_string:
+            url = f"{url}?{query_string}"
+
+        options = self.get_backend_http_options("GET")
+        response = requests.get(url, **options)
+        if not response.ok:
+            try:
+                error = response.json()
+            except (ValueError, requests.exceptions.JSONDecodeError):
+                error = {"message": response.text, "code": response.status_code}
+            raise PaymentsError.from_backend(
+                "Unable to fetch organization activity", error
+            )
+
+        data: Dict[str, Any] = response.json() or {}
+        items_raw = data.get("items") or []
+        items = [OrganizationActivityEvent.model_validate(item) for item in items_raw]
+        return OrganizationActivityPage(
+            items=items,
+            total=int(data.get("total", 0)),
+            page=int(data.get("page", filters.page if filters and filters.page else 1)),
+            offset=int(
+                data.get("offset", filters.offset if filters and filters.offset else 10)
+            ),
+        )
+
+
+def resolve_publication_headers(
+    organization_id: Optional[str],
+) -> Optional[Dict[str, str]]:
+    """Build the per-call ``extra_headers`` dict for publish methods.
+
+    Returns ``None`` when no override is requested so existing callers
+    receive identical request shapes.
+    """
+    if organization_id:
+        return {CURRENT_ORG_ID_HEADER: organization_id}
+    return None

--- a/payments_py/api/plans_api.py
+++ b/payments_py/api/plans_api.py
@@ -15,6 +15,7 @@ from payments_py.common.types import (
     PlanBalance,
 )
 from payments_py.api.base_payments import BasePaymentsAPI
+from payments_py.api.organizations_api import resolve_publication_headers
 from payments_py.api.nvm_api import (
     API_URL_REGISTER_PLAN,
     API_URL_GET_PLAN,
@@ -73,6 +74,7 @@ class PlansAPI(BasePaymentsAPI):
         access_limit: Optional[
             Literal["credits", "time"]
         ] = None,  # 'credits' or 'time'
+        organization_id: Optional[str] = None,
     ) -> Dict[str, str]:
         """
         Allows an AI Builder to create a Payment Plan on Nevermined in a flexible manner.
@@ -86,6 +88,10 @@ class PlansAPI(BasePaymentsAPI):
             price_config: Plan price configuration
             credits_config: Plan credits configuration
             nonce: Optional nonce for the transaction
+            access_limit: Optional access limit for the plan
+            organization_id: Optional org id (e.g. ``"org-..."``) to publish
+                into for this call only. Sends an ``X-Current-Org-Id``
+                header without mutating the instance-level pin.
 
         Returns:
             The unique identifier of the plan (Plan ID) of the newly created plan
@@ -116,7 +122,9 @@ class PlansAPI(BasePaymentsAPI):
         if price_dict.get("currency"):
             body["currency"] = price_dict["currency"]
 
-        options = self.get_backend_http_options("POST", body)
+        options = self.get_backend_http_options(
+            "POST", body, extra_headers=resolve_publication_headers(organization_id)
+        )
         url = f"{self.environment.backend}{API_URL_REGISTER_PLAN}"
 
         response = requests.post(url, **options)
@@ -132,6 +140,7 @@ class PlansAPI(BasePaymentsAPI):
         plan_metadata: PlanMetadata,
         price_config: PlanPriceConfig,
         credits_config: PlanCreditsConfig,
+        organization_id: Optional[str] = None,
     ) -> Dict[str, str]:
         """
         Allows an AI Builder to create a Payment Plan on Nevermined based on Credits.
@@ -144,6 +153,7 @@ class PlansAPI(BasePaymentsAPI):
             plan_metadata: Plan metadata
             price_config: Plan price configuration
             credits_config: Plan credits configuration
+            organization_id: Optional org id to publish into for this call.
 
         Returns:
             The unique identifier of the plan (Plan ID) of the newly created plan
@@ -158,7 +168,11 @@ class PlansAPI(BasePaymentsAPI):
             )
 
         return self.register_plan(
-            plan_metadata, price_config, credits_config, access_limit="credits"
+            plan_metadata,
+            price_config,
+            credits_config,
+            access_limit="credits",
+            organization_id=organization_id,
         )
 
     def register_time_plan(
@@ -166,6 +180,7 @@ class PlansAPI(BasePaymentsAPI):
         plan_metadata: PlanMetadata,
         price_config: PlanPriceConfig,
         credits_config: PlanCreditsConfig,
+        organization_id: Optional[str] = None,
     ) -> Dict[str, str]:
         """
         Allows an AI Builder to create a Payment Plan on Nevermined limited by duration.
@@ -178,6 +193,7 @@ class PlansAPI(BasePaymentsAPI):
             plan_metadata: Plan metadata
             price_config: Plan price configuration
             credits_config: Plan credits configuration
+            organization_id: Optional org id to publish into for this call.
 
         Returns:
             The unique identifier of the plan (Plan ID) of the newly created plan
@@ -187,7 +203,11 @@ class PlansAPI(BasePaymentsAPI):
         """
 
         return self.register_plan(
-            plan_metadata, price_config, credits_config, access_limit="time"
+            plan_metadata,
+            price_config,
+            credits_config,
+            access_limit="time",
+            organization_id=organization_id,
         )
 
     def register_credits_trial_plan(
@@ -195,6 +215,7 @@ class PlansAPI(BasePaymentsAPI):
         plan_metadata: PlanMetadata,
         price_config: PlanPriceConfig,
         credits_config: PlanCreditsConfig,
+        organization_id: Optional[str] = None,
     ) -> Dict[str, str]:
         """
         Allows an AI Builder to create a Trial Payment Plan on Nevermined based on Credits.
@@ -205,18 +226,25 @@ class PlansAPI(BasePaymentsAPI):
             plan_metadata: Plan metadata
             price_config: Plan price configuration
             credits_config: Plan credits configuration
+            organization_id: Optional org id to publish into for this call.
 
         Returns:
             The unique identifier of the plan (Plan ID) of the newly created plan
         """
         plan_metadata.is_trial_plan = True
-        return self.register_credits_plan(plan_metadata, price_config, credits_config)
+        return self.register_credits_plan(
+            plan_metadata,
+            price_config,
+            credits_config,
+            organization_id=organization_id,
+        )
 
     def register_time_trial_plan(
         self,
         plan_metadata: PlanMetadata,
         price_config: PlanPriceConfig,
         credits_config: PlanCreditsConfig,
+        organization_id: Optional[str] = None,
     ) -> Dict[str, str]:
         """
         Allows an AI Builder to create a Trial Payment Plan on Nevermined limited by duration.
@@ -227,12 +255,18 @@ class PlansAPI(BasePaymentsAPI):
             plan_metadata: Plan metadata
             price_config: Plan price configuration
             credits_config: Plan credits configuration
+            organization_id: Optional org id to publish into for this call.
 
         Returns:
             The unique identifier of the plan (Plan ID) of the newly created plan
         """
         plan_metadata.is_trial_plan = True
-        return self.register_time_plan(plan_metadata, price_config, credits_config)
+        return self.register_time_plan(
+            plan_metadata,
+            price_config,
+            credits_config,
+            organization_id=organization_id,
+        )
 
     def get_plan(self, plan_id: str) -> Dict[str, Any]:
         """

--- a/payments_py/api/plans_api.py
+++ b/payments_py/api/plans_api.py
@@ -115,7 +115,12 @@ class PlansAPI(BasePaymentsAPI):
             "metadataAttributes": self.pydantic_to_dict(plan_metadata),
             "priceConfig": price_dict,
             "creditsConfig": self.pydantic_to_dict(credits_config),
-            "nonce": nonce,
+            # Send `nonce` as a decimal string so the backend's uint256
+            # validator (BCK.COMMON.0026) accepts it for very large
+            # values that would overflow JSON's safe-integer range.
+            # The TypeScript SDK gets this for free via the BigInt
+            # `jsonReplacer`; Python needs the explicit cast.
+            "nonce": str(nonce),
             "isTrialPlan": getattr(plan_metadata, "is_trial_plan", False),
             "accessLimit": access_limit,
         }

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -463,16 +463,26 @@ class MyMembership(BaseModel):
 
     Returned by :meth:`OrganizationsAPI.get_my_memberships` and used by
     clients to power workspace pickers and "where will this publish?" UX.
+
+    Shape mirrors ``MyMembershipDto`` in the Nevermined backend
+    (``apps/api/src/organizations/dto/my-membership.dto.ts``).
     """
 
     model_config = ConfigDict(populate_by_name=True)
 
     org_id: str = Field(alias="orgId")
-    organization_name: str = Field(alias="organizationName")
-    organization_type: OrganizationType = Field(alias="organizationType")
+    org_name: str = Field(alias="orgName")
     role: OrganizationMemberRole
-    user_is_active: bool = Field(alias="userIsActive")
-    organization_is_active: bool = Field(alias="organizationIsActive")
+    org_type: OrganizationType = Field(alias="orgType")
+    is_admin: bool = Field(alias="isAdmin")
+    # `True` when the org has at least one ``organizationSubscription`` row —
+    # the org has previously been associated with a paid tier (active,
+    # past_due, trialing, lapsed, or canceled). Combined with
+    # ``org_type == Lapsed`` it distinguishes "subscription expired" from
+    # "free org that never subscribed".
+    has_subscription_history: bool = Field(
+        default=False, alias="hasSubscriptionHistory"
+    )
 
 
 class OrganizationActivityEventType(str, Enum):
@@ -483,50 +493,96 @@ class OrganizationActivityEventType(str, Enum):
     plain ``str`` so consumers don't break on first-encounter.
     """
 
-    MEMBER_INVITED = "MEMBER_INVITED"
-    MEMBER_ACCEPTED = "MEMBER_ACCEPTED"
-    MEMBER_ROLE_CHANGED = "MEMBER_ROLE_CHANGED"
-    MEMBER_DEACTIVATED = "MEMBER_DEACTIVATED"
-    MEMBER_REACTIVATED = "MEMBER_REACTIVATED"
-    MEMBER_REMOVED = "MEMBER_REMOVED"
-    CUSTOMER_ADDED = "CUSTOMER_ADDED"
-    CUSTOMER_BLOCKED = "CUSTOMER_BLOCKED"
-    SUBSCRIPTION_CREATED = "SUBSCRIPTION_CREATED"
-    SUBSCRIPTION_CANCELED = "SUBSCRIPTION_CANCELED"
-    WEBHOOK_DELIVERED = "WEBHOOK_DELIVERED"
+    # Membership lifecycle
+    MEMBER_INVITED = "member.invited"
+    MEMBER_JOINED = "member.joined"
+    MEMBER_ROLE_CHANGED = "member.role_changed"
+    MEMBER_DEACTIVATED = "member.deactivated"
+    MEMBER_REACTIVATED = "member.reactivated"
+    MEMBER_REMOVED = "member.removed"
+    INVITATION_REVOKED = "invitation.revoked"
+    INVITATION_EXPIRED = "invitation.expired"
+    # Resource lifecycle
+    AGENT_CREATED = "agent.created"
+    PLAN_CREATED = "plan.created"
+    PLAN_PURCHASED = "plan.purchased"
+    # Customer lifecycle
+    CUSTOMER_ADDED = "customer.added"
+    CUSTOMER_BLOCKED = "customer.blocked"
+    CUSTOMER_UNBLOCKED = "customer.unblocked"
+    # Subscription lifecycle
+    SUBSCRIPTION_UPGRADED = "subscription.upgraded"
+    SUBSCRIPTION_DOWNGRADED = "subscription.downgraded"
+    SUBSCRIPTION_CANCELED = "subscription.canceled"
+    SUBSCRIPTION_LAPSED = "subscription.lapsed"
+    # Webhook delivery
+    WEBHOOK_DELIVERED = "webhook.delivered"
+    WEBHOOK_FAILED = "webhook.failed"
+
+
+class OrganizationActivityEventSubject(BaseModel):
+    """Resource an activity event is about.
+
+    ``kind`` describes the resource type (``plan``, ``agent``, ``member``,
+    ``subscription``, ``invitation``, ``customer``, ``webhook``) and ``id``
+    is the resource identifier. Extras vary by kind — invitations include
+    ``role`` + ``email``, members include ``role`` + ``userId``,
+    subscriptions include ``tier``. The model accepts unknown keys for
+    forward-compatibility.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    kind: str
+    id: str
 
 
 class OrganizationActivityEvent(BaseModel):
-    """A single event emitted into the organization activity feed."""
+    """A single event emitted into the organization activity feed.
+
+    Shape mirrors ``OrganizationActivityEventResponseDto`` in the backend.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
     id: str
     event_type: str = Field(alias="eventType")
-    org_id: str = Field(alias="orgId")
     actor_user_id: Optional[str] = Field(default=None, alias="actorUserId")
-    target_user_id: Optional[str] = Field(default=None, alias="targetUserId")
+    subject: OrganizationActivityEventSubject
     metadata: Optional[Dict[str, Any]] = None
-    created_at: str = Field(alias="createdAt")
+    occurred_at: str = Field(alias="occurredAt")
 
 
 class OrganizationActivityPage(BaseModel):
-    """Paginated page of activity events."""
+    """Paginated page of activity events.
+
+    The backend only echoes ``items`` and ``total``; ``page`` and ``limit``
+    are not in the response.
+    """
 
     items: List[OrganizationActivityEvent] = Field(default_factory=list)
     total: int = 0
-    page: int = 1
-    offset: int = 10
 
 
 class OrganizationActivityFilters(BaseModel):
-    """Optional filters accepted by :meth:`OrganizationsAPI.get_organization_activity`."""
+    """Optional filters accepted by :meth:`OrganizationsAPI.get_organization_activity`.
 
-    event_type: Optional[Union[OrganizationActivityEventType, str]] = None
+    ``event_type`` accepts a single value or a list (sent to the backend
+    as a comma-separated list). ``limit`` is the page size (backend cap
+    is 200); the legacy ``offset`` name is not supported by this endpoint.
+    """
+
+    event_type: Optional[
+        Union[
+            OrganizationActivityEventType,
+            str,
+            List[Union[OrganizationActivityEventType, str]],
+        ]
+    ] = None
     actor_user_id: Optional[str] = None
     from_: Optional[str] = Field(default=None, alias="from")
     to: Optional[str] = None
     page: Optional[int] = None
-    offset: Optional[int] = None
+    limit: Optional[int] = None
 
     model_config = ConfigDict(populate_by_name=True)

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -341,6 +341,24 @@ class PlanCreditsConfig(BaseModel):
     max_amount: int
     nft_address: Optional[str] = None
 
+    def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+        """Serialize uint256-typed fields as decimal strings.
+
+        The Nevermined backend tightened uint256 validation on plan and
+        agent-and-plan registration. JSON numbers are rejected for fields
+        that map to Solidity ``uint256`` (``durationSecs``, ``amount``,
+        ``minAmount``, ``maxAmount``) because numbers larger than
+        ``Number.MAX_SAFE_INTEGER`` lose precision in transit. The
+        TypeScript SDK gets this for free via the ``BigInt``
+        ``jsonReplacer``; Python emits the same wire shape by
+        stringifying here.
+        """
+        d = super().model_dump(**kwargs)
+        for field in ("duration_secs", "amount", "min_amount", "max_amount"):
+            if field in d and d[field] is not None:
+                d[field] = str(d[field])
+        return d
+
 
 class PlanBalance(BaseModel):
     """

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -468,12 +468,18 @@ class OrganizationMemberRole(str, Enum):
 
 
 class OrganizationType(str, Enum):
-    """Tier of an organization."""
+    """Tier of an organization. Mirrors the backend ``OrganizationType`` enum
+    (``libs/commons/src/lib/types/types.ts`` in nvm-monorepo).
 
-    FREE = "Free"
+    No ``Free`` member — the backend never emits it (legacy bucket replaced
+    by ``Lapsed``). ``Other`` is the legacy pre-tiered-pricing bucket and
+    is still returned for orgs that pre-date the tier system.
+    """
+
     PREMIUM = "Premium"
     ENTERPRISE = "Enterprise"
     LAPSED = "Lapsed"
+    OTHER = "Other"
 
 
 class MyMembership(BaseModel):
@@ -491,7 +497,11 @@ class MyMembership(BaseModel):
     org_id: str = Field(alias="orgId")
     org_name: str = Field(alias="orgName")
     role: OrganizationMemberRole
-    org_type: OrganizationType = Field(alias="orgType")
+    # ``Union[OrganizationType, str]`` for forward-compat: if the backend
+    # introduces a new tier before the SDK ships an enum update,
+    # ``model_validate`` falls through to a bare string instead of raising.
+    # Matches the same shape used by ``OrganizationActivityEvent.event_type``.
+    org_type: Union[OrganizationType, str] = Field(alias="orgType")
     is_admin: bool = Field(alias="isAdmin")
     # `True` when the org has at least one ``organizationSubscription`` row —
     # the org has previously been associated with a paid tier (active,

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -13,6 +13,23 @@ Address = str
 class PaymentOptions(BaseModel):
     """
     Options for initializing the Payments class.
+
+    Args:
+        environment: Nevermined environment (e.g. ``"sandbox"``, ``"live"``).
+        nvm_api_key: NVM API key used to authenticate against the backend.
+        return_url: Optional URL to return to after login (browser flows).
+        app_id: Optional application identifier stamped on registered assets.
+        version: Optional SDK version reported to the backend.
+        headers: Optional default headers to merge into every request.
+        organization_id: Optional organization id (e.g. ``"org-..."``) used
+            as the active workspace for every authenticated backend call.
+            When set, the SDK forwards it as the ``X-Current-Org-Id``
+            request header so the backend scopes published agents, plans,
+            and other workspace-aware resources to this organization.
+            If omitted, the backend falls back to the API key's org tag
+            or the caller's most-recent active membership (see
+            ``CurrentOrgContextGuard`` in nvm-monorepo). Override per-call
+            via the ``organization_id`` argument on publish methods.
     """
 
     environment: str
@@ -21,6 +38,7 @@ class PaymentOptions(BaseModel):
     app_id: Optional[str] = None
     version: Optional[str] = None
     headers: Optional[Dict[str, str]] = None
+    organization_id: Optional[str] = None
 
 
 class Endpoint(BaseModel):
@@ -411,3 +429,104 @@ class NvmAPIResult(BaseModel):
     http_status: Optional[int] = None
     data: Optional[Dict[str, Any]] = None
     when: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Organizations
+# ---------------------------------------------------------------------------
+
+
+class OrganizationMemberRole(str, Enum):
+    """Role of a member inside an organization.
+
+    Mirrors ``OrganizationMemberRole`` from ``@nevermined-io/commons`` in the
+    nvm-monorepo backend. ``CLIENT`` is retained for backwards compatibility
+    with historical rows; new memberships only use ``ADMIN`` or ``MEMBER``.
+    """
+
+    ADMIN = "Admin"
+    MEMBER = "Member"
+    CLIENT = "Client"
+
+
+class OrganizationType(str, Enum):
+    """Tier of an organization."""
+
+    FREE = "Free"
+    PREMIUM = "Premium"
+    ENTERPRISE = "Enterprise"
+    LAPSED = "Lapsed"
+
+
+class MyMembership(BaseModel):
+    """A single organization the authenticated user is an active member of.
+
+    Returned by :meth:`OrganizationsAPI.get_my_memberships` and used by
+    clients to power workspace pickers and "where will this publish?" UX.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    org_id: str = Field(alias="orgId")
+    organization_name: str = Field(alias="organizationName")
+    organization_type: OrganizationType = Field(alias="organizationType")
+    role: OrganizationMemberRole
+    user_is_active: bool = Field(alias="userIsActive")
+    organization_is_active: bool = Field(alias="organizationIsActive")
+
+
+class OrganizationActivityEventType(str, Enum):
+    """Known event types emitted into the organization activity feed.
+
+    The SDK accepts unknown strings as well — when the backend introduces
+    a new event type, ``OrganizationActivityEvent.event_type`` stays a
+    plain ``str`` so consumers don't break on first-encounter.
+    """
+
+    MEMBER_INVITED = "MEMBER_INVITED"
+    MEMBER_ACCEPTED = "MEMBER_ACCEPTED"
+    MEMBER_ROLE_CHANGED = "MEMBER_ROLE_CHANGED"
+    MEMBER_DEACTIVATED = "MEMBER_DEACTIVATED"
+    MEMBER_REACTIVATED = "MEMBER_REACTIVATED"
+    MEMBER_REMOVED = "MEMBER_REMOVED"
+    CUSTOMER_ADDED = "CUSTOMER_ADDED"
+    CUSTOMER_BLOCKED = "CUSTOMER_BLOCKED"
+    SUBSCRIPTION_CREATED = "SUBSCRIPTION_CREATED"
+    SUBSCRIPTION_CANCELED = "SUBSCRIPTION_CANCELED"
+    WEBHOOK_DELIVERED = "WEBHOOK_DELIVERED"
+
+
+class OrganizationActivityEvent(BaseModel):
+    """A single event emitted into the organization activity feed."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    event_type: str = Field(alias="eventType")
+    org_id: str = Field(alias="orgId")
+    actor_user_id: Optional[str] = Field(default=None, alias="actorUserId")
+    target_user_id: Optional[str] = Field(default=None, alias="targetUserId")
+    metadata: Optional[Dict[str, Any]] = None
+    created_at: str = Field(alias="createdAt")
+
+
+class OrganizationActivityPage(BaseModel):
+    """Paginated page of activity events."""
+
+    items: List[OrganizationActivityEvent] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    offset: int = 10
+
+
+class OrganizationActivityFilters(BaseModel):
+    """Optional filters accepted by :meth:`OrganizationsAPI.get_organization_activity`."""
+
+    event_type: Optional[Union[OrganizationActivityEventType, str]] = None
+    actor_user_id: Optional[str] = None
+    from_: Optional[str] = Field(default=None, alias="from")
+    to: Optional[str] = None
+    page: Optional[int] = None
+    offset: Optional[int] = None
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/payments_py/payments.py
+++ b/payments_py/payments.py
@@ -220,10 +220,13 @@ class Payments(BasePaymentsAPI):
             ):
                 attr.set_organization_id(organization_id)
 
-        # Lazily-built APIs (mcp, agentcore, delegation) are reset so the
-        # next access reconstructs them with the new pin in place.
-        self._mcp_integration = None
-        self._agentcore_api = None
+        # ``_mcp_integration`` and ``_agentcore_api`` hold a reference to
+        # ``self`` and observe ``current_organization_id`` live — don't
+        # discard them here or any tools/resources/prompts that callers
+        # already registered on the MCP integration would be lost.
+        # ``_delegation_api`` snapshots the org id at construction time
+        # via ``_build_options()``, so reset it to force a rebuild with
+        # the new pin on the next access.
         self._delegation_api = None
 
     @property

--- a/payments_py/payments.py
+++ b/payments_py/payments.py
@@ -2,7 +2,7 @@
 Main Payments class for the Nevermined Payments protocol.
 """
 
-from typing import Dict, Any
+from typing import Any, Dict, Optional
 from payments_py.common.payments_error import PaymentsError
 from payments_py.common.types import PaymentOptions
 from payments_py.api.query_api import AIQueryApi
@@ -11,6 +11,7 @@ from payments_py.api.plans_api import PlansAPI
 from payments_py.api.agents_api import AgentsAPI
 from payments_py.api.requests_api import AgentRequestsAPI
 from payments_py.api.observability_api import ObservabilityAPI
+from payments_py.api.organizations_api import OrganizationsAPI
 from payments_py.api.contracts_api import ContractsAPI
 from payments_py.x402.facilitator_api import FacilitatorAPI
 from payments_py.x402.token import X402TokenAPI
@@ -91,6 +92,7 @@ class Payments(BasePaymentsAPI):
         self.requests = AgentRequestsAPI.get_instance(options)
         self.query = AIQueryApi.get_instance()
         self.observability = ObservabilityAPI.get_instance(options)
+        self.organizations = OrganizationsAPI.get_instance(options)
         self.facilitator = FacilitatorAPI.get_instance(options)
         self.x402 = X402TokenAPI.get_instance(options)
         self.contracts_api = ContractsAPI(options)
@@ -179,7 +181,50 @@ class Payments(BasePaymentsAPI):
             environment=self.environment_name,
             app_id=self.app_id,
             version=self.version,
+            organization_id=self.current_organization_id,
         )
+
+    def set_organization_id(self, organization_id: Optional[str]) -> None:
+        """Pin (or clear) the active organization workspace across every sub-API.
+
+        Forwards the choice as the ``X-Current-Org-Id`` header on every
+        subsequent authenticated request. Pass ``None`` to clear the pin
+        and let the backend fall back to the API key's org tag or the
+        caller's most-recent active membership.
+
+        For one-off targeting (e.g. publish a single agent into Org B
+        without leaving Org B as the active workspace) prefer the
+        per-call ``organization_id`` argument on the relevant publish
+        method.
+
+        Args:
+            organization_id: Org id to pin (e.g. ``"org-..."``) or ``None``
+                to clear.
+
+        Example::
+
+            payments.set_organization_id("org-abc123")
+            payments.agents.register_agent(metadata, api, [plan_id])
+            # → lands in org-abc123
+        """
+        super().set_organization_id(organization_id)
+        # Propagate to every eagerly-constructed sub-API automatically so a
+        # future addition to ``_initialize_api`` is picked up without
+        # touching this method. ``hasattr`` filters out attrs that don't
+        # carry org context (e.g. ``query`` which is not a Payments API).
+        for attr in vars(self).values():
+            if attr is self:
+                continue
+            if hasattr(attr, "set_organization_id") and callable(
+                getattr(attr, "set_organization_id")
+            ):
+                attr.set_organization_id(organization_id)
+
+        # Lazily-built APIs (mcp, agentcore, delegation) are reset so the
+        # next access reconstructs them with the new pin in place.
+        self._mcp_integration = None
+        self._agentcore_api = None
+        self._delegation_api = None
 
     @property
     def is_logged_in(self) -> bool:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -32,16 +32,27 @@ TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "60"))
 # Same address used across all E2E tests
 TEST_ERC20_TOKEN = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
 
-# Test API keys - can be overridden via environment variables
-# Default values are for staging_sandbox environment
+# Test API keys - can be overridden via environment variables.
+# Defaults are the staging-sandbox `testing-merchant@nevermined.io` /
+# `testing-buyer@nevermined.io` accounts; both are members of the
+# `Nevermined Testing` Enterprise org so plan/agent registrations bypass
+# the personal-account caps.
 SUBSCRIBER_API_KEY = os.getenv(
     "TEST_SUBSCRIBER_API_KEY",
-    "sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDcxZTZGN2Y4QzY4ZTdlMkU5NkIzYzkwNjU1YzJEMmNBMzc2QmMzZmQiLCJqdGkiOiIweDMwN2Y0NWRkMTBiOTc1YjhlNDU5NzNkMmNiNTljY2MzZDQ2NjFmY2RiOTJiMTVmMjI2ZDNhY2Q0NjdkODYyMDUiLCJleHAiOjE3OTY5MzM3MjcsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.0khtYy6bG_m6mDE2Oa1sozQLBHve2yVwyUeeM9DAHzFxhwK86JSfGL973Sg8FzhTfD2xhzYWiFP3KV2GjWNnDRs",
+    "sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDRkNEM5RmFBRjY2ZmI1NjI5NDY0MGZDMzI5NjgzMTdEYWQ4ZWQ4ZWQiLCJqdGkiOiIweGZjNzU1N2Q0NGNmNjEzYjI0OWRjNjZkYjk1ZGMyZmNiMmM5MTUxM2M1YmYxMWZkNjEzYmE2YTM3ZjA1ZWJmN2MiLCJleHAiOjQ5MzUxMzE2OTcsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.kwvQxOC0XLMXQlVOSQiGgr7iggma1X5QIu46odHXzp5zwNav1PQfR3j6xW1KgkVFt0tHHRjVuzVBPHG2Dahbnhw",
 )
 
 AGENT_API_KEY = os.getenv(
     "TEST_BUILDER_API_KEY",
-    "sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDlkREQwMkQ0RTExMWFiNWNFNDc1MTE5ODdCMjUwMGZjQjU2MjUyYzYiLCJqdGkiOiIweDQ2YzY3OTk5MTY5NDBhZmI4ZGNmNmQ2NmRmZmY4MGE0YmVhYWMyY2NiYWZlOTlkOGEwOTAwYTBjMzhmZjdkNjEiLCJleHAiOjE3OTU1NDI4NzAsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.n51gkto9Jw-MXxnXW92XDAB_CnHUFxkritWp9Lj1qFASmtf_TuQwU57bauIEGrQygumX8S3pXqRqeGRWT2AJiRs",
+    "sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDM0RDdGMjBmOTYzMDI0NGFkRmI0Y2Q0ODQwY2Q1MTBGN0ZGQTczQzgiLCJqdGkiOiIweGNiZGVhMzE2OTgzYTJjOWYyNDVlYzQyZWI3MjJiNmM4ZDkxNTM2ZmYwOGNmM2QyNTg5ZjBkN2VmMGZlNjA0NTMiLCJleHAiOjQ5MzUxMzE2MjQsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.gmI-i6GlwA0t__X1Ql5kBAjxViDas-cVY3WuNW5oTAh5I-CuALkIxznF468bfNvnwImAfgc2GrJ_PSnLJg3F7xw",
+)
+
+# Enterprise org on staging where both fixture accounts are members; passed
+# through to the SDK so the `X-Current-Org-Id` header is set explicitly on
+# every publish. Override via `TEST_BUILDER_ORG_ID` if a CI run should target
+# a different org.
+TEST_BUILDER_ORG_ID = os.getenv(
+    "TEST_BUILDER_ORG_ID", "org-031a0329-ebe2-444e-ac2a-1637f694ad0b"
 )
 
 # Alias for backward compatibility (some tests use BUILDER_API_KEY)
@@ -94,10 +105,16 @@ def payments_subscriber():
     Create a Payments instance for the subscriber.
 
     This fixture is shared across all E2E test files and provides
-    a Payments instance configured with the subscriber API key.
+    a Payments instance configured with the subscriber API key. The
+    Enterprise org is pinned via ``organization_id`` so any writes the
+    subscriber drives are scoped to the test workspace.
     """
     return Payments(
-        PaymentOptions(nvm_api_key=SUBSCRIBER_API_KEY, environment=TEST_ENVIRONMENT)
+        PaymentOptions(
+            nvm_api_key=SUBSCRIBER_API_KEY,
+            environment=TEST_ENVIRONMENT,
+            organization_id=TEST_BUILDER_ORG_ID,
+        )
     )
 
 
@@ -107,10 +124,16 @@ def payments_agent():
     Create a Payments instance for the agent (builder).
 
     This fixture is shared across all E2E test files and provides
-    a Payments instance configured with the agent/builder API key.
+    a Payments instance configured with the agent/builder API key,
+    pinned to the Enterprise test org so plan / agent registrations
+    bypass the personal-account cap.
     """
     return Payments(
-        PaymentOptions(nvm_api_key=AGENT_API_KEY, environment=TEST_ENVIRONMENT)
+        PaymentOptions(
+            nvm_api_key=AGENT_API_KEY,
+            environment=TEST_ENVIRONMENT,
+            organization_id=TEST_BUILDER_ORG_ID,
+        )
     )
 
 
@@ -124,7 +147,11 @@ def payments_builder():
     This provides backward compatibility.
     """
     return Payments(
-        PaymentOptions(nvm_api_key=BUILDER_API_KEY, environment=TEST_ENVIRONMENT)
+        PaymentOptions(
+            nvm_api_key=BUILDER_API_KEY,
+            environment=TEST_ENVIRONMENT,
+            organization_id=TEST_BUILDER_ORG_ID,
+        )
     )
 
 

--- a/tests/e2e/test_organizations_e2e.py
+++ b/tests/e2e/test_organizations_e2e.py
@@ -49,8 +49,31 @@ def _unpinned_payments() -> Payments:
     )
 
 
-def test_get_my_memberships_returns_enterprise_org_with_dto_shape():
+def _ensure_in_target_org() -> Payments:
+    """Skip the test cleanly if the configured ``BUILDER_API_KEY`` identity
+    is not a member of ``TEST_BUILDER_ORG_ID``.
+
+    Some CI environments still wire the legacy fixture accounts that
+    aren't members of the new Enterprise test org; in that case these
+    tests skip rather than fail. Once the secrets are rotated to the
+    ``testing-merchant@nevermined.io`` / ``testing-buyer@nevermined.io``
+    identities described in CLAUDE.md, every test runs.
+    """
     payments = _unpinned_payments()
+    try:
+        memberships = payments.organizations.get_my_memberships()
+    except Exception as e:  # pragma: no cover - network failure path
+        pytest.skip(f"get_my_memberships() failed: {e}")
+    if not any(m.org_id == TEST_BUILDER_ORG_ID for m in memberships):
+        pytest.skip(
+            f"account is not a member of {TEST_BUILDER_ORG_ID}; "
+            "rotate TEST_BUILDER_API_KEY to enable"
+        )
+    return payments
+
+
+def test_get_my_memberships_returns_enterprise_org_with_dto_shape():
+    payments = _ensure_in_target_org()
     memberships = payments.organizations.get_my_memberships()
 
     assert isinstance(memberships, list)
@@ -67,7 +90,7 @@ def test_get_my_memberships_returns_enterprise_org_with_dto_shape():
 
 
 def test_set_organization_id_routes_published_plan_into_target_org():
-    payments = _unpinned_payments()
+    payments = _ensure_in_target_org()
     payments.set_organization_id(TEST_BUILDER_ORG_ID)
     assert payments.get_organization_id() == TEST_BUILDER_ORG_ID
 
@@ -93,7 +116,7 @@ def test_set_organization_id_routes_published_plan_into_target_org():
 
 
 def test_per_call_organization_id_override_targets_org_without_mutating_pin():
-    payments = _unpinned_payments()
+    payments = _ensure_in_target_org()
     assert payments.get_organization_id() is None
 
     builder_address = payments.get_account_address()
@@ -116,7 +139,7 @@ def test_per_call_organization_id_override_targets_org_without_mutating_pin():
 
 
 def test_get_organization_activity_returns_paginated_page():
-    payments = _unpinned_payments()
+    payments = _ensure_in_target_org()
     page = payments.organizations.get_organization_activity(
         TEST_BUILDER_ORG_ID,
         OrganizationActivityFilters(page=1, limit=5),
@@ -136,7 +159,7 @@ def test_get_organization_activity_returns_paginated_page():
 
 
 def test_get_organization_activity_narrows_by_event_type():
-    payments = _unpinned_payments()
+    payments = _ensure_in_target_org()
     page = payments.organizations.get_organization_activity(
         TEST_BUILDER_ORG_ID,
         OrganizationActivityFilters(

--- a/tests/e2e/test_organizations_e2e.py
+++ b/tests/e2e/test_organizations_e2e.py
@@ -1,0 +1,151 @@
+"""End-to-end coverage for the multi-org workspace surface added in PR #179.
+
+Runs against staging-sandbox using the ``Testing Merchant`` fixture identity,
+which is an Admin of the Enterprise org ``Nevermined Testing``. Verifies the
+three building blocks the SDK now exposes:
+
+  1. ``get_my_memberships()`` returns the org the caller belongs to with the
+     backend-defined shape (orgId / orgName / role / orgType / isAdmin).
+  2. Pinning the workspace via ``set_organization_id(org_id)`` routes a
+     publish into that org — the resulting plan carries the org id.
+  3. The per-call ``organization_id=`` override on a publish method does the
+     same thing for a single call without mutating the instance pin.
+
+``get_organization_activity`` is exercised as a smoke read; the assertion is
+only that the call returns a paginated shape.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from payments_py.common.types import (
+    OrganizationActivityEventType,
+    OrganizationActivityFilters,
+    OrganizationMemberRole,
+    OrganizationType,
+    PaymentOptions,
+    PlanMetadata,
+)
+from payments_py.payments import Payments
+from payments_py.plans import (
+    get_crypto_price_config,
+    get_fixed_credits_config,
+)
+
+from tests.e2e.conftest import (
+    BUILDER_API_KEY,
+    TEST_BUILDER_ORG_ID,
+    TEST_ENVIRONMENT,
+)
+
+pytestmark = pytest.mark.slow
+
+
+def _unpinned_payments() -> Payments:
+    """Fresh client with no pinned workspace; lets the test drive the pin."""
+    return Payments(
+        PaymentOptions(nvm_api_key=BUILDER_API_KEY, environment=TEST_ENVIRONMENT)
+    )
+
+
+def test_get_my_memberships_returns_enterprise_org_with_dto_shape():
+    payments = _unpinned_payments()
+    memberships = payments.organizations.get_my_memberships()
+
+    assert isinstance(memberships, list)
+    assert len(memberships) > 0
+
+    matches = [m for m in memberships if m.org_id == TEST_BUILDER_ORG_ID]
+    assert matches, f"expected to find {TEST_BUILDER_ORG_ID} in memberships"
+    m = matches[0]
+    assert m.org_name
+    assert m.org_type == OrganizationType.ENTERPRISE
+    assert m.role in (OrganizationMemberRole.ADMIN, OrganizationMemberRole.MEMBER)
+    assert isinstance(m.is_admin, bool)
+    assert isinstance(m.has_subscription_history, bool)
+
+
+def test_set_organization_id_routes_published_plan_into_target_org():
+    payments = _unpinned_payments()
+    payments.set_organization_id(TEST_BUILDER_ORG_ID)
+    assert payments.get_organization_id() == TEST_BUILDER_ORG_ID
+
+    builder_address = payments.get_account_address()
+    price_config = get_crypto_price_config(0, builder_address)
+    credits_config = get_fixed_credits_config(100, 1)
+
+    plan_name = f"E2E orgs set_organization_id {datetime.now(timezone.utc).isoformat()}"
+    result = payments.plans.register_plan(
+        plan_metadata=PlanMetadata(name=plan_name),
+        price_config=price_config,
+        credits_config=credits_config,
+    )
+    plan_id = result["planId"]
+    assert plan_id
+
+    plan = payments.plans.get_plan(plan_id)
+    assert plan.get("orgId") == TEST_BUILDER_ORG_ID
+
+    # Reset pin to a known state.
+    payments.set_organization_id(None)
+    assert payments.get_organization_id() is None
+
+
+def test_per_call_organization_id_override_targets_org_without_mutating_pin():
+    payments = _unpinned_payments()
+    assert payments.get_organization_id() is None
+
+    builder_address = payments.get_account_address()
+    price_config = get_crypto_price_config(0, builder_address)
+    credits_config = get_fixed_credits_config(100, 1)
+
+    plan_name = f"E2E orgs per-call override {datetime.now(timezone.utc).isoformat()}"
+    result = payments.plans.register_plan(
+        plan_metadata=PlanMetadata(name=plan_name),
+        price_config=price_config,
+        credits_config=credits_config,
+        organization_id=TEST_BUILDER_ORG_ID,
+    )
+    plan_id = result["planId"]
+    assert plan_id
+
+    plan = payments.plans.get_plan(plan_id)
+    assert plan.get("orgId") == TEST_BUILDER_ORG_ID
+    assert payments.get_organization_id() is None
+
+
+def test_get_organization_activity_returns_paginated_page():
+    payments = _unpinned_payments()
+    page = payments.organizations.get_organization_activity(
+        TEST_BUILDER_ORG_ID,
+        OrganizationActivityFilters(page=1, limit=5),
+    )
+
+    assert isinstance(page.items, list)
+    assert isinstance(page.total, int)
+    assert len(page.items) > 0
+
+    event = page.items[0]
+    assert isinstance(event.id, str)
+    assert isinstance(event.event_type, str)
+    assert event.subject is not None
+    assert isinstance(event.subject.kind, str)
+    assert isinstance(event.subject.id, str)
+    assert isinstance(event.occurred_at, str)
+
+
+def test_get_organization_activity_narrows_by_event_type():
+    payments = _unpinned_payments()
+    page = payments.organizations.get_organization_activity(
+        TEST_BUILDER_ORG_ID,
+        OrganizationActivityFilters(
+            event_type=OrganizationActivityEventType.PLAN_CREATED,
+            page=1,
+            limit=10,
+        ),
+    )
+    assert all(
+        event.event_type == OrganizationActivityEventType.PLAN_CREATED.value
+        for event in page.items
+    )

--- a/tests/unit/test_base_payments_http.py
+++ b/tests/unit/test_base_payments_http.py
@@ -12,7 +12,9 @@ import json
 from unittest.mock import MagicMock
 
 from payments_py.api.base_payments import (
+    ALLOWED_EXTRA_HEADERS,
     BasePaymentsAPI,
+    CURRENT_ORG_ID_HEADER,
     _JS_MAX_SAFE_INTEGER,
     _stringify_unsafe_ints,
 )
@@ -102,3 +104,69 @@ class TestGetBackendHTTPOptions:
         assert body["amount"] == str(big)
         # Public path doesn't carry Authorization
         assert "Authorization" not in opts["headers"]
+
+
+class TestExtraHeadersAllowlist:
+    """The ``extra_headers`` argument on :meth:`get_backend_http_options` is
+    used by the per-call workspace-targeting path (``X-Current-Org-Id``).
+    Without an allowlist a caller could inject ``Authorization`` or
+    ``Content-Type`` through it and override the SDK's own auth — these
+    tests pin the allowlist (mirror of TS ``ALLOWED_EXTRA_HEADERS``).
+    """
+
+    def test_allowlist_includes_only_current_org_id_header(self):
+        # Hard-coded membership check — drift here implies the security
+        # surface widened. Any addition must be a deliberate review item.
+        assert ALLOWED_EXTRA_HEADERS == {CURRENT_ORG_ID_HEADER}
+
+    def test_current_org_id_header_passes_through(self):
+        bp = _bp_with_safe_jwt()
+        opts = bp.get_backend_http_options(
+            "GET",
+            extra_headers={CURRENT_ORG_ID_HEADER: "org-target-123"},
+        )
+        assert opts["headers"][CURRENT_ORG_ID_HEADER] == "org-target-123"
+
+    def test_unknown_headers_are_dropped(self):
+        bp = _bp_with_safe_jwt()
+        opts = bp.get_backend_http_options(
+            "GET",
+            extra_headers={"X-Custom-Trace-Id": "abc-123"},
+        )
+        assert "X-Custom-Trace-Id" not in opts["headers"]
+
+    def test_authorization_header_cannot_be_overridden(self):
+        # The SDK sets Authorization itself from the NVM API key. A caller
+        # passing Authorization through extra_headers must not silently
+        # replace it — that would let a per-call override hijack the auth.
+        bp = _bp_with_safe_jwt()
+        original_auth = bp.get_backend_http_options("GET")["headers"]["Authorization"]
+        opts = bp.get_backend_http_options(
+            "GET",
+            extra_headers={"Authorization": "Bearer evil-token"},
+        )
+        assert opts["headers"]["Authorization"] == original_auth
+
+    def test_content_type_header_cannot_be_overridden(self):
+        bp = _bp_with_safe_jwt()
+        opts = bp.get_backend_http_options(
+            "POST",
+            {"foo": "bar"},
+            extra_headers={"Content-Type": "text/plain"},
+        )
+        assert opts["headers"]["Content-Type"] == "application/json"
+
+    def test_mixed_allowed_and_disallowed_headers(self):
+        # Allowed key still goes through; disallowed keys silently dropped.
+        bp = _bp_with_safe_jwt()
+        opts = bp.get_backend_http_options(
+            "GET",
+            extra_headers={
+                CURRENT_ORG_ID_HEADER: "org-keep",
+                "X-Forwarded-For": "192.0.2.1",
+                "Cookie": "session=evil",
+            },
+        )
+        assert opts["headers"][CURRENT_ORG_ID_HEADER] == "org-keep"
+        assert "X-Forwarded-For" not in opts["headers"]
+        assert "Cookie" not in opts["headers"]

--- a/tests/unit/test_organizations_api.py
+++ b/tests/unit/test_organizations_api.py
@@ -105,9 +105,9 @@ class TestGetMyMemberships:
         assert memberships[1].role == OrganizationMemberRole.MEMBER
 
     def test_tolerates_unexpected_non_array_body(self):
-        # Backend changes that return an object instead of an array must not
-        # crash the SDK — newer event types and forward-compat shapes should
-        # degrade gracefully to an empty list rather than a TypeError.
+        # Backend changes that return an object instead of an array must
+        # not crash the SDK — `get_my_memberships()` should degrade
+        # gracefully to an empty list rather than a TypeError.
         payments = _make_payments()
         with requests_mock.Mocker() as m:
             m.get(

--- a/tests/unit/test_organizations_api.py
+++ b/tests/unit/test_organizations_api.py
@@ -1,0 +1,332 @@
+"""Unit tests for the OrganizationsAPI workspace surface.
+
+Covers the two new endpoints (``GET /my-memberships`` and
+``GET /:orgId/activity``) plus the ``X-Current-Org-Id`` header
+plumbing — instance pin via ``PaymentOptions.organization_id`` /
+``Payments.set_organization_id`` and per-call override on the
+publish methods.
+
+The mock NVM API key is the same fixture used in ``test_payments.py``.
+"""
+
+import os
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+import requests_mock
+
+from payments_py.api.base_payments import CURRENT_ORG_ID_HEADER
+from payments_py.common.payments_error import PaymentsError
+from payments_py.common.types import (
+    AgentAPIAttributes,
+    AgentMetadata,
+    MyMembership,
+    OrganizationActivityEventType,
+    OrganizationActivityFilters,
+    OrganizationMemberRole,
+    OrganizationType,
+    PaymentOptions,
+    PlanCreditsConfig,
+    PlanMetadata,
+    PlanPriceConfig,
+    PlanRedemptionType,
+)
+from payments_py.environments import Environments
+from payments_py.payments import Payments
+
+TEST_API_KEY = os.getenv(
+    "TEST_PROXY_BEARER_TOKEN",
+    "sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweEVCNDk3OTU2OTRBMDc1QTY0ZTY2MzdmMUU5MGYwMjE0Mzg5YjI0YTMiLCJqdGkiOiIweGMzYjYyMWJkYTM5ZDllYWQyMTUyMDliZWY0MDBhMDEzYjM1YjQ2Zjc1NzM4YWFjY2I5ZjdkYWI0ZjQ5MmM5YjgiLCJleHAiOjE3OTQ2NTUwNjAsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.YMkGQUjGh7_m07nj8SKXZReNKSryg9mTU3qwJr_TKYATUixbYQTte3CKucjqvgAGzJAd1Kq2ubz3b37n5Zsllxs",
+)
+
+BACKEND = Environments["staging_sandbox"].backend.rstrip("/")
+
+
+def _make_payments(organization_id=None):
+    return Payments.get_instance(
+        PaymentOptions(
+            nvm_api_key=TEST_API_KEY,
+            environment="staging_sandbox",
+            organization_id=organization_id,
+        )
+    )
+
+
+def _make_publish_fixtures():
+    """Minimal AgentMetadata/AgentAPI/PlanPriceConfig/PlanCreditsConfig
+    fixtures suitable for register_* mocks.
+    """
+    return {
+        "agent_metadata": AgentMetadata(name="Bot"),
+        "agent_api": AgentAPIAttributes(),
+        "plan_metadata": PlanMetadata(name="Plan"),
+        "price_config": PlanPriceConfig(amounts=[0], receivers=[], is_crypto=True),
+        "credits_config": PlanCreditsConfig(
+            is_redemption_amount_fixed=True,
+            redemption_type=PlanRedemptionType.ONLY_OWNER,
+            duration_secs=0,
+            amount="100",
+            min_amount=1,
+            max_amount=1,
+        ),
+    }
+
+
+class TestGetMyMemberships:
+    def test_returns_parsed_list(self):
+        payments = _make_payments()
+        body = [
+            {
+                "orgId": "org-aaa",
+                "organizationName": "Acme",
+                "organizationType": "Premium",
+                "role": "Admin",
+                "userIsActive": True,
+                "organizationIsActive": True,
+            },
+            {
+                "orgId": "org-bbb",
+                "organizationName": "Beta",
+                "organizationType": "Enterprise",
+                "role": "Member",
+                "userIsActive": True,
+                "organizationIsActive": True,
+            },
+        ]
+        with requests_mock.Mocker() as m:
+            m.get(f"{BACKEND}/api/v1/organizations/my-memberships", json=body)
+            memberships = payments.organizations.get_my_memberships()
+
+        assert len(memberships) == 2
+        assert isinstance(memberships[0], MyMembership)
+        assert memberships[0].org_id == "org-aaa"
+        assert memberships[0].organization_type == OrganizationType.PREMIUM
+        assert memberships[0].role == OrganizationMemberRole.ADMIN
+        assert memberships[1].role == OrganizationMemberRole.MEMBER
+
+    def test_tolerates_unexpected_non_array_body(self):
+        # Backend changes that return an object instead of an array must not
+        # crash the SDK — newer event types and forward-compat shapes should
+        # degrade gracefully to an empty list rather than a TypeError.
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/organizations/my-memberships",
+                json={"unexpected": "shape"},
+            )
+            assert payments.organizations.get_my_memberships() == []
+
+    def test_raises_on_5xx(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/organizations/my-memberships",
+                status_code=500,
+                json={"message": "boom"},
+            )
+            with pytest.raises(PaymentsError):
+                payments.organizations.get_my_memberships()
+
+
+class TestGetOrganizationActivity:
+    def test_encodes_filters_in_query_string(self):
+        payments = _make_payments()
+        body = {"items": [], "total": 0, "page": 1, "offset": 25}
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/organizations/org-xyz/activity",
+                json=body,
+            )
+            page = payments.organizations.get_organization_activity(
+                "org-xyz",
+                OrganizationActivityFilters(
+                    event_type=OrganizationActivityEventType.MEMBER_INVITED,
+                    actor_user_id="us-1",
+                    **{"from": "2026-01-01T00:00:00Z"},
+                    to="2026-12-31T23:59:59Z",
+                    page=2,
+                    offset=25,
+                ),
+            )
+
+        assert page.total == 0
+        assert m.last_request is not None
+        # requests_mock.qs lowercases everything; parse the raw URL ourselves
+        # so case-sensitive values like "MEMBER_INVITED" survive the check.
+        qs = parse_qs(urlparse(m.last_request.url).query)
+        assert qs["eventType"] == ["MEMBER_INVITED"]
+        assert qs["actorUserId"] == ["us-1"]
+        assert qs["from"] == ["2026-01-01T00:00:00Z"]
+        assert qs["to"] == ["2026-12-31T23:59:59Z"]
+        assert qs["page"] == ["2"]
+        assert qs["offset"] == ["25"]
+
+    def test_no_filters_means_no_query_string(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/organizations/org-xyz/activity",
+                json={"items": [], "total": 0, "page": 1, "offset": 10},
+            )
+            payments.organizations.get_organization_activity("org-xyz")
+            assert m.last_request.qs == {}
+
+    def test_parses_items(self):
+        payments = _make_payments()
+        body = {
+            "items": [
+                {
+                    "id": "ev-1",
+                    "eventType": "MEMBER_INVITED",
+                    "orgId": "org-xyz",
+                    "actorUserId": "us-admin",
+                    "metadata": {"email": "x@y.z"},
+                    "createdAt": "2026-05-18T00:00:00Z",
+                },
+            ],
+            "total": 1,
+            "page": 1,
+            "offset": 10,
+        }
+        with requests_mock.Mocker() as m:
+            m.get(f"{BACKEND}/api/v1/organizations/org-xyz/activity", json=body)
+            page = payments.organizations.get_organization_activity("org-xyz")
+
+        assert page.total == 1
+        assert len(page.items) == 1
+        assert page.items[0].id == "ev-1"
+        assert page.items[0].event_type == "MEMBER_INVITED"
+        assert page.items[0].metadata == {"email": "x@y.z"}
+
+    def test_rejects_without_org_id(self):
+        payments = _make_payments()
+        with pytest.raises(PaymentsError):
+            payments.organizations.get_organization_activity("")
+
+    def test_raises_on_403(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/organizations/org-forbidden/activity",
+                status_code=403,
+                json={"errorCode": "BCK.AUTH.0004", "message": "not a member"},
+            )
+            with pytest.raises(PaymentsError):
+                payments.organizations.get_organization_activity("org-forbidden")
+
+
+class TestInstanceLevelOrgPin:
+    def test_constructor_option_sets_header(self):
+        payments = _make_payments(organization_id="org-pin")
+        with requests_mock.Mocker() as m:
+            m.get(f"{BACKEND}/api/v1/organizations/my-memberships", json=[])
+            payments.organizations.get_my_memberships()
+
+            assert m.last_request.headers.get(CURRENT_ORG_ID_HEADER) == "org-pin"
+
+    def test_set_organization_id_mutates_subsequent_calls(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(f"{BACKEND}/api/v1/organizations/my-memberships", json=[])
+
+            payments.organizations.get_my_memberships()
+            first_header = m.last_request.headers.get(CURRENT_ORG_ID_HEADER)
+
+            payments.set_organization_id("org-after-set")
+            payments.organizations.get_my_memberships()
+            second_header = m.last_request.headers.get(CURRENT_ORG_ID_HEADER)
+
+            payments.set_organization_id(None)
+            payments.organizations.get_my_memberships()
+            third_header = m.last_request.headers.get(CURRENT_ORG_ID_HEADER)
+
+        assert first_header is None
+        assert second_header == "org-after-set"
+        assert third_header is None
+
+    def test_set_organization_id_propagates_to_sibling_apis(self):
+        payments = _make_payments()
+        payments.set_organization_id("org-fan-out")
+
+        assert payments.agents.get_organization_id() == "org-fan-out"
+        assert payments.plans.get_organization_id() == "org-fan-out"
+        assert payments.organizations.get_organization_id() == "org-fan-out"
+
+
+class TestPerCallOrgOverride:
+    def test_register_agent_forwards_organization_id_without_mutating_pin(self):
+        payments = _make_payments(organization_id="org-pinned")
+        fixtures = _make_publish_fixtures()
+        with requests_mock.Mocker() as m:
+            m.post(
+                f"{BACKEND}/api/v1/protocol/agents",
+                json={"data": {"agentId": "ag-1"}},
+            )
+            payments.agents.register_agent(
+                fixtures["agent_metadata"],
+                fixtures["agent_api"],
+                ["plan-1"],
+                organization_id="org-override",
+            )
+
+            assert m.last_request.headers.get(CURRENT_ORG_ID_HEADER) == "org-override"
+
+        # Instance pin must not be overwritten by the per-call hint.
+        assert payments.agents.get_organization_id() == "org-pinned"
+        assert payments.get_organization_id() == "org-pinned"
+
+    def test_register_agent_falls_back_to_pin_when_no_override(self):
+        payments = _make_payments(organization_id="org-pinned")
+        fixtures = _make_publish_fixtures()
+        with requests_mock.Mocker() as m:
+            m.post(
+                f"{BACKEND}/api/v1/protocol/agents",
+                json={"data": {"agentId": "ag-2"}},
+            )
+            payments.agents.register_agent(
+                fixtures["agent_metadata"],
+                fixtures["agent_api"],
+                ["plan-1"],
+            )
+
+            assert m.last_request.headers.get(CURRENT_ORG_ID_HEADER) == "org-pinned"
+
+    def test_register_agent_and_plan_accepts_override(self):
+        payments = _make_payments()
+        fixtures = _make_publish_fixtures()
+        with requests_mock.Mocker() as m:
+            m.post(
+                f"{BACKEND}/api/v1/protocol/agents/plans",
+                json={
+                    "data": {"agentId": "ag-3", "planId": "pl-3"},
+                    "txHash": "0xabc",
+                },
+            )
+            payments.agents.register_agent_and_plan(
+                fixtures["agent_metadata"],
+                fixtures["agent_api"],
+                fixtures["plan_metadata"],
+                fixtures["price_config"],
+                fixtures["credits_config"],
+                None,
+                organization_id="org-c",
+            )
+
+            assert m.last_request.headers.get(CURRENT_ORG_ID_HEADER) == "org-c"
+
+    def test_register_plan_forwards_override(self):
+        payments = _make_payments()
+        fixtures = _make_publish_fixtures()
+        with requests_mock.Mocker() as m:
+            m.post(
+                f"{BACKEND}/api/v1/protocol/plans",
+                json={"planId": "pl-4"},
+            )
+            payments.plans.register_plan(
+                fixtures["plan_metadata"],
+                fixtures["price_config"],
+                fixtures["credits_config"],
+                organization_id="org-d",
+            )
+
+            assert m.last_request.headers.get(CURRENT_ORG_ID_HEADER) == "org-d"

--- a/tests/unit/test_organizations_api.py
+++ b/tests/unit/test_organizations_api.py
@@ -78,19 +78,19 @@ class TestGetMyMemberships:
         body = [
             {
                 "orgId": "org-aaa",
-                "organizationName": "Acme",
-                "organizationType": "Premium",
+                "orgName": "Acme",
                 "role": "Admin",
-                "userIsActive": True,
-                "organizationIsActive": True,
+                "orgType": "Premium",
+                "isAdmin": True,
+                "hasSubscriptionHistory": True,
             },
             {
                 "orgId": "org-bbb",
-                "organizationName": "Beta",
-                "organizationType": "Enterprise",
+                "orgName": "Beta",
                 "role": "Member",
-                "userIsActive": True,
-                "organizationIsActive": True,
+                "orgType": "Enterprise",
+                "isAdmin": False,
+                "hasSubscriptionHistory": True,
             },
         ]
         with requests_mock.Mocker() as m:
@@ -100,9 +100,12 @@ class TestGetMyMemberships:
         assert len(memberships) == 2
         assert isinstance(memberships[0], MyMembership)
         assert memberships[0].org_id == "org-aaa"
-        assert memberships[0].organization_type == OrganizationType.PREMIUM
+        assert memberships[0].org_name == "Acme"
+        assert memberships[0].org_type == OrganizationType.PREMIUM
         assert memberships[0].role == OrganizationMemberRole.ADMIN
+        assert memberships[0].is_admin is True
         assert memberships[1].role == OrganizationMemberRole.MEMBER
+        assert memberships[1].is_admin is False
 
     def test_tolerates_unexpected_non_array_body(self):
         # Backend changes that return an object instead of an array must
@@ -131,7 +134,7 @@ class TestGetMyMemberships:
 class TestGetOrganizationActivity:
     def test_encodes_filters_in_query_string(self):
         payments = _make_payments()
-        body = {"items": [], "total": 0, "page": 1, "offset": 25}
+        body = {"items": [], "total": 0}
         with requests_mock.Mocker() as m:
             m.get(
                 f"{BACKEND}/api/v1/organizations/org-xyz/activity",
@@ -145,28 +148,45 @@ class TestGetOrganizationActivity:
                     **{"from": "2026-01-01T00:00:00Z"},
                     to="2026-12-31T23:59:59Z",
                     page=2,
-                    offset=25,
+                    limit=25,
                 ),
             )
 
         assert page.total == 0
         assert m.last_request is not None
-        # requests_mock.qs lowercases everything; parse the raw URL ourselves
-        # so case-sensitive values like "MEMBER_INVITED" survive the check.
         qs = parse_qs(urlparse(m.last_request.url).query)
-        assert qs["eventType"] == ["MEMBER_INVITED"]
+        assert qs["eventType"] == ["member.invited"]
         assert qs["actorUserId"] == ["us-1"]
         assert qs["from"] == ["2026-01-01T00:00:00Z"]
         assert qs["to"] == ["2026-12-31T23:59:59Z"]
         assert qs["page"] == ["2"]
-        assert qs["offset"] == ["25"]
+        assert qs["limit"] == ["25"]
+
+    def test_joins_array_event_type_filter(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/organizations/org-xyz/activity",
+                json={"items": [], "total": 0},
+            )
+            payments.organizations.get_organization_activity(
+                "org-xyz",
+                OrganizationActivityFilters(
+                    event_type=[
+                        OrganizationActivityEventType.PLAN_CREATED,
+                        OrganizationActivityEventType.AGENT_CREATED,
+                    ],
+                ),
+            )
+            qs = parse_qs(urlparse(m.last_request.url).query)
+            assert qs["eventType"] == ["plan.created,agent.created"]
 
     def test_no_filters_means_no_query_string(self):
         payments = _make_payments()
         with requests_mock.Mocker() as m:
             m.get(
                 f"{BACKEND}/api/v1/organizations/org-xyz/activity",
-                json={"items": [], "total": 0, "page": 1, "offset": 10},
+                json={"items": [], "total": 0},
             )
             payments.organizations.get_organization_activity("org-xyz")
             assert m.last_request.qs == {}
@@ -176,17 +196,19 @@ class TestGetOrganizationActivity:
         body = {
             "items": [
                 {
-                    "id": "ev-1",
-                    "eventType": "MEMBER_INVITED",
-                    "orgId": "org-xyz",
+                    "id": "ae-1",
+                    "eventType": "plan.created",
                     "actorUserId": "us-admin",
-                    "metadata": {"email": "x@y.z"},
-                    "createdAt": "2026-05-18T00:00:00Z",
+                    "subject": {
+                        "kind": "plan",
+                        "id": "12345",
+                        "name": "Test Plan",
+                    },
+                    "metadata": {"foo": "bar"},
+                    "occurredAt": "2026-05-21T00:00:00Z",
                 },
             ],
             "total": 1,
-            "page": 1,
-            "offset": 10,
         }
         with requests_mock.Mocker() as m:
             m.get(f"{BACKEND}/api/v1/organizations/org-xyz/activity", json=body)
@@ -194,9 +216,16 @@ class TestGetOrganizationActivity:
 
         assert page.total == 1
         assert len(page.items) == 1
-        assert page.items[0].id == "ev-1"
-        assert page.items[0].event_type == "MEMBER_INVITED"
-        assert page.items[0].metadata == {"email": "x@y.z"}
+        event = page.items[0]
+        assert event.id == "ae-1"
+        assert event.event_type == "plan.created"
+        assert event.actor_user_id == "us-admin"
+        assert event.subject.kind == "plan"
+        assert event.subject.id == "12345"
+        # Extras from the subject flow through via Pydantic's extra="allow".
+        assert getattr(event.subject, "name", None) == "Test Plan"
+        assert event.metadata == {"foo": "bar"}
+        assert event.occurred_at == "2026-05-21T00:00:00Z"
 
     def test_rejects_without_org_id(self):
         payments = _make_payments()


### PR DESCRIPTION
## Summary

- Adds a new `OrganizationsAPI` with `get_my_memberships()` and `get_organization_activity(org_id, filters)`, exposed as `payments.organizations`.
- Adds workspace targeting: pin via `Payments.set_organization_id()` / `PaymentOptions.organization_id`, or per-call via an `organization_id=` keyword on `agents.register_agent`, `agents.register_agent_and_plan`, and every `plans.register_*` helper.
- Transport is the `X-Current-Org-Id` header (resolved by `CurrentOrgContextGuard` in nvm-monorepo). The base HTTP client gains an `extra_headers` channel for per-call overrides; the `Payments` fan-out auto-discovers every eagerly-constructed sub-API and resets lazy caches.
- New Pydantic models: `MyMembership`, `OrganizationActivityEvent`, `OrganizationActivityEventType`, `OrganizationActivityPage`, `OrganizationActivityFilters`, plus the `OrganizationMemberRole` and `OrganizationType` enums.

## Test plan

- [x] `poetry run pytest -m "not slow"` — 407 tests pass including 15 new in `tests/unit/test_organizations_api.py`
- [x] `poetry run black --check payments_py tests` clean
- [ ] Smoke test against staging-sandbox: list memberships for a multi-org account, fetch activity for one org, publish an agent with `organization_id=` and confirm it lands in the right workspace via the webapp

## Notes

- Built against `main` after `git fetch`; branch was cut from `origin/main` cleanly.
- Sync `requests`-based, matches the existing module style (no httpx migration).