### PR TITLE
docs(langchain): add Python LangChain integration source for the Mintlify pipeline

### DIFF
--- a/.github/workflows/publish-mintlify-docs.yml
+++ b/.github/workflows/publish-mintlify-docs.yml
@@ -46,8 +46,8 @@ jobs:
           FILE_COUNT=$(find payments-py/docs/api -name "*.md" | wc -l)
           echo "Found $FILE_COUNT documentation files"
 
-          if [ "$FILE_COUNT" -lt 11 ]; then
-            echo "Error: Expected at least 11 documentation files, found $FILE_COUNT"
+          if [ "$FILE_COUNT" -lt 12 ]; then
+            echo "Error: Expected at least 12 documentation files, found $FILE_COUNT"
             exit 1
           fi
 
@@ -81,8 +81,8 @@ jobs:
           CONVERTED_COUNT=$(find ../mintlify-output -name "*.mdx" | wc -l)
           echo "Converted $CONVERTED_COUNT files to MDX format"
 
-          if [ "$CONVERTED_COUNT" -lt 11 ]; then
-            echo "Error: Expected at least 11 converted files, found $CONVERTED_COUNT"
+          if [ "$CONVERTED_COUNT" -lt 12 ]; then
+            echo "Error: Expected at least 12 converted files, found $CONVERTED_COUNT"
             exit 1
           fi
 
@@ -151,7 +151,7 @@ jobs:
             This PR updates the Python SDK documentation for version `${{ steps.version.outputs.version }}`.
 
             ### Changes
