### PR TITLE
fix(x402): silence runtime UserWarnings — Extension schema shadow + InsecureRequestWarning

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,3 +247,14 @@ poetry install --extras "strands langchain"   # install all optional extras
 poetry run pytest -m "not slow"               # full unit + integration suite
 poetry run pytest tests/unit/x402/            # one directory
 ```
+
+### Custom CA bundle (self-signed-cert environments)
+
+The SDK uses `requests`' default TLS verification against the system trust store. Public Nevermined backends (sandbox, live) serve real certs, so no configuration is needed.
+
+If you're pointing the SDK at a dev environment that serves a self-signed certificate (e.g. a local Caddy with its own CA), export `REQUESTS_CA_BUNDLE` before running — `requests` reads it directly, no SDK change required:
+
+```bash
+export REQUESTS_CA_BUNDLE=/path/to/your-ca.pem
+poetry run python your_script.py
+```

--- a/payments_py/api/base_payments.py
+++ b/payments_py/api/base_payments.py
@@ -182,11 +182,6 @@ class BasePaymentsAPI:
         Returns:
             HTTP options object
         """
-        # Disable SSL verification for development/staging environments
-        # For now, disable SSL verification for all environments to handle
-        # self-signed certificates
-        verify_ssl = False
-
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -203,9 +198,10 @@ class BasePaymentsAPI:
                 {k: v for k, v in extra_headers.items() if k in ALLOWED_EXTRA_HEADERS}
             )
 
+        # Leave TLS verification on (requests' default). For environments with
+        # self-signed certs, point ``REQUESTS_CA_BUNDLE`` at the CA cert.
         options = {
             "headers": headers,
-            "verify": verify_ssl,
             "timeout": DEFAULT_HTTP_TIMEOUT,
         }
         if body:
@@ -229,14 +225,13 @@ class BasePaymentsAPI:
         Returns:
             HTTP options object
         """
-        verify_ssl = False
-
+        # Leave TLS verification on (requests' default). For environments with
+        # self-signed certs, point ``REQUESTS_CA_BUNDLE`` at the CA cert.
         options = {
             "headers": {
                 "Accept": "application/json",
                 "Content-Type": "application/json",
             },
-            "verify": verify_ssl,
             "timeout": DEFAULT_HTTP_TIMEOUT,
         }
         if body:

--- a/payments_py/api/contracts_api.py
+++ b/payments_py/api/contracts_api.py
@@ -85,7 +85,7 @@ class ContractsAPI(BasePaymentsAPI):
             info_url = f"{backend_url}{API_URL_INFO}"
 
             # Info endpoint doesn't require authentication
-            response = requests.get(info_url, verify=False)
+            response = requests.get(info_url)
             response.raise_for_status()
 
             info_data = response.json()

--- a/payments_py/x402/extensions/nevermined/validate.py
+++ b/payments_py/x402/extensions/nevermined/validate.py
@@ -57,7 +57,7 @@ def validate_nevermined_extension(extension: NeverminedExtension) -> ValidationR
         else:
             # Pydantic Extension model
             info = extension.info
-            schema = extension.schema
+            schema = extension.schema_
 
         # Validate info against schema using JSON Schema
         validate(instance=info, schema=schema)

--- a/payments_py/x402/types_v2.py
+++ b/payments_py/x402/types_v2.py
@@ -14,7 +14,7 @@ https://github.com/coinbase/x402/tree/v2-development
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 from typing import Any, Dict, List, Optional
 
@@ -47,7 +47,12 @@ class Extension(BaseModel):
     """
 
     info: Dict[str, Any]
-    schema: Dict[str, Any]
+    # ``schema`` is the x402 wire field name, but as a Python attribute it
+    # shadows pydantic's deprecated ``BaseModel.schema()`` classmethod and
+    # triggers a UserWarning at class definition time. We use ``schema_`` as
+    # the Python attribute and alias it to ``"schema"`` so the JSON wire
+    # shape is preserved.
+    schema_: Dict[str, Any] = Field(..., alias="schema")
 
     model_config = ConfigDict(
         alias_generator=to_camel,


### PR DESCRIPTION
## Summary

Cleans up two long-running UserWarnings that fired on every SDK import / call against `api.sandbox.nevermined.dev`. Surfaced while running the Sprint 0 LangChain tutorial.

### Fix #1 — `Extension` field-shadowing UserWarning

`payments_py.x402.types_v2.Extension` declared `schema: Dict[str, Any]`, which collides with `pydantic.BaseModel.schema()` (the v1 method pydantic v2 still exposes for back-compat). On every import pydantic emitted:

```
UserWarning: Field name "schema" in "Extension" shadows an attribute in parent "BaseModel"
```

Renamed the Python attribute to `schema_` and pinned the alias explicitly with `Field(..., alias="schema")`. `populate_by_name=True` was already in the model_config, so `Extension(schema=...)` keyword construction is unchanged, and `model_dump(by_alias=True)` still emits the wire shape `{"schema": ...}`. The one internal reader (`extensions/nevermined/validate.py`) was updated to `extension.schema_`.

### Fix #2 — `InsecureRequestWarning` on every backend call

`base_payments.py` set `verify_ssl = False` on every backend HTTPS request out of the SDK, with a *"for now, disable SSL verification for all environments to handle self-signed certificates"* comment. `contracts_api.py` had the same `verify=False` on the deployment-info call. Net result: every demo against `api.sandbox.nevermined.dev` printed two-to-four `InsecureRequestWarning` lines, and the SDK was silently MITM-vulnerable on the wire even though sandbox and live backends both serve real, trusted certs.

Removed `verify_ssl = False` from both `get_backend_http_options` and `get_public_http_options`, plus the `verify=False` in `contracts_api.get_deployment_info`. `requests` now uses its default `verify=True`, validating the cert against the system trust store.

For environments with self-signed certs (rare, dev-only), the standard `requests` escape hatch — `REQUESTS_CA_BUNDLE` env var pointing at the CA cert — still works without any SDK change.

## Changes

- `payments_py/x402/types_v2.py`: `schema` → `schema_` + `Field(..., alias="schema")`. `Field` added to imports. Inline comment explains the rename.
- `payments_py/x402/extensions/nevermined/validate.py`: internal reader updated to `extension.schema_`.
- `payments_py/api/base_payments.py`: `verify_ssl = False` removed from both `get_backend_http_options` and `get_public_http_options`. Added comment pointing at `REQUESTS_CA_BUNDLE` as the escape hatch for self-signed-cert environments.
- `payments_py/api/contracts_api.py`: `requests.get(info_url, verify=False)` → `requests.get(info_url)`.

## Wire compatibility (Fix #1)

- `Extension(info={...}, schema={...})` — unchanged (`populate_by_name=True`).
- `model_dump(by_alias=True)` → `{"info": ..., "schema": {...}}` — unchanged (alias).

## Breaking change scope (Fix #1)

- ✅ JSON wire shape: unchanged.
- ✅ Construction (`Extension(schema=...)`): unchanged.
- ⚠️ **Attribute access** on Extension instances: `.schema` now resolves to pydantic's deprecated `BaseModel.schema()` classmethod (returns the model JSON schema). External consumers should switch to `.schema_`. Internal grep finds zero usages outside the one updated reader.

## Test plan

- [x] `python -W error::UserWarning -c "from payments_py.x402.types_v2 import Extension; Extension(info={}, schema={})"` — clean.
- [x] `poetry run pytest tests/unit/` — 446/446 pass.
- [x] `poetry run black --check` — 145 files clean.
- [x] End-to-end tutorial run against real sandbox: all five steps (discovery → token acquisition → agent invocation → settlement receipt) complete cleanly. **No `InsecureRequestWarning` emitted**; **no `UserWarning` from the schema field**.
- [x] Rebased onto current main (after #183 merged).

## Motivation

Surfaced while running the Sprint 0 LangChain tutorial demo. Both warnings fired on every run, making the demo output noisy and (in the case of `InsecureRequestWarning`) calling attention to a real wire-security regression that shipped silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)