-            - ✅ Updated all 11 documentation files
+            - ✅ Updated all 12 documentation files
             - 📦 Source: [nevermined-io/payments-py@${{ github.sha }}](https://github.com/nevermined-io/payments-py/commit/${{ github.sha }})
             - 🏷️ Version: `${{ steps.version.outputs.version }}`
             - 🎯 Target Branch: `${{ steps.version.outputs.target_branch }}`
@@ -168,6 +168,7 @@ jobs:
             - `mcp-module.mdx`
             - `a2a-module.mdx`
             - `x402-module.mdx`
+            - `langchain-module.mdx`
 
             ### Conversion Details
             - Converted from Markdown to Mintlify MDX format

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -1,0 +1,264 @@
+# LangChain Integration
+
+This guide covers the LangChain and LangGraph integration shipped in the `[langchain]` optional extra of `payments-py`. The module `payments_py.x402.langchain` provides the decorator, helpers, and exceptions for monetizing LangChain tools with the x402 protocol.
+
+For the conceptual walk-through (two integration approaches, the discovery-first flow, dynamic credits patterns), see the [LangChain integration guide](/docs/integrate/add-to-your-agent/langchain). For a runnable end-to-end demo, see the [`langchain-paid-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-paid-agent-py) tutorial.
+
+## Installation
+
+```bash
+pip install payments-py[langchain] langgraph langchain-openai
+```
+
+The `[langchain]` extra installs `langchain-core`. `langgraph` and `langchain-openai` are optional — needed only if you build a LangGraph agent.
+
+## Exports
+
+| Symbol | Purpose |
+|--------|---------|
+| `requires_payment` | Decorator that gates a `@tool` on an x402 access token |
+| `PaymentRequiredError` | Exception raised when the token is missing or verification fails |
+| `last_settlement` | Read the most recent settlement receipt from outside the agent's call stack |
+| `create_paid_react_agent` | LangGraph ReAct agent builder that lets `PaymentRequiredError` propagate intact |
+
+All four are exported from `payments_py.x402.langchain`:
+
+```python
+from payments_py.x402.langchain import (
+    requires_payment,
+    PaymentRequiredError,
+    last_settlement,
+    create_paid_react_agent,
+)
+```
+
+## `requires_payment`
+
+Decorator that protects a LangChain `@tool` with x402 payment verification and settlement. Pulls the access token from `RunnableConfig.configurable["payment_token"]`, verifies it, runs the tool body, then settles credits.
+
+### Signature
+
+```python
+def requires_payment(
+    payments: Payments,
+    plan_id: str | None = None,
+    plan_ids: list[str] | None = None,
+    credits: int | Callable[[dict], int] = 1,
+    agent_id: str | None = None,
+    network: str | None = None,
+    scheme: str | None = None,
+) -> Callable
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `payments` | A `Payments` instance with `payments.facilitator` configured. |
+| `plan_id` / `plan_ids` | The plan(s) the tool charges against. Pass one of the two; `plan_id` is a convenience for the single-plan case. |
+| `credits` | How many credits to charge. Sent to the facilitator as `max_amount`. See [credits semantics](#credits-semantics) for fixed-vs-range plans. |
+| `agent_id` | Optional agent identifier propagated to the receipt. |
+| `network` | Optional CAIP-2 network ID. Auto-resolved from the plan when omitted. |
+| `scheme` | Optional x402 scheme (`nvm:erc4337` or `nvm:card-delegation`). Auto-resolved when omitted. |
+
+### Decorator order
+
+`@tool` **outside**, `@requires_payment` **inside**:
+
+```python
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+from payments_py import Payments, PaymentOptions
+from payments_py.x402.langchain import requires_payment
+
+payments = Payments.get_instance(
+    PaymentOptions(nvm_api_key="nvm:builder-key", environment="sandbox")
+)
+
+@tool
+@requires_payment(payments=payments, plan_id="plan-123", credits=1)
+def get_market_insight(topic: str, config: RunnableConfig = None) -> str:
+    """Return a short market insight. Costs 1 credit per call."""
+    return f"Market insight for '{topic}': demand is up 12% QoQ."
+```
+
+The protected function **must** accept a `config: RunnableConfig` parameter — that is how the decorator reads the payment token at call time.
+
+### Dynamic credits
+
+`credits` accepts three forms:
+
+- **Static int** — `credits=1` (fixed cost per call).
+- **Lambda** — `credits=lambda ctx: max(1, len(ctx["result"]) // 100)`.
+- **Named function** — `credits=my_fn` where `my_fn(ctx) -> int`.
+
+When callable, `ctx` is `{"args": <tool kwargs>, "result": <tool return>}`. Dynamic credits resolve **after** execution so the result is available.
+
+### Credits semantics
+
+The `credits` argument is sent to the facilitator as `max_amount`. The actual amount redeemed depends on the plan's server-side credit configuration:
+
+- **Fixed plans** (`plan.credits.minAmount == plan.credits.maxAmount`) always burn `plan.credits.maxAmount`. The decorator's `credits=N` is then effectively a no-op (per [nevermined-io/nvm-monorepo#1568](https://github.com/nevermined-io/nvm-monorepo/issues/1568)).
+- **Range plans** clamp the supplied value into `[plan.credits.minAmount, plan.credits.maxAmount]`.
+
+If you want predictable per-call cost, configure the plan as fixed; the decorator value is then a client-side declaration.
+
+## `PaymentRequiredError`
+
+Raised by `@requires_payment` when the token is missing from `config["configurable"]["payment_token"]`, or when the facilitator rejects the token (expired, invalid signature, insufficient balance, etc.). Carries the full `X402PaymentRequired` payload so callers can run the x402 discovery flow.
+
+```python
+from payments_py.x402.langchain import PaymentRequiredError
+
+try:
+    agent.invoke({"messages": [("human", "...")]}, config={"configurable": {}})
+except PaymentRequiredError as err:
+    accepts = err.payment_required.accepts[0]
+    # accepts.scheme    → "nvm:erc4337" or "nvm:card-delegation"
+    # accepts.network   → CAIP-2 chain or provider name (stripe, braintree, visa)
+    # accepts.plan_id   → which plan to acquire a token against
+```
+
+### Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `payment_required` | `X402PaymentRequired \| None` | The full x402 v2 payment-required payload. `accepts[0]` carries scheme / network / plan_id / agent_id. |
+
+For the discovery → acquire → retry flow, see the [LangChain integration guide](/docs/integrate/add-to-your-agent/langchain).
+
+## `last_settlement`
+
+Returns the most recent `SettleResponse` produced by `@requires_payment` in this process. Use this after invoking a LangGraph runnable to recover the settlement receipt — `credits_redeemed`, `remaining_balance`, `transaction`, `network`, `payer` — without threading it back through `RunnableConfig.configurable` (which LangGraph copies per node, so the SDK's in-place write is not visible to the outer caller).
+
+### Signature
+
+```python
+def last_settlement() -> SettleResponse | None
+```
+
+Returns `None` if no settlement has happened yet in this process, or if the most recent invocation raised before reaching the settle phase.
+
+### Example
+
+```python
+from payments_py.x402.langchain import last_settlement
+
+result = agent.invoke(
+    {"messages": [("human", "...")]},
+    config={"configurable": {"payment_token": token}},
+)
+
+receipt = last_settlement()
+if receipt:
+    print(f"  credits_redeemed: {receipt.credits_redeemed}")
+    print(f"  remaining_balance: {receipt.remaining_balance}")
+    print(f"  transaction: {receipt.transaction}")
+```
+
+!!! warning "Single-tenant"
+
+    `last_settlement()` reads from a module-level slot. In multi-tenant processes (e.g. a server handling concurrent settlements), the value reflects whichever invocation settled most recently — there is no per-call isolation. For multi-tenant scenarios, surface settlement via a callback or observability layer instead.
+
+## `create_paid_react_agent`
+
+Thin wrapper over [`langgraph.prebuilt.create_react_agent`](https://langchain-ai.github.io/langgraph/reference/prebuilt/#create_react_agent) that constructs the underlying `ToolNode` with `handle_tool_errors=False`. That single change is what lets `PaymentRequiredError` propagate all the way back to `agent.invoke()`'s caller with its `X402PaymentRequired` payload intact — the default `ToolNode` behaviour stringifies the exception into a `ToolMessage` for the LLM and **loses the payload**.
+
+### Signature
+
+```python
+def create_paid_react_agent(
+    model: Any,
+    tools: Sequence[Any],
+    **kwargs: Any,
+) -> CompiledStateGraph
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `model` | Anything accepted by `create_react_agent`'s `model` argument (a `BaseChatModel`, a string, a runnable, etc.). |
+| `tools` | Sequence of LangChain tools — typically functions decorated with `@tool` and `@requires_payment`. |
+| `**kwargs` | Forwarded verbatim to `create_react_agent` (`prompt`, `state_schema`, `checkpointer`, …). Unknown kwargs raise `TypeError` from LangGraph at call time. |
+
+`langgraph` is imported lazily so the `[langchain]` extra need not pull it in. Install LangGraph yourself (`pip install langgraph`) to use this helper.
+
+### Example
+
+```python
+from langchain_openai import ChatOpenAI
+from payments_py.x402.langchain import create_paid_react_agent, requires_payment
+
+@tool
+@requires_payment(payments=payments, plan_id=PLAN_ID, credits=1)
+def get_market_insight(topic: str, config=None) -> str:
+    return f"Market insight for {topic} ..."
+
+agent = create_paid_react_agent(
+    ChatOpenAI(model="gpt-4o-mini", temperature=0),
+    [get_market_insight],
+    prompt="You are a market data assistant. Always call get_market_insight.",
+)
+```
+
+## End-to-end usage
+
+The canonical x402 flow uses all four symbols together — discovery, acquisition, retry, receipt read:
+
+```python
+import os
+from dotenv import load_dotenv
+from payments_py import Payments, PaymentOptions
+from payments_py.x402.langchain import (
+    PaymentRequiredError,
+    create_paid_react_agent,
+    last_settlement,
+    requires_payment,
+)
+from payments_py.x402.types import DelegationConfig, X402TokenOptions
+
+load_dotenv()
+payments = Payments.get_instance(
+    PaymentOptions(
+        nvm_api_key=os.environ["NVM_API_KEY"],
+        environment=os.getenv("NVM_ENVIRONMENT", "sandbox"),
+    )
+)
+
+# 1. Build the agent (see the LangChain integration guide for the protected tool).
+agent = create_paid_react_agent(model, [get_market_insight], prompt=prompt)
+
+# 2. Discover what the agent's tool charges by invoking without a token.
+try:
+    agent.invoke({"messages": [("human", QUERY)]}, config={"configurable": {}})
+except PaymentRequiredError as err:
+    accept = err.payment_required.accepts[0]
+
+# 3. Acquire a token against the discovered plan.
+pm = next(m for m in payments.delegation.list_payment_methods()
+          if m.provider == accept.network)
+token = payments.x402.get_x402_access_token(
+    accept.plan_id,
+    token_options=X402TokenOptions(
+        scheme=accept.scheme,
+        delegation_config=DelegationConfig(
+            provider_payment_method_id=pm.id,
+            spending_limit_cents=10000,
+            duration_secs=3600,
+            currency="usd",
+        ),
+    ),
+)["accessToken"]
+
+# 4. Retry with the token and read the settlement.
+result = agent.invoke(
+    {"messages": [("human", QUERY)]},
+    config={"configurable": {"payment_token": token}},
+)
+receipt = last_settlement()
+```
+
+For the full, runnable version see [`tutorials/langchain-paid-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-paid-agent-py).
+
+## Related
+
+- [LangChain integration guide](/docs/integrate/add-to-your-agent/langchain) — conceptual walk-through, the two integration approaches (decorator vs. HTTP middleware), and the TypeScript variant.
+- [x402 Protocol](11-x402.md) — token generation, delegation config, scheme resolution.
+- [`tutorials/langchain-paid-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-paid-agent-py) — the minimal end-to-end demo.

--- a/scripts/convert_to_mintlify.py
+++ b/scripts/convert_to_mintlify.py
@@ -69,6 +69,11 @@ FILE_MAPPING = {
         "icon": "lock",
         "description": "Use x402 protocol for payment verification and settlement",
     },
+    "12-langchain-integration.md": {
+        "target": "langchain-module.mdx",
+        "icon": "link-simple",
+        "description": "Decorator, helpers, and exceptions for protecting LangChain and LangGraph tools",
+    },
 }
 
 # Link mapping for internal references
@@ -84,6 +89,7 @@ LINK_MAPPING = {
     "09-mcp-integration.md": "/docs/api-reference/python/mcp-module",
     "10-a2a-integration.md": "/docs/api-reference/python/a2a-module",
     "11-x402.md": "/docs/api-reference/python/x402-module",
+    "12-langchain-integration.md": "/docs/api-reference/python/langchain-module",
 }
 
 


### PR DESCRIPTION
## Summary

Adds the 12th documentation source file so the existing \`publish-mintlify-docs.yml\` workflow produces a \`docs/api-reference/python/langchain-module.mdx\` in [nevermined-io/docs](https://github.com/nevermined-io/docs) on the next \`v*.*.*\` release tag — same flow as the existing 11 Python module pages.

## Changes

- **\`docs/api/12-langchain-integration.md\` (NEW)** — source MD covering \`requires_payment\`, \`PaymentRequiredError\`, \`last_settlement\`, and \`create_paid_react_agent\`, plus an end-to-end discovery → token → retry walk. Plain Markdown with MkDocs admonitions so the converter produces a Mintlify-compatible MDX with frontmatter + Note/Warning components.
- **\`scripts/convert_to_mintlify.py\`** — FILE_MAPPING + LINK_MAPPING entries for the new file.
- **\`.github/workflows/publish-mintlify-docs.yml\`** — both \`-lt 11\` count checks bumped to \`-lt 12\`, "Updated all 11" → "Updated all 12", and \`langchain-module.mdx\` added to the auto-generated PR body's file list.

## Test plan

- [x] \`poetry run python scripts/convert_to_mintlify.py --source docs/api --target /tmp/mintlify-out --verbose\` — **12 of 12 files converted, 0 errors**. New file produces a valid MDX with proper frontmatter.
- [x] \`poetry run pre-commit run\` on changed files — \`black: Passed\`.
- [x] Workflow YAML still valid (visual inspection; no syntax-changing edits).

## Motivation

While preparing a hand-authored \`docs/api-reference/python/langchain-module.mdx\` in [nevermined-io/docs#178](https://github.com/nevermined-io/docs/pull/178), we noticed the docs CLAUDE.md rule ("sourced from different repositories — don't modify directly") was correct: the existing \`publish-mintlify-docs.yml\` does \`rm -f "\$TARGET_DIR"/*.mdx\` before copying converted output. Hand-authoring in the docs repo would have been **silently deleted on the next release**. This PR is the structurally correct path — source lives here, the workflow converts and lands on release.

## Merge sequence (release-train coordination)

1. **This PR** lands on \`payments-py/main\` (no immediate user-facing change — the source MD is not part of the converter output until the next tag).
2. **Tag a payments-py release** (e.g., \`v1.6.1\` or \`v1.7.0\`). The workflow runs, converts 12 files, opens a PR on \`nevermined-io/docs\`, auto-merges → the new \`langchain-module.mdx\` lands in the docs site.
3. **Then [nevermined-io/docs#178](https://github.com/nevermined-io/docs/pull/178) can merge** — its \`docs.json\` sidebar slot for \`langchain-module\` and its cross-links from the integration guide both light up at that point.

Tracked in the LangChain integration epic at [nevermined-io/nvm-monorepo#1703](https://github.com/nevermined-io/nvm-monorepo/issues/1703), Sprint 0 sub-issue [#1704](https://github.com/nevermined-io/nvm-monorepo/issues/1704).

🤖 Generated with [Claude Code](https://claude.com/claude-code)