### PR TITLE
feat(langsmith): emit verify + settlement spans for LangSmith tracing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,18 @@ The CI pipeline runs:
 2. **Unit & Integration** (`.github/workflows/test.yaml`) - Fast tests
 3. **E2E** - Slow tests (runs after unit/integration pass)
 
+## Release Process
+
+**Do NOT bump the version in `pyproject.toml` by hand in a feature PR.** The release is fully automated through three workflows:
+
+1. **`prepare-release.yml`** — manual trigger via Actions UI (`workflow_dispatch`). Takes a `version` input (e.g. `1.8.0`), bumps `pyproject.toml`, opens a PR from a `release/<version>` branch.
+2. **`finalize-release.yml`** — fires when the `release/*` PR is merged. Creates the `v<version>` git tag.
+3. **`release-python.yml`** — fires on `v*.*` tag push. Builds and publishes to PyPI.
+
+In addition, **`publish-mintlify-docs.yml`** fires on the same tag, runs `scripts/convert_to_mintlify.py` over `docs/api/`, and opens a PR in `nevermined-io/docs_mintlify` updating `docs/api-reference/python/*.mdx`.
+
+Feature PRs ship code, tests, and source docs (`docs/api/*.md`). The version stays where it is — the human releasing decides what number to use and runs the workflow.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ payments = Payments.get_instance(
 )
 ```
 
+### Optional integrations
+
+The core SDK has no integration dependencies. Add one or more of the following extras when installing:
+
+| Extra | Pulls in | Purpose |
+| --- | --- | --- |
+| `fastapi` | `fastapi`, `starlette` | `payments_py.x402.fastapi.PaymentMiddleware` for HTTP route-level payment gating |
+| `strands` | `strands-agents` | Strands `@requires_payment` decorator |
+| `langchain` | `langchain-core` | LangChain `@requires_payment` decorator + `create_paid_react_agent` |
+| `langsmith` | `langsmith` | Auto-emit `nvm:verify` and `nvm:settlement` spans into LangSmith traces when `LANGSMITH_TRACING=true` |
+
+```bash
+pip install "payments-py[langchain,langsmith]"
+```
+
 ## A2A Integration (Agents-to-Agents)
 
 The Python SDK can both start an A2A server (FastAPI-based) and act as an A2A client.

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -309,13 +309,28 @@ The payment flow itself is unaffected by trace-shipping failures — verify, too
 | `nvm:verify`     | `nvm.agent_id`             | configured `agent_id`                             |
 | `nvm:verify`     | `nvm.payer`                | from `VerifyResponse.payer`                       |
 | `nvm:verify`     | `nvm.agent_request_id`     | from `VerifyResponse.agent_request_id`            |
+| `nvm:verify`     | `nvm.payment_token`        | first 16 chars + `…` + last 4 chars of the x402 access token |
 | `nvm:verify`     | `nvm.verify.duration_ms`   | measured                                          |
 | `nvm:settlement` | `nvm.credits_redeemed`     | from `SettleResponse.credits_redeemed`            |
 | `nvm:settlement` | `nvm.balance.after`        | from `SettleResponse.remaining_balance`           |
 | `nvm:settlement` | `nvm.tx_hash`              | from `SettleResponse.transaction`                 |
 | `nvm:settlement` | `nvm.network`              | from `SettleResponse.network`                     |
 | `nvm:settlement` | `nvm.payer`                | from `SettleResponse.payer`                       |
+| `nvm:settlement` | `nvm.payment_token`        | first 16 chars + `…` + last 4 chars of the x402 access token |
 | `nvm:settlement` | `nvm.settle.duration_ms`   | measured                                          |
+
+### Sensitive data in traces
+
+The `payment_token` that the buyer passes via `config["configurable"]["payment_token"]` is captured by LangChain as part of the run's configurable dict and **surfaced in full in the run's metadata in the LangSmith UI**. The token grants access to the protected tool until it expires — treat a LangSmith trace with the same trust level you'd treat a session log that contains the token.
+
+For correlation across spans the decorator attaches an abbreviated `nvm.payment_token` attribute (`eyJ4NDAyVmVyc2lv…bsig`) to both `nvm:verify` and `nvm:settlement`. That gives you "which token was this?" without exposing the full credential.
+
+If your LangSmith workspace has untrusted readers, redact the full token. Either:
+
+- Set `export LANGSMITH_HIDE_INPUTS=true` to globally suppress the configurable dict from every run's metadata (heavy hammer — affects every traced run, not just paid ones).
+- Or strip `payment_token` from the configurable dict after `agent.invoke()` returns / before logging the trace elsewhere.
+
+The abbreviated `nvm.payment_token` attribute remains visible in either case.
 
 ### Manual use (non-LangChain paths)
 

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -332,6 +332,7 @@ Other `nvm.*` attributes that may be considered sensitive depending on your cont
 - `nvm.payer` — the payer's wallet address (public on-chain, but a stable identifier).
 - `nvm.tx_hash` — the settlement transaction id.
 - `nvm.agent_request_id` — Nevermined-internal correlation id.
+- `nvm.balance.after` — the payer's remaining credit balance after this settlement. Reveals per-payer depletion patterns to anyone with trace read access on the operator's LangSmith project. Suppress with `LANGSMITH_HIDE_OUTPUTS=true` or post-filter.
 
 None of these grant access on their own.
 

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -257,6 +257,67 @@ receipt = last_settlement()
 
 For the full, runnable version see [`tutorials/langchain-paid-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-paid-agent-py).
 
+## Observability with LangSmith
+
+When the optional `[langsmith]` extra is installed and a LangSmith run is active in the calling context, `@requires_payment` automatically emits two child spans nested under the active tool span:
+
+- **`nvm:verify`** — opens around the verify-permissions call, with attributes describing the scheme, plan, payer, and verify duration.
+- **`nvm:settlement`** — opens around the settle-permissions call, with attributes describing credits redeemed, remaining balance, transaction hash, network, and settle duration.
+
+The same `nvm.*` metadata is also attached to the parent tool span so the trace is searchable from either level.
+
+### Install
+
+```bash
+pip install "payments-py[langchain,langsmith]"
+```
+
+### Enable
+
+```bash
+export LANGSMITH_TRACING=true
+export LANGSMITH_API_KEY=<your-langsmith-api-key>
+```
+
+No code changes are needed beyond the existing `@requires_payment` decorator — the spans are emitted automatically when LangSmith is active. If `langsmith` is not installed or `LANGSMITH_TRACING` is unset, span emission is a silent no-op.
+
+### Span attributes
+
+| Span             | Attribute                  | Source                                            |
+| ---------------- | -------------------------- | ------------------------------------------------- |
+| `nvm:verify`     | `nvm.plan_ids`             | configured `plan_id` / `plan_ids`                 |
+| `nvm:verify`     | `nvm.scheme`               | resolved scheme (`nvm:erc4337` or `nvm:card-delegation`) |
+| `nvm:verify`     | `nvm.network`              | CAIP-2 chain or provider name                     |
+| `nvm:verify`     | `nvm.agent_id`             | configured `agent_id`                             |
+| `nvm:verify`     | `nvm.payer`                | from `VerifyResponse.payer`                       |
+| `nvm:verify`     | `nvm.agent_request_id`     | from `VerifyResponse.agent_request_id`            |
+| `nvm:verify`     | `nvm.verify.duration_ms`   | measured                                          |
+| `nvm:settlement` | `nvm.credits_redeemed`     | from `SettleResponse.credits_redeemed`            |
+| `nvm:settlement` | `nvm.balance.after`        | from `SettleResponse.remaining_balance`           |
+| `nvm:settlement` | `nvm.tx_hash`              | from `SettleResponse.transaction`                 |
+| `nvm:settlement` | `nvm.network`              | from `SettleResponse.network`                     |
+| `nvm:settlement` | `nvm.payer`                | from `SettleResponse.payer`                       |
+| `nvm:settlement` | `nvm.settle.duration_ms`   | measured                                          |
+
+### Manual use (non-LangChain paths)
+
+The same context managers are also exported for code that wants to emit Nevermined-flavored spans without going through `@requires_payment` (e.g. the FastAPI middleware path):
+
+```python
+from payments_py.langsmith import (
+    settlement_span,
+    verify_span,
+    build_settle_metadata,
+)
+
+with settlement_span(plan_ids=["plan-1"]) as span:
+    settlement = payments.facilitator.settle_permissions(...)
+    if span is not None:
+        span.add_metadata(build_settle_metadata(settlement, ["plan-1"]))
+```
+
+Span emission failures are caught internally — observability is best-effort and will not interfere with the payment flow.
+
 ## Related
 
 - [LangChain integration guide](/docs/integrate/add-to-your-agent/langchain) — conceptual walk-through, the two integration approaches (decorator vs. HTTP middleware), and the TypeScript variant.

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -277,9 +277,27 @@ pip install "payments-py[langchain,langsmith]"
 ```bash
 export LANGSMITH_TRACING=true
 export LANGSMITH_API_KEY=<your-langsmith-api-key>
+export LANGSMITH_PROJECT=<your-project-name>  # optional
 ```
 
 No code changes are needed beyond the existing `@requires_payment` decorator — the spans are emitted automatically when LangSmith is active. If `langsmith` is not installed or `LANGSMITH_TRACING` is unset, span emission is a silent no-op.
+
+#### Regional endpoint
+
+LangSmith hosts accounts across several regions. The SDK defaults to GCP US (`https://api.smith.langchain.com`); accounts in any other region must set `LANGSMITH_ENDPOINT` or the trace POST will fail with `403 Forbidden` on `/runs/multipart`.
+
+| Region   | Endpoint                                      |
+| -------- | --------------------------------------------- |
+| GCP US   | `https://api.smith.langchain.com` *(default)* |
+| GCP EU   | `https://eu.api.smith.langchain.com`          |
+| GCP APAC | `https://apac.api.smith.langchain.com`        |
+| AWS US   | `https://aws.api.smith.langchain.com`         |
+
+```bash
+export LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com
+```
+
+The payment flow itself is unaffected by trace-shipping failures — verify, tool execution, and settle proceed normally. Only the LangSmith trace ingestion fails, surfaced as `langsmith.utils.LangSmithError` warnings.
 
 ### Span attributes
 

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -321,16 +321,19 @@ The payment flow itself is unaffected by trace-shipping failures — verify, too
 
 ### Sensitive data in traces
 
-The `payment_token` that the buyer passes via `config["configurable"]["payment_token"]` is captured by LangChain as part of the run's configurable dict and **surfaced in full in the run's metadata in the LangSmith UI**. The token grants access to the protected tool until it expires — treat a LangSmith trace with the same trust level you'd treat a session log that contains the token.
+The `payment_token` that the buyer passes via `config["configurable"]["payment_token"]` is captured by LangChain into the parent tool span's metadata, and would normally be inherited by any child span — including the `nvm:verify` and `nvm:settlement` spans the decorator emits. The full token grants access to the protected tool until it expires, so the decorator **proactively strips `payment_token` from the parent tool span's metadata** before opening any child span. The full credential never reaches a Nevermined span attribute.
 
-For correlation across spans the decorator attaches an abbreviated `nvm.payment_token` attribute (`eyJ4NDAyVmVyc2lv…bsig`) to both `nvm:verify` and `nvm:settlement`. That gives you "which token was this?" without exposing the full credential.
+For correlation across spans the decorator surfaces an abbreviated `nvm.payment_token` attribute (`eyJ4NDAyVmVyc2lv…bsig`, first 16 chars + ellipsis + last 4) on both `nvm:verify` and `nvm:settlement`. That gives you "which token was this?" without exposing the credential itself.
 
-If your LangSmith workspace has untrusted readers, redact the full token. Either:
+The active redaction covers the documented LangChain-via-configurable path. If you're surfacing the token through a different channel (custom callbacks, an explicit `add_metadata({"payment_token": ...})`, raw inputs to a tool whose signature contains the token), the decorator can't see those — strip them yourself or set `export LANGSMITH_HIDE_INPUTS=true` for blanket coverage.
 
-- Set `export LANGSMITH_HIDE_INPUTS=true` to globally suppress the configurable dict from every run's metadata (heavy hammer — affects every traced run, not just paid ones).
-- Or strip `payment_token` from the configurable dict after `agent.invoke()` returns / before logging the trace elsewhere.
+Other `nvm.*` attributes that may be considered sensitive depending on your context:
 
-The abbreviated `nvm.payment_token` attribute remains visible in either case.
+- `nvm.payer` — the payer's wallet address (public on-chain, but a stable identifier).
+- `nvm.tx_hash` — the settlement transaction id.
+- `nvm.agent_request_id` — Nevermined-internal correlation id.
+
+None of these grant access on their own.
 
 ### Manual use (non-LangChain paths)
 

--- a/docs/reference/langsmith.md
+++ b/docs/reference/langsmith.md
@@ -1,0 +1,26 @@
+# LangSmith Spans Reference
+
+Helpers for emitting Nevermined-flavored payment spans into a LangSmith trace.
+
+When the optional `[langsmith]` extra is installed and a LangSmith run is active in the current context (typically because `LANGSMITH_TRACING=true` is set and the call is inside a traced runnable), the `@requires_payment` decorator automatically uses these helpers to emit dedicated `nvm:verify` and `nvm:settlement` child spans nested under the active tool span.
+
+For non-LangChain code paths (e.g. the FastAPI middleware) the context managers can also be used directly — see the example in `verify_span` / `settlement_span`.
+
+All helpers in this module silently no-op when:
+
+- the `langsmith` package is not installed, or
+- no LangSmith run tree is active in the current context.
+
+Failures inside this module never propagate out — observability is best-effort and must not interfere with the payment flow.
+
+::: payments_py.langsmith.spans
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - verify_span
+        - settlement_span
+        - build_verify_metadata
+        - build_settle_metadata
+        - active_run_tree
+        - add_metadata

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,7 +90,9 @@ nav:
     - 09. MCP Integration: api/09-mcp-integration.md
     - 10. A2A Integration: api/10-a2a-integration.md
     - 11. x402 Protocol: api/11-x402.md
+    - 12. LangChain Integration: api/12-langchain-integration.md
   - Reference:
     - Payments Class: reference/payments.md
     - Data Models: reference/data_models.md
     - Environments: reference/environments.md
+    - LangSmith Spans: reference/langsmith.md

--- a/payments_py/langsmith/__init__.py
+++ b/payments_py/langsmith/__init__.py
@@ -31,6 +31,7 @@ from payments_py.langsmith.spans import (
     add_metadata,
     build_settle_metadata,
     build_verify_metadata,
+    redact_metadata_keys,
     settlement_span,
     verify_span,
 )
@@ -41,6 +42,7 @@ __all__ = [
     "add_metadata",
     "build_settle_metadata",
     "build_verify_metadata",
+    "redact_metadata_keys",
     "settlement_span",
     "verify_span",
 ]

--- a/payments_py/langsmith/__init__.py
+++ b/payments_py/langsmith/__init__.py
@@ -26,6 +26,7 @@ LangSmith traces::
 """
 
 from payments_py.langsmith.spans import (
+    abbreviate_token,
     active_run_tree,
     add_metadata,
     build_settle_metadata,
@@ -35,6 +36,7 @@ from payments_py.langsmith.spans import (
 )
 
 __all__ = [
+    "abbreviate_token",
     "active_run_tree",
     "add_metadata",
     "build_settle_metadata",

--- a/payments_py/langsmith/__init__.py
+++ b/payments_py/langsmith/__init__.py
@@ -1,0 +1,44 @@
+"""LangSmith observability bridge for Nevermined payments.
+
+When the optional ``[langsmith]`` extra is installed and a LangSmith run is
+active in the calling context (typically because ``LANGSMITH_TRACING=true``
+is set and the agent is invoked through a traced runnable), the
+``@requires_payment`` decorator automatically emits dedicated ``nvm:verify``
+and ``nvm:settlement`` child spans nested under the active tool span. Both
+spans carry diagnostic ``nvm.*`` metadata for audit and reconciliation, and
+the same metadata is also attached to the parent tool span so cmd-F searches
+in the LangSmith UI land on either span.
+
+This module is import-safe even without ``langsmith`` installed; all helpers
+become no-ops in that case. Failures in observability never propagate out
+into the payment flow.
+
+Manual use is supported for non-LangChain code paths (e.g. the FastAPI
+middleware) that still want to surface Nevermined-flavored spans into
+LangSmith traces::
+
+    from payments_py.langsmith import settlement_span, build_settle_metadata
+
+    with settlement_span(plan_ids=["plan-1"]) as span:
+        settlement = payments.facilitator.settle_permissions(...)
+        if span is not None:
+            span.add_metadata(build_settle_metadata(settlement, ["plan-1"]))
+"""
+
+from payments_py.langsmith.spans import (
+    active_run_tree,
+    add_metadata,
+    build_settle_metadata,
+    build_verify_metadata,
+    settlement_span,
+    verify_span,
+)
+
+__all__ = [
+    "active_run_tree",
+    "add_metadata",
+    "build_settle_metadata",
+    "build_verify_metadata",
+    "settlement_span",
+    "verify_span",
+]

--- a/payments_py/langsmith/spans.py
+++ b/payments_py/langsmith/spans.py
@@ -57,6 +57,34 @@ def add_metadata(run_tree: Optional[Any], metadata: dict) -> None:
         logger.debug("LangSmith add_metadata failed (ignored)", exc_info=True)
 
 
+def redact_metadata_keys(run_tree: Optional[Any], *keys: str) -> None:
+    """Remove ``keys`` from ``run_tree``'s metadata in place.
+
+    LangSmith inherits a parent run's metadata to child runs created via
+    ``ls.trace(...)``, so call this on the parent run BEFORE opening any
+    child spans whose metadata should not carry the keys. The most common
+    use is stripping ``payment_token`` from the parent tool span's
+    metadata, since LangChain auto-captures every entry in
+    ``config["configurable"]`` and the access token grants access to the
+    protected tool until it expires.
+
+    No-op when ``run_tree`` is ``None`` or no keys are provided. All
+    errors are swallowed -- observability hygiene must never disrupt the
+    payment flow.
+    """
+    if run_tree is None or not keys:
+        return
+    try:
+        extra = getattr(run_tree, "extra", None)
+        if isinstance(extra, dict):
+            metadata = extra.get("metadata")
+            if isinstance(metadata, dict):
+                for key in keys:
+                    metadata.pop(key, None)
+    except Exception:
+        logger.debug("LangSmith redact_metadata_keys failed (ignored)", exc_info=True)
+
+
 def abbreviate_token(token: Optional[str]) -> Optional[str]:
     """Return a short ``<first 16>…<last 4>`` form of a payment token.
 

--- a/payments_py/langsmith/spans.py
+++ b/payments_py/langsmith/spans.py
@@ -174,6 +174,38 @@ def build_settle_metadata(
 
 
 @contextmanager
+def _open_nvm_span(name: str, inputs: dict) -> Iterator[Optional[Any]]:
+    """Shared implementation behind :func:`verify_span` / :func:`settlement_span`.
+
+    Yields the underlying LangSmith ``RunTree`` if a parent run is active and
+    ``_ls.trace`` setup succeeds; yields ``None`` otherwise. The ``ExitStack``
+    is load-bearing: it swallows setup errors via the try/except below while
+    letting body exceptions propagate cleanly through the ``@contextmanager``
+    protocol (a previous broad try/except here surfaced as
+    ``"generator didn't stop after throw()"`` -- see the regression tests in
+    ``tests/unit/langsmith/test_spans.py``).
+    """
+    if active_run_tree() is None:
+        yield None
+        return
+
+    with ExitStack() as stack:
+        try:
+            span = stack.enter_context(
+                _ls.trace(  # type: ignore[union-attr]
+                    name=name,
+                    run_type="tool",
+                    inputs=inputs,
+                )
+            )
+        except Exception:
+            logger.debug("LangSmith %s setup failed (ignored)", name, exc_info=True)
+            yield None
+            return
+        yield span
+
+
+@contextmanager
 def verify_span(
     plan_ids: list[str],
     scheme: Optional[str] = None,
@@ -200,10 +232,6 @@ def verify_span(
                 plan_ids=["plan-1"], verification=verification,
             ))
     """
-    if active_run_tree() is None:
-        yield None
-        return
-
     inputs: dict = {"plan_ids": list(plan_ids)}
     if scheme:
         inputs["scheme"] = scheme
@@ -212,19 +240,7 @@ def verify_span(
     if agent_id:
         inputs["agent_id"] = agent_id
 
-    with ExitStack() as stack:
-        try:
-            span = stack.enter_context(
-                _ls.trace(  # type: ignore[union-attr]
-                    name="nvm:verify",
-                    run_type="tool",
-                    inputs=inputs,
-                )
-            )
-        except Exception:
-            logger.debug("LangSmith verify_span setup failed (ignored)", exc_info=True)
-            yield None
-            return
+    with _open_nvm_span("nvm:verify", inputs) as span:
         yield span
 
 
@@ -237,27 +253,9 @@ def settlement_span(
 
     Same semantics as :func:`verify_span`.
     """
-    if active_run_tree() is None:
-        yield None
-        return
-
     inputs: dict = {"plan_ids": list(plan_ids)}
     if agent_id:
         inputs["agent_id"] = agent_id
 
-    with ExitStack() as stack:
-        try:
-            span = stack.enter_context(
-                _ls.trace(  # type: ignore[union-attr]
-                    name="nvm:settlement",
-                    run_type="tool",
-                    inputs=inputs,
-                )
-            )
-        except Exception:
-            logger.debug(
-                "LangSmith settlement_span setup failed (ignored)", exc_info=True
-            )
-            yield None
-            return
+    with _open_nvm_span("nvm:settlement", inputs) as span:
         yield span

--- a/payments_py/langsmith/spans.py
+++ b/payments_py/langsmith/spans.py
@@ -57,6 +57,24 @@ def add_metadata(run_tree: Optional[Any], metadata: dict) -> None:
         logger.debug("LangSmith add_metadata failed (ignored)", exc_info=True)
 
 
+def abbreviate_token(token: Optional[str]) -> Optional[str]:
+    """Return a short ``<first 16>…<last 4>`` form of a payment token.
+
+    Used to attach an identifiable but non-functional reference to the
+    x402 access token in span metadata. Long enough for humans to spot
+    which token was used; short enough not to leak the credential.
+
+    Returns ``None`` if ``token`` is ``None`` or empty. Returns the token
+    unchanged when it is already 20 characters or fewer (no benefit to
+    abbreviating).
+    """
+    if not token:
+        return None
+    if len(token) <= 20:
+        return token
+    return f"{token[:16]}…{token[-4:]}"
+
+
 def build_verify_metadata(
     plan_ids: list[str],
     scheme: Optional[str] = None,
@@ -64,8 +82,14 @@ def build_verify_metadata(
     agent_id: Optional[str] = None,
     verification: Optional[VerifyResponse] = None,
     duration_ms: Optional[float] = None,
+    token: Optional[str] = None,
 ) -> dict:
-    """Build the ``nvm.*`` metadata dict for a verify span. Drops ``None`` values."""
+    """Build the ``nvm.*`` metadata dict for a verify span. Drops ``None`` values.
+
+    ``token`` is abbreviated via :func:`abbreviate_token` before being
+    surfaced as ``nvm.payment_token`` so the full credential never ends
+    up in metadata that we control.
+    """
     md: dict = {"nvm.plan_ids": list(plan_ids)}
     if scheme:
         md["nvm.scheme"] = scheme
@@ -75,6 +99,9 @@ def build_verify_metadata(
         md["nvm.agent_id"] = agent_id
     if duration_ms is not None:
         md["nvm.verify.duration_ms"] = round(duration_ms, 2)
+    abbreviated = abbreviate_token(token)
+    if abbreviated:
+        md["nvm.payment_token"] = abbreviated
     if verification is not None:
         if verification.payer:
             md["nvm.payer"] = verification.payer
@@ -90,13 +117,21 @@ def build_settle_metadata(
     plan_ids: list[str],
     agent_id: Optional[str] = None,
     duration_ms: Optional[float] = None,
+    token: Optional[str] = None,
 ) -> dict:
-    """Build the ``nvm.*`` metadata dict for a settlement span. Drops ``None`` values."""
+    """Build the ``nvm.*`` metadata dict for a settlement span. Drops ``None`` values.
+
+    ``token`` is abbreviated via :func:`abbreviate_token` before being
+    surfaced as ``nvm.payment_token``.
+    """
     md: dict = {"nvm.plan_ids": list(plan_ids)}
     if agent_id:
         md["nvm.agent_id"] = agent_id
     if duration_ms is not None:
         md["nvm.settle.duration_ms"] = round(duration_ms, 2)
+    abbreviated = abbreviate_token(token)
+    if abbreviated:
+        md["nvm.payment_token"] = abbreviated
     if settlement.credits_redeemed is not None:
         md["nvm.credits_redeemed"] = settlement.credits_redeemed
     if settlement.remaining_balance is not None:

--- a/payments_py/langsmith/spans.py
+++ b/payments_py/langsmith/spans.py
@@ -1,0 +1,183 @@
+"""LangSmith span helpers for Nevermined payment events.
+
+All helpers in this module silently no-op when:
+  - the ``langsmith`` package is not installed; or
+  - no LangSmith run tree is active in the current context
+    (e.g. ``LANGSMITH_TRACING`` is unset, or the call is not inside a traced
+    runnable).
+
+Failures inside this module never propagate out -- observability is
+best-effort and must not interfere with the payment flow.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+from payments_py.x402.types import SettleResponse, VerifyResponse
+
+logger = logging.getLogger(__name__)
+
+try:
+    import langsmith as _ls
+    from langsmith.run_helpers import get_current_run_tree as _get_current_run_tree
+
+    _LANGSMITH_AVAILABLE = True
+except ImportError:
+    _ls = None  # type: ignore[assignment]
+    _get_current_run_tree = None  # type: ignore[assignment]
+    _LANGSMITH_AVAILABLE = False
+
+
+def active_run_tree() -> Optional[Any]:
+    """Return the current LangSmith ``RunTree``, or ``None`` if no run is active.
+
+    Safe to call regardless of whether ``langsmith`` is installed.
+    """
+    if not _LANGSMITH_AVAILABLE:
+        return None
+    try:
+        return _get_current_run_tree()
+    except Exception:
+        return None
+
+
+def add_metadata(run_tree: Optional[Any], metadata: dict) -> None:
+    """Attach ``metadata`` to ``run_tree``, swallowing any error.
+
+    No-op if ``run_tree`` is ``None`` or ``metadata`` is empty.
+    """
+    if run_tree is None or not metadata:
+        return
+    try:
+        run_tree.add_metadata(metadata)
+    except Exception:
+        logger.debug("LangSmith add_metadata failed (ignored)", exc_info=True)
+
+
+def build_verify_metadata(
+    plan_ids: list[str],
+    scheme: Optional[str] = None,
+    network: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    verification: Optional[VerifyResponse] = None,
+    duration_ms: Optional[float] = None,
+) -> dict:
+    """Build the ``nvm.*`` metadata dict for a verify span. Drops ``None`` values."""
+    md: dict = {"nvm.plan_ids": list(plan_ids)}
+    if scheme:
+        md["nvm.scheme"] = scheme
+    if network:
+        md["nvm.network"] = network
+    if agent_id:
+        md["nvm.agent_id"] = agent_id
+    if duration_ms is not None:
+        md["nvm.verify.duration_ms"] = round(duration_ms, 2)
+    if verification is not None:
+        if verification.payer:
+            md["nvm.payer"] = verification.payer
+        if verification.network and "nvm.network" not in md:
+            md["nvm.network"] = verification.network
+        if verification.agent_request_id:
+            md["nvm.agent_request_id"] = verification.agent_request_id
+    return md
+
+
+def build_settle_metadata(
+    settlement: SettleResponse,
+    plan_ids: list[str],
+    agent_id: Optional[str] = None,
+    duration_ms: Optional[float] = None,
+) -> dict:
+    """Build the ``nvm.*`` metadata dict for a settlement span. Drops ``None`` values."""
+    md: dict = {"nvm.plan_ids": list(plan_ids)}
+    if agent_id:
+        md["nvm.agent_id"] = agent_id
+    if duration_ms is not None:
+        md["nvm.settle.duration_ms"] = round(duration_ms, 2)
+    if settlement.credits_redeemed is not None:
+        md["nvm.credits_redeemed"] = settlement.credits_redeemed
+    if settlement.remaining_balance is not None:
+        md["nvm.balance.after"] = settlement.remaining_balance
+    if settlement.transaction:
+        md["nvm.tx_hash"] = settlement.transaction
+    if settlement.network:
+        md["nvm.network"] = settlement.network
+    if settlement.payer:
+        md["nvm.payer"] = settlement.payer
+    return md
+
+
+@contextmanager
+def verify_span(
+    plan_ids: list[str],
+    scheme: Optional[str] = None,
+    network: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> Iterator[Optional[Any]]:
+    """Open an ``nvm:verify`` child span around a verify call.
+
+    Yields the underlying ``RunTree`` if LangSmith is active and a parent
+    run is in scope; yields ``None`` otherwise. Always safe to call.
+
+    Example::
+
+        with verify_span(plan_ids=["plan-1"]) as span:
+            verification = payments.facilitator.verify_permissions(...)
+            add_metadata(span, build_verify_metadata(
+                plan_ids=["plan-1"], verification=verification,
+            ))
+    """
+    if active_run_tree() is None:
+        yield None
+        return
+
+    inputs: dict = {"plan_ids": list(plan_ids)}
+    if scheme:
+        inputs["scheme"] = scheme
+    if network:
+        inputs["network"] = network
+    if agent_id:
+        inputs["agent_id"] = agent_id
+
+    try:
+        with _ls.trace(  # type: ignore[union-attr]
+            name="nvm:verify",
+            run_type="tool",
+            inputs=inputs,
+        ) as span:
+            yield span
+    except Exception:
+        logger.debug("LangSmith verify_span failed (ignored)", exc_info=True)
+        yield None
+
+
+@contextmanager
+def settlement_span(
+    plan_ids: list[str],
+    agent_id: Optional[str] = None,
+) -> Iterator[Optional[Any]]:
+    """Open an ``nvm:settlement`` child span around a settle call.
+
+    Same semantics as :func:`verify_span`.
+    """
+    if active_run_tree() is None:
+        yield None
+        return
+
+    inputs: dict = {"plan_ids": list(plan_ids)}
+    if agent_id:
+        inputs["agent_id"] = agent_id
+
+    try:
+        with _ls.trace(  # type: ignore[union-attr]
+            name="nvm:settlement",
+            run_type="tool",
+            inputs=inputs,
+        ) as span:
+            yield span
+    except Exception:
+        logger.debug("LangSmith settlement_span failed (ignored)", exc_info=True)
+        yield None

--- a/payments_py/langsmith/spans.py
+++ b/payments_py/langsmith/spans.py
@@ -13,7 +13,7 @@ best-effort and must not interfere with the payment flow.
 from __future__ import annotations
 
 import logging
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from typing import Any, Iterator, Optional
 
 from payments_py.x402.types import SettleResponse, VerifyResponse
@@ -122,6 +122,13 @@ def verify_span(
     Yields the underlying ``RunTree`` if LangSmith is active and a parent
     run is in scope; yields ``None`` otherwise. Always safe to call.
 
+    Exceptions raised by the caller's body propagate out unchanged -- the
+    underlying ``langsmith.trace`` context manager sees them via its
+    ``__exit__`` and records the span as failed before re-raising. Only
+    errors raised inside the trace SETUP (constructing or entering the
+    LangSmith context) are swallowed, since those are pure observability
+    concerns and must never interfere with the payment flow.
+
     Example::
 
         with verify_span(plan_ids=["plan-1"]) as span:
@@ -142,16 +149,20 @@ def verify_span(
     if agent_id:
         inputs["agent_id"] = agent_id
 
-    try:
-        with _ls.trace(  # type: ignore[union-attr]
-            name="nvm:verify",
-            run_type="tool",
-            inputs=inputs,
-        ) as span:
-            yield span
-    except Exception:
-        logger.debug("LangSmith verify_span failed (ignored)", exc_info=True)
-        yield None
+    with ExitStack() as stack:
+        try:
+            span = stack.enter_context(
+                _ls.trace(  # type: ignore[union-attr]
+                    name="nvm:verify",
+                    run_type="tool",
+                    inputs=inputs,
+                )
+            )
+        except Exception:
+            logger.debug("LangSmith verify_span setup failed (ignored)", exc_info=True)
+            yield None
+            return
+        yield span
 
 
 @contextmanager
@@ -171,13 +182,19 @@ def settlement_span(
     if agent_id:
         inputs["agent_id"] = agent_id
 
-    try:
-        with _ls.trace(  # type: ignore[union-attr]
-            name="nvm:settlement",
-            run_type="tool",
-            inputs=inputs,
-        ) as span:
-            yield span
-    except Exception:
-        logger.debug("LangSmith settlement_span failed (ignored)", exc_info=True)
-        yield None
+    with ExitStack() as stack:
+        try:
+            span = stack.enter_context(
+                _ls.trace(  # type: ignore[union-attr]
+                    name="nvm:settlement",
+                    run_type="tool",
+                    inputs=inputs,
+                )
+            )
+        except Exception:
+            logger.debug(
+                "LangSmith settlement_span setup failed (ignored)", exc_info=True
+            )
+            yield None
+            return
+        yield span

--- a/payments_py/x402/langchain/decorator.py
+++ b/payments_py/x402/langchain/decorator.py
@@ -207,6 +207,31 @@ def _store_in_configurable(config: Any, key: str, value: Any) -> None:
         configurable[key] = value
 
 
+def _attach_metadata_safely(
+    span: Any,
+    parent_rt: Any,
+    builder: Callable[..., dict],
+    label: str,
+    **builder_kwargs: Any,
+) -> None:
+    """Build metadata via ``builder`` and attach it to ``span`` + ``parent_rt``.
+
+    Wraps the build+attach sequence in a single try/except so observability
+    failures (a builder bug, an ``add_metadata`` exception) are logged at
+    debug and swallowed -- they must never block the payment flow or mask
+    a downstream ``PaymentRequiredError``. ``label`` only affects the log
+    message ("LangSmith <label> metadata attach failed (ignored)").
+    """
+    try:
+        md = builder(**builder_kwargs)
+        add_metadata(span, md)
+        add_metadata(parent_rt, md)
+    except Exception:
+        logger.debug(
+            "LangSmith %s metadata attach failed (ignored)", label, exc_info=True
+        )
+
+
 def _verify_payment(
     func: Callable,
     kwargs: dict,
@@ -250,20 +275,16 @@ def _verify_payment(
     ) as vspan:
         # Pre-verify metadata is best-effort -- a build/attach failure here
         # must not block the actual verify call or mask PaymentRequiredError.
-        try:
-            pre_verify_md = build_verify_metadata(
-                plan_ids=config.plan_ids,
-                scheme=resolved_scheme,
-                network=config.network,
-                agent_id=config.agent_id,
-            )
-            add_metadata(vspan, pre_verify_md)
-            add_metadata(parent_rt, pre_verify_md)
-        except Exception:
-            logger.debug(
-                "LangSmith pre-verify metadata attach failed (ignored)",
-                exc_info=True,
-            )
+        _attach_metadata_safely(
+            vspan,
+            parent_rt,
+            build_verify_metadata,
+            "pre-verify",
+            plan_ids=config.plan_ids,
+            scheme=resolved_scheme,
+            network=config.network,
+            agent_id=config.agent_id,
+        )
 
         token = _extract_payment_token(runnable_config)
         if not token:
@@ -285,22 +306,19 @@ def _verify_payment(
         # Augment metadata with verification results. Same best-effort
         # guarantee -- observability must not mask the PaymentRequiredError
         # that follows if the verification is invalid.
-        try:
-            verify_md = build_verify_metadata(
-                plan_ids=config.plan_ids,
-                scheme=resolved_scheme,
-                network=config.network,
-                agent_id=config.agent_id,
-                verification=verification,
-                duration_ms=(time.monotonic() - verify_started) * 1000,
-                token=token,
-            )
-            add_metadata(vspan, verify_md)
-            add_metadata(parent_rt, verify_md)
-        except Exception:
-            logger.debug(
-                "LangSmith verify metadata attach failed (ignored)", exc_info=True
-            )
+        _attach_metadata_safely(
+            vspan,
+            parent_rt,
+            build_verify_metadata,
+            "verify",
+            plan_ids=config.plan_ids,
+            scheme=resolved_scheme,
+            network=config.network,
+            agent_id=config.agent_id,
+            verification=verification,
+            duration_ms=(time.monotonic() - verify_started) * 1000,
+            token=token,
+        )
 
         if not verification.is_valid:
             reason = verification.invalid_reason or "Payment verification failed"
@@ -366,21 +384,17 @@ def _settle_payment(
             _store_in_configurable(runnable_config, "payment_settlement", settlement)
             _LAST_SETTLEMENT["value"] = settlement
 
-            try:
-                settle_md = build_settle_metadata(
-                    settlement=settlement,
-                    plan_ids=plan_ids,
-                    agent_id=verified.agent_id,
-                    duration_ms=(time.monotonic() - settle_started) * 1000,
-                    token=verified.token,
-                )
-                add_metadata(sspan, settle_md)
-                add_metadata(parent_rt, settle_md)
-            except Exception:
-                logger.debug(
-                    "LangSmith settle metadata attach failed (ignored)",
-                    exc_info=True,
-                )
+            _attach_metadata_safely(
+                sspan,
+                parent_rt,
+                build_settle_metadata,
+                "settle",
+                settlement=settlement,
+                plan_ids=plan_ids,
+                agent_id=verified.agent_id,
+                duration_ms=(time.monotonic() - settle_started) * 1000,
+                token=verified.token,
+            )
 
     except Exception as settle_error:
         logger.warning("Payment settlement failed: %s", settle_error)

--- a/payments_py/x402/langchain/decorator.py
+++ b/payments_py/x402/langchain/decorator.py
@@ -63,9 +63,18 @@ Client-side flow::
 import functools
 import inspect
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
+from payments_py.langsmith.spans import (
+    active_run_tree,
+    add_metadata,
+    build_settle_metadata,
+    build_verify_metadata,
+    settlement_span,
+    verify_span,
+)
 from payments_py.x402.helpers import build_payment_required_for_plans
 from payments_py.x402.resolve_scheme import resolve_scheme
 from payments_py.x402.types import (
@@ -145,6 +154,7 @@ class _VerifiedPayment:
     payment_required: X402PaymentRequired
     credits_to_charge: int
     payment_context: PaymentContext
+    agent_id: Optional[str] = None
 
 
 def _resolve_credits_pre(
@@ -227,18 +237,36 @@ def _verify_payment(
     # For verification, use pre-resolved credits or default to 1
     credits_to_charge = credits_pre if credits_pre is not None else 1
 
-    verification = config.payments.facilitator.verify_permissions(
-        payment_required=payment_required,
-        x402_access_token=token,
-        max_amount=str(credits_to_charge),
-    )
-
-    if not verification.is_valid:
-        reason = verification.invalid_reason or "Payment verification failed"
-        raise PaymentRequiredError(
-            f"Payment verification failed: {reason}",
-            payment_required,
+    parent_rt = active_run_tree()
+    verify_started = time.monotonic()
+    with verify_span(
+        plan_ids=config.plan_ids,
+        scheme=resolved_scheme,
+        network=config.network,
+        agent_id=config.agent_id,
+    ) as vspan:
+        verification = config.payments.facilitator.verify_permissions(
+            payment_required=payment_required,
+            x402_access_token=token,
+            max_amount=str(credits_to_charge),
         )
+        verify_md = build_verify_metadata(
+            plan_ids=config.plan_ids,
+            scheme=resolved_scheme,
+            network=config.network,
+            agent_id=config.agent_id,
+            verification=verification,
+            duration_ms=(time.monotonic() - verify_started) * 1000,
+        )
+        add_metadata(vspan, verify_md)
+        add_metadata(parent_rt, verify_md)
+
+        if not verification.is_valid:
+            reason = verification.invalid_reason or "Payment verification failed"
+            raise PaymentRequiredError(
+                f"Payment verification failed: {reason}",
+                payment_required,
+            )
 
     payment_context = PaymentContext(
         token=token,
@@ -255,6 +283,7 @@ def _verify_payment(
         payment_required=payment_required,
         credits_to_charge=credits_to_charge,
         payment_context=payment_context,
+        agent_id=config.agent_id,
     )
 
 
@@ -273,16 +302,33 @@ def _settle_payment(
     """
     final_credits = _resolve_credits_post(credits_cfg, kwargs, result)
 
-    try:
-        settlement = payments.facilitator.settle_permissions(
-            payment_required=verified.payment_required,
-            x402_access_token=verified.token,
-            max_amount=str(final_credits),
-            agent_request_id=verified.payment_context.agent_request_id,
-        )
+    plan_ids = [a.plan_id for a in verified.payment_required.accepts if a.plan_id]
 
-        _store_in_configurable(runnable_config, "payment_settlement", settlement)
-        _LAST_SETTLEMENT["value"] = settlement
+    parent_rt = active_run_tree()
+    settle_started = time.monotonic()
+    try:
+        with settlement_span(
+            plan_ids=plan_ids,
+            agent_id=verified.agent_id,
+        ) as sspan:
+            settlement = payments.facilitator.settle_permissions(
+                payment_required=verified.payment_required,
+                x402_access_token=verified.token,
+                max_amount=str(final_credits),
+                agent_request_id=verified.payment_context.agent_request_id,
+            )
+
+            settle_md = build_settle_metadata(
+                settlement=settlement,
+                plan_ids=plan_ids,
+                agent_id=verified.agent_id,
+                duration_ms=(time.monotonic() - settle_started) * 1000,
+            )
+            add_metadata(sspan, settle_md)
+            add_metadata(parent_rt, settle_md)
+
+            _store_in_configurable(runnable_config, "payment_settlement", settlement)
+            _LAST_SETTLEMENT["value"] = settlement
 
     except Exception as settle_error:
         logger.warning("Payment settlement failed: %s", settle_error)

--- a/payments_py/x402/langchain/decorator.py
+++ b/payments_py/x402/langchain/decorator.py
@@ -72,6 +72,7 @@ from payments_py.langsmith.spans import (
     add_metadata,
     build_settle_metadata,
     build_verify_metadata,
+    redact_metadata_keys,
     settlement_span,
     verify_span,
 )
@@ -227,6 +228,13 @@ def _verify_payment(
     )
 
     parent_rt = active_run_tree()
+    # LangChain auto-captures every key in config["configurable"] into the
+    # parent tool span's metadata, and child spans we create inherit that
+    # metadata at construction time. Strip the full x402 access token from
+    # the parent BEFORE opening verify_span so neither the parent nor the
+    # child carries the raw credential. The abbreviated nvm.payment_token
+    # remains available for correlation.
+    redact_metadata_keys(parent_rt, "payment_token")
     verify_started = time.monotonic()
     # Open the verify span BEFORE the token-presence check so failed probes
     # (no payment_token in config) still produce a clearly-named span and
@@ -240,14 +248,22 @@ def _verify_payment(
         network=config.network,
         agent_id=config.agent_id,
     ) as vspan:
-        pre_verify_md = build_verify_metadata(
-            plan_ids=config.plan_ids,
-            scheme=resolved_scheme,
-            network=config.network,
-            agent_id=config.agent_id,
-        )
-        add_metadata(vspan, pre_verify_md)
-        add_metadata(parent_rt, pre_verify_md)
+        # Pre-verify metadata is best-effort -- a build/attach failure here
+        # must not block the actual verify call or mask PaymentRequiredError.
+        try:
+            pre_verify_md = build_verify_metadata(
+                plan_ids=config.plan_ids,
+                scheme=resolved_scheme,
+                network=config.network,
+                agent_id=config.agent_id,
+            )
+            add_metadata(vspan, pre_verify_md)
+            add_metadata(parent_rt, pre_verify_md)
+        except Exception:
+            logger.debug(
+                "LangSmith pre-verify metadata attach failed (ignored)",
+                exc_info=True,
+            )
 
         token = _extract_payment_token(runnable_config)
         if not token:
@@ -265,17 +281,26 @@ def _verify_payment(
             x402_access_token=token,
             max_amount=str(credits_to_charge),
         )
-        verify_md = build_verify_metadata(
-            plan_ids=config.plan_ids,
-            scheme=resolved_scheme,
-            network=config.network,
-            agent_id=config.agent_id,
-            verification=verification,
-            duration_ms=(time.monotonic() - verify_started) * 1000,
-            token=token,
-        )
-        add_metadata(vspan, verify_md)
-        add_metadata(parent_rt, verify_md)
+
+        # Augment metadata with verification results. Same best-effort
+        # guarantee -- observability must not mask the PaymentRequiredError
+        # that follows if the verification is invalid.
+        try:
+            verify_md = build_verify_metadata(
+                plan_ids=config.plan_ids,
+                scheme=resolved_scheme,
+                network=config.network,
+                agent_id=config.agent_id,
+                verification=verification,
+                duration_ms=(time.monotonic() - verify_started) * 1000,
+                token=token,
+            )
+            add_metadata(vspan, verify_md)
+            add_metadata(parent_rt, verify_md)
+        except Exception:
+            logger.debug(
+                "LangSmith verify metadata attach failed (ignored)", exc_info=True
+            )
 
         if not verification.is_valid:
             reason = verification.invalid_reason or "Payment verification failed"
@@ -334,18 +359,28 @@ def _settle_payment(
                 agent_request_id=verified.payment_context.agent_request_id,
             )
 
-            settle_md = build_settle_metadata(
-                settlement=settlement,
-                plan_ids=plan_ids,
-                agent_id=verified.agent_id,
-                duration_ms=(time.monotonic() - settle_started) * 1000,
-                token=verified.token,
-            )
-            add_metadata(sspan, settle_md)
-            add_metadata(parent_rt, settle_md)
-
+            # Persist the receipt BEFORE building metadata -- the on-chain
+            # settle already happened, so a metadata-build failure must not
+            # strand local state (`last_settlement()` would return stale or
+            # `None`, and configurable["payment_settlement"] would be missing).
             _store_in_configurable(runnable_config, "payment_settlement", settlement)
             _LAST_SETTLEMENT["value"] = settlement
+
+            try:
+                settle_md = build_settle_metadata(
+                    settlement=settlement,
+                    plan_ids=plan_ids,
+                    agent_id=verified.agent_id,
+                    duration_ms=(time.monotonic() - settle_started) * 1000,
+                    token=verified.token,
+                )
+                add_metadata(sspan, settle_md)
+                add_metadata(parent_rt, settle_md)
+            except Exception:
+                logger.debug(
+                    "LangSmith settle metadata attach failed (ignored)",
+                    exc_info=True,
+                )
 
     except Exception as settle_error:
         logger.warning("Payment settlement failed: %s", settle_error)

--- a/payments_py/x402/langchain/decorator.py
+++ b/payments_py/x402/langchain/decorator.py
@@ -68,6 +68,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
 from payments_py.langsmith.spans import (
+    abbreviate_token,
     active_run_tree,
     add_metadata,
     build_settle_metadata,
@@ -155,7 +156,6 @@ class _VerifiedPayment:
     payment_required: X402PaymentRequired
     credits_to_charge: int
     payment_context: PaymentContext
-    agent_id: Optional[str] = None
 
 
 def _resolve_credits_pre(
@@ -221,15 +221,23 @@ def _attach_metadata_safely(
     debug and swallowed -- they must never block the payment flow or mask
     a downstream ``PaymentRequiredError``. ``label`` only affects the log
     message ("LangSmith <label> metadata attach failed (ignored)").
+
+    Pre-abbreviates any ``token`` kwarg before calling ``builder`` so the
+    raw x402 access token never reaches the frame locals visible to
+    exception enrichers (Sentry's ``logging`` integration, structlog's
+    ``ExceptionRenderer``, etc.). ``exc_info`` is deliberately omitted
+    from the log call for the same reason -- the failure label alone is
+    enough to diagnose observability bugs without dumping locals to a
+    second SaaS destination.
     """
+    if "token" in builder_kwargs:
+        builder_kwargs["token"] = abbreviate_token(builder_kwargs["token"])
     try:
         md = builder(**builder_kwargs)
         add_metadata(span, md)
         add_metadata(parent_rt, md)
     except Exception:
-        logger.debug(
-            "LangSmith %s metadata attach failed (ignored)", label, exc_info=True
-        )
+        logger.debug("LangSmith %s metadata attach failed (ignored)", label)
 
 
 def _verify_payment(
@@ -342,7 +350,6 @@ def _verify_payment(
         payment_required=payment_required,
         credits_to_charge=credits_to_charge,
         payment_context=payment_context,
-        agent_id=config.agent_id,
     )
 
 
@@ -350,8 +357,7 @@ def _settle_payment(
     verified: _VerifiedPayment,
     result: Any,
     kwargs: dict,
-    payments: Any,
-    credits_cfg: Union[int, CreditsCallable],
+    config: _PaymentConfig,
     runnable_config: Any,
 ) -> None:
     """Settle credits after successful tool execution.
@@ -359,7 +365,7 @@ def _settle_payment(
     Resolves dynamic credits post-execution (if callable) and stores
     the settlement response in ``config["configurable"]["payment_settlement"]``.
     """
-    final_credits = _resolve_credits_post(credits_cfg, kwargs, result)
+    final_credits = _resolve_credits_post(config.credits, kwargs, result)
 
     plan_ids = [a.plan_id for a in verified.payment_required.accepts if a.plan_id]
 
@@ -368,9 +374,9 @@ def _settle_payment(
     try:
         with settlement_span(
             plan_ids=plan_ids,
-            agent_id=verified.agent_id,
+            agent_id=config.agent_id,
         ) as sspan:
-            settlement = payments.facilitator.settle_permissions(
+            settlement = config.payments.facilitator.settle_permissions(
                 payment_required=verified.payment_required,
                 x402_access_token=verified.token,
                 max_amount=str(final_credits),
@@ -391,7 +397,7 @@ def _settle_payment(
                 "settle",
                 settlement=settlement,
                 plan_ids=plan_ids,
-                agent_id=verified.agent_id,
+                agent_id=config.agent_id,
                 duration_ms=(time.monotonic() - settle_started) * 1000,
                 token=verified.token,
             )
@@ -537,14 +543,7 @@ def _execute_with_payment(
     runnable_config = _extract_runnable_config(kwargs)
     verified = _verify_payment(func, kwargs, config, runnable_config)
     result = func(*args, **kwargs)
-    _settle_payment(
-        verified,
-        result,
-        kwargs,
-        config.payments,
-        config.credits,
-        runnable_config,
-    )
+    _settle_payment(verified, result, kwargs, config, runnable_config)
     return result
 
 
@@ -558,12 +557,5 @@ async def _execute_with_payment_async(
     runnable_config = _extract_runnable_config(kwargs)
     verified = _verify_payment(func, kwargs, config, runnable_config)
     result = await func(*args, **kwargs)
-    _settle_payment(
-        verified,
-        result,
-        kwargs,
-        config.payments,
-        config.credits,
-        runnable_config,
-    )
+    _settle_payment(verified, result, kwargs, config, runnable_config)
     return result

--- a/payments_py/x402/langchain/decorator.py
+++ b/payments_py/x402/langchain/decorator.py
@@ -272,6 +272,7 @@ def _verify_payment(
             agent_id=config.agent_id,
             verification=verification,
             duration_ms=(time.monotonic() - verify_started) * 1000,
+            token=token,
         )
         add_metadata(vspan, verify_md)
         add_metadata(parent_rt, verify_md)
@@ -338,6 +339,7 @@ def _settle_payment(
                 plan_ids=plan_ids,
                 agent_id=verified.agent_id,
                 duration_ms=(time.monotonic() - settle_started) * 1000,
+                token=verified.token,
             )
             add_metadata(sspan, settle_md)
             add_metadata(parent_rt, settle_md)

--- a/payments_py/x402/langchain/decorator.py
+++ b/payments_py/x402/langchain/decorator.py
@@ -226,25 +226,40 @@ def _verify_payment(
         scheme=resolved_scheme,
     )
 
-    token = _extract_payment_token(runnable_config)
-    if not token:
-        raise PaymentRequiredError(
-            "Payment required: missing payment_token in config['configurable']",
-            payment_required,
-        )
-
-    credits_pre = _resolve_credits_pre(config.credits, kwargs)
-    # For verification, use pre-resolved credits or default to 1
-    credits_to_charge = credits_pre if credits_pre is not None else 1
-
     parent_rt = active_run_tree()
     verify_started = time.monotonic()
+    # Open the verify span BEFORE the token-presence check so failed probes
+    # (no payment_token in config) still produce a clearly-named span and
+    # have the static nvm.* attrs (plan_ids, scheme, network, agent_id)
+    # attached to both the span and the parent tool span. Without this,
+    # discovery-probe traces look like generic LangChain failures with no
+    # Nevermined-related metadata.
     with verify_span(
         plan_ids=config.plan_ids,
         scheme=resolved_scheme,
         network=config.network,
         agent_id=config.agent_id,
     ) as vspan:
+        pre_verify_md = build_verify_metadata(
+            plan_ids=config.plan_ids,
+            scheme=resolved_scheme,
+            network=config.network,
+            agent_id=config.agent_id,
+        )
+        add_metadata(vspan, pre_verify_md)
+        add_metadata(parent_rt, pre_verify_md)
+
+        token = _extract_payment_token(runnable_config)
+        if not token:
+            raise PaymentRequiredError(
+                "Payment required: missing payment_token in config['configurable']",
+                payment_required,
+            )
+
+        credits_pre = _resolve_credits_pre(config.credits, kwargs)
+        # For verification, use pre-resolved credits or default to 1
+        credits_to_charge = credits_pre if credits_pre is not None else 1
+
         verification = config.payments.facilitator.verify_permissions(
             payment_required=payment_required,
             x402_access_token=token,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1590,7 +1590,7 @@ files = [
     {file = "langsmith-0.7.10-py3-none-any.whl", hash = "sha256:90b92623c2d7b832ce081a7b3f214ac2e5ec6c5f5af1b28c14b5d32ad6726fcc"},
     {file = "langsmith-0.7.10.tar.gz", hash = "sha256:50163f7016f182907077eb086dbfa84bf576a4b3d6b21ef2565f52169de3579d"},
 ]
-markers = {main = "extra == \"langchain\""}
+markers = {main = "extra == \"langchain\" or extra == \"langsmith\""}
 
 [package.dependencies]
 httpx = ">=0.23.0,<1"
@@ -2305,7 +2305,7 @@ files = [
     {file = "orjson-3.11.7-cp314-cp314-win_arm64.whl", hash = "sha256:4a2e9c5be347b937a2e0203866f12bba36082e89b402ddb9e927d5822e43088d"},
     {file = "orjson-3.11.7.tar.gz", hash = "sha256:9b1a67243945819ce55d24a30b59d6a168e86220452d2c96f4d1f093e71c0c49"},
 ]
-markers = {main = "extra == \"langchain\" and platform_python_implementation != \"PyPy\""}
+markers = {main = "(extra == \"langchain\" or extra == \"langsmith\") and platform_python_implementation != \"PyPy\""}
 
 [[package]]
 name = "ormsgpack"
@@ -3376,7 +3376,7 @@ files = [
     {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
     {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
 ]
-markers = {main = "extra == \"langchain\""}
+markers = {main = "extra == \"langchain\" or extra == \"langsmith\""}
 
 [package.dependencies]
 requests = ">=2.0.1,<3.0.0"
@@ -3809,7 +3809,7 @@ files = [
     {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:258186964039a8e36db10810c1ece879d229b01331e09e9030bc5dcabe231bd2"},
     {file = "uuid_utils-0.14.1.tar.gz", hash = "sha256:9bfc95f64af80ccf129c604fb6b8ca66c6f256451e32bc4570f760e4309c9b69"},
 ]
-markers = {main = "extra == \"langchain\""}
+markers = {main = "extra == \"langchain\" or extra == \"langsmith\""}
 
 [[package]]
 name = "uvicorn"
@@ -4181,7 +4181,7 @@ files = [
     {file = "xxhash-3.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d"},
     {file = "xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6"},
 ]
-markers = {main = "extra == \"langchain\""}
+markers = {main = "extra == \"langchain\" or extra == \"langsmith\""}
 
 [[package]]
 name = "yarl"
@@ -4456,7 +4456,7 @@ files = [
     {file = "zstandard-0.25.0-cp39-cp39-win_amd64.whl", hash = "sha256:37daddd452c0ffb65da00620afb8e17abd4adaae6ce6310702841760c2c26860"},
     {file = "zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b"},
 ]
-markers = {main = "extra == \"langchain\""}
+markers = {main = "extra == \"langchain\" or extra == \"langsmith\""}
 
 [package.extras]
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
@@ -4464,9 +4464,10 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [extras]
 fastapi = ["fastapi", "starlette"]
 langchain = ["langchain-core"]
+langsmith = ["langsmith"]
 strands = ["strands-agents"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "7d043318d67330bba1333bcfe6725a3df751b9f46b63540c960b28aded45722c"
+content-hash = "31a4f1a7ae255dba32565786f8577af04ecb04fa692c96c0ca8a7e1be881a83f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,13 @@ fastapi = {version = "^0.120.0", optional = true}
 starlette = {version = "^0.49.1", optional = true}
 strands-agents = {version = ">=1.0.0", optional = true}
 langchain-core = {version = ">=0.3.0", optional = true}
+langsmith = {version = ">=0.1.40,<1.0.0", optional = true}
 
 [tool.poetry.extras]
 fastapi = ["fastapi", "starlette"]
 strands = ["strands-agents"]
 langchain = ["langchain-core"]
+langsmith = ["langsmith"]
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.1.1"

--- a/tests/unit/langsmith/test_spans.py
+++ b/tests/unit/langsmith/test_spans.py
@@ -327,6 +327,19 @@ def test_verify_span_yields_none_on_trace_exception():
             assert span is None
 
 
+def test_settlement_span_yields_none_on_trace_exception():
+    """Parity test for verify_span. Both currently delegate to _open_nvm_span;
+    this pins the contract so a future split-out can't regress only one path."""
+    fake_ls = MagicMock()
+    fake_ls.trace.side_effect = RuntimeError("trace failed")
+    with (
+        patch.object(spans, "_get_current_run_tree", return_value=MagicMock()),
+        patch.object(spans, "_ls", fake_ls),
+    ):
+        with settlement_span(plan_ids=["plan-1"]) as span:
+            assert span is None
+
+
 def test_verify_span_propagates_body_exception_to_caller():
     """Caller-raised exceptions must propagate out, not be swallowed.
 

--- a/tests/unit/langsmith/test_spans.py
+++ b/tests/unit/langsmith/test_spans.py
@@ -1,0 +1,259 @@
+"""Unit tests for the LangSmith span helpers."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from payments_py.langsmith import spans
+from payments_py.langsmith.spans import (
+    active_run_tree,
+    add_metadata,
+    build_settle_metadata,
+    build_verify_metadata,
+    settlement_span,
+    verify_span,
+)
+from payments_py.x402.types import SettleResponse, VerifyResponse
+
+# --------------------------------------------------------------------------- #
+# build_verify_metadata
+# --------------------------------------------------------------------------- #
+
+
+def test_build_verify_metadata_minimal():
+    md = build_verify_metadata(plan_ids=["plan-1"])
+    assert md == {"nvm.plan_ids": ["plan-1"]}
+
+
+def test_build_verify_metadata_full_static_fields():
+    md = build_verify_metadata(
+        plan_ids=["plan-1", "plan-2"],
+        scheme="nvm:card-delegation",
+        network="stripe",
+        agent_id="agent-xyz",
+        duration_ms=12.345,
+    )
+    assert md == {
+        "nvm.plan_ids": ["plan-1", "plan-2"],
+        "nvm.scheme": "nvm:card-delegation",
+        "nvm.network": "stripe",
+        "nvm.agent_id": "agent-xyz",
+        "nvm.verify.duration_ms": 12.35,  # rounded to 2 dp
+    }
+
+
+def test_build_verify_metadata_extracts_from_verification():
+    verification = VerifyResponse(
+        is_valid=True,
+        payer="0xpayer",
+        network="base-sepolia",
+        agent_request_id="req-123",
+    )
+    md = build_verify_metadata(
+        plan_ids=["plan-1"],
+        verification=verification,
+    )
+    assert md["nvm.payer"] == "0xpayer"
+    assert md["nvm.network"] == "base-sepolia"
+    assert md["nvm.agent_request_id"] == "req-123"
+
+
+def test_build_verify_metadata_explicit_network_wins_over_verification():
+    verification = VerifyResponse(is_valid=True, network="base-sepolia")
+    md = build_verify_metadata(
+        plan_ids=["plan-1"],
+        network="stripe",
+        verification=verification,
+    )
+    assert md["nvm.network"] == "stripe"
+
+
+def test_build_verify_metadata_drops_none_and_empty():
+    md = build_verify_metadata(plan_ids=["plan-1"], scheme=None, agent_id="")
+    assert "nvm.scheme" not in md
+    assert "nvm.agent_id" not in md
+
+
+# --------------------------------------------------------------------------- #
+# build_settle_metadata
+# --------------------------------------------------------------------------- #
+
+
+def test_build_settle_metadata_full():
+    settlement = SettleResponse(
+        success=True,
+        payer="0xpayer",
+        transaction="0xdeadbeef",
+        network="stripe",
+        credits_redeemed="5",
+        remaining_balance="45",
+    )
+    md = build_settle_metadata(
+        settlement=settlement,
+        plan_ids=["plan-1"],
+        agent_id="agent-xyz",
+        duration_ms=42.0,
+    )
+    assert md == {
+        "nvm.plan_ids": ["plan-1"],
+        "nvm.agent_id": "agent-xyz",
+        "nvm.settle.duration_ms": 42.0,
+        "nvm.credits_redeemed": "5",
+        "nvm.balance.after": "45",
+        "nvm.tx_hash": "0xdeadbeef",
+        "nvm.network": "stripe",
+        "nvm.payer": "0xpayer",
+    }
+
+
+def test_build_settle_metadata_omits_empty_transaction_and_network():
+    settlement = SettleResponse(success=True, transaction="", network="")
+    md = build_settle_metadata(settlement=settlement, plan_ids=["plan-1"])
+    assert "nvm.tx_hash" not in md
+    assert "nvm.network" not in md
+
+
+def test_build_settle_metadata_drops_none_credits():
+    settlement = SettleResponse(success=True, transaction="0x1", network="stripe")
+    md = build_settle_metadata(settlement=settlement, plan_ids=["plan-1"])
+    assert "nvm.credits_redeemed" not in md
+    assert "nvm.balance.after" not in md
+
+
+# --------------------------------------------------------------------------- #
+# active_run_tree + add_metadata
+# --------------------------------------------------------------------------- #
+
+
+def test_active_run_tree_returns_none_when_langsmith_unavailable():
+    with patch.object(spans, "_LANGSMITH_AVAILABLE", False):
+        assert active_run_tree() is None
+
+
+def test_active_run_tree_returns_none_when_helper_returns_none():
+    with patch.object(spans, "_get_current_run_tree", return_value=None):
+        assert active_run_tree() is None
+
+
+def test_active_run_tree_returns_run_tree_from_helper():
+    fake_rt = MagicMock()
+    with patch.object(spans, "_get_current_run_tree", return_value=fake_rt):
+        assert active_run_tree() is fake_rt
+
+
+def test_active_run_tree_swallows_helper_exception():
+    with patch.object(
+        spans, "_get_current_run_tree", side_effect=RuntimeError("no tracer")
+    ):
+        assert active_run_tree() is None
+
+
+def test_add_metadata_no_op_when_run_tree_is_none():
+    # Should not raise.
+    add_metadata(None, {"k": "v"})
+
+
+def test_add_metadata_no_op_when_metadata_empty():
+    rt = MagicMock()
+    add_metadata(rt, {})
+    rt.add_metadata.assert_not_called()
+
+
+def test_add_metadata_calls_run_tree_add_metadata():
+    rt = MagicMock()
+    add_metadata(rt, {"nvm.plan_id": "p1"})
+    rt.add_metadata.assert_called_once_with({"nvm.plan_id": "p1"})
+
+
+def test_add_metadata_swallows_run_tree_exception():
+    rt = MagicMock()
+    rt.add_metadata.side_effect = RuntimeError("boom")
+    add_metadata(rt, {"k": "v"})  # must not raise
+
+
+# --------------------------------------------------------------------------- #
+# verify_span + settlement_span
+# --------------------------------------------------------------------------- #
+
+
+def test_verify_span_yields_none_when_no_active_run():
+    with patch.object(spans, "_get_current_run_tree", return_value=None):
+        with verify_span(plan_ids=["plan-1"]) as span:
+            assert span is None
+
+
+def test_verify_span_yields_span_from_ls_trace():
+    fake_parent = MagicMock(name="parent_run_tree")
+    fake_child = MagicMock(name="child_span")
+
+    @contextmanager
+    def fake_trace(**kwargs):
+        # Echo the args so we can assert on them.
+        fake_child.recorded_args = kwargs
+        yield fake_child
+
+    fake_ls = MagicMock()
+    fake_ls.trace = fake_trace
+
+    with (
+        patch.object(spans, "_get_current_run_tree", return_value=fake_parent),
+        patch.object(spans, "_ls", fake_ls),
+    ):
+        with verify_span(
+            plan_ids=["plan-1"],
+            scheme="nvm:erc4337",
+            network="base-sepolia",
+            agent_id="agent-x",
+        ) as span:
+            assert span is fake_child
+
+    assert fake_child.recorded_args["name"] == "nvm:verify"
+    assert fake_child.recorded_args["run_type"] == "tool"
+    assert fake_child.recorded_args["inputs"] == {
+        "plan_ids": ["plan-1"],
+        "scheme": "nvm:erc4337",
+        "network": "base-sepolia",
+        "agent_id": "agent-x",
+    }
+
+
+def test_verify_span_yields_none_on_trace_exception():
+    fake_ls = MagicMock()
+    fake_ls.trace.side_effect = RuntimeError("trace failed")
+    with (
+        patch.object(spans, "_get_current_run_tree", return_value=MagicMock()),
+        patch.object(spans, "_ls", fake_ls),
+    ):
+        with verify_span(plan_ids=["plan-1"]) as span:
+            assert span is None
+
+
+def test_settlement_span_yields_none_when_no_active_run():
+    with patch.object(spans, "_get_current_run_tree", return_value=None):
+        with settlement_span(plan_ids=["plan-1"]) as span:
+            assert span is None
+
+
+def test_settlement_span_yields_span_from_ls_trace():
+    fake_parent = MagicMock(name="parent_run_tree")
+    fake_child = MagicMock(name="child_span")
+
+    @contextmanager
+    def fake_trace(**kwargs):
+        fake_child.recorded_args = kwargs
+        yield fake_child
+
+    fake_ls = MagicMock()
+    fake_ls.trace = fake_trace
+
+    with (
+        patch.object(spans, "_get_current_run_tree", return_value=fake_parent),
+        patch.object(spans, "_ls", fake_ls),
+    ):
+        with settlement_span(plan_ids=["plan-1"], agent_id="agent-x") as span:
+            assert span is fake_child
+
+    assert fake_child.recorded_args["name"] == "nvm:settlement"
+    assert fake_child.recorded_args["inputs"] == {
+        "plan_ids": ["plan-1"],
+        "agent_id": "agent-x",
+    }

--- a/tests/unit/langsmith/test_spans.py
+++ b/tests/unit/langsmith/test_spans.py
@@ -3,6 +3,8 @@
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from payments_py.langsmith import spans
 from payments_py.langsmith.spans import (
     active_run_tree,
@@ -225,6 +227,81 @@ def test_verify_span_yields_none_on_trace_exception():
     ):
         with verify_span(plan_ids=["plan-1"]) as span:
             assert span is None
+
+
+def test_verify_span_propagates_body_exception_to_caller():
+    """Caller-raised exceptions must propagate out, not be swallowed.
+
+    Regression test: an earlier implementation wrapped the `with _ls.trace(): yield`
+    in a broad try/except that re-yielded None on any exception, which violates
+    the @contextmanager protocol and surfaces as
+    `RuntimeError("generator didn't stop after throw()")`. The user-visible
+    symptom was that the very first `agent.invoke()` (the discovery probe in
+    the langchain tutorial) crashed with that error instead of the expected
+    PaymentRequiredError.
+    """
+    parent_rt = MagicMock(name="parent_run_tree")
+    span_handle = MagicMock(name="span_handle")
+    exit_calls: list[tuple] = []
+
+    @contextmanager
+    def fake_trace(**kwargs):
+        try:
+            yield span_handle
+        except BaseException as e:
+            exit_calls.append((type(e), str(e)))
+            raise
+
+    fake_ls = MagicMock()
+    fake_ls.trace = fake_trace
+
+    class Boom(Exception):
+        pass
+
+    with (
+        patch.object(spans, "_get_current_run_tree", return_value=parent_rt),
+        patch.object(spans, "_ls", fake_ls),
+    ):
+        with pytest.raises(Boom):
+            with verify_span(plan_ids=["plan-1"]) as span:
+                assert span is span_handle
+                raise Boom("from body")
+
+    # The inner _ls.trace context manager saw the exception (so LangSmith
+    # marks the span as failed), and the exception propagated up to the caller.
+    assert exit_calls == [(Boom, "from body")]
+
+
+def test_settlement_span_propagates_body_exception_to_caller():
+    """Mirror of test_verify_span_propagates_body_exception_to_caller for settle."""
+    parent_rt = MagicMock(name="parent_run_tree")
+    span_handle = MagicMock(name="span_handle")
+    exit_calls: list[tuple] = []
+
+    @contextmanager
+    def fake_trace(**kwargs):
+        try:
+            yield span_handle
+        except BaseException as e:
+            exit_calls.append((type(e), str(e)))
+            raise
+
+    fake_ls = MagicMock()
+    fake_ls.trace = fake_trace
+
+    class Boom(Exception):
+        pass
+
+    with (
+        patch.object(spans, "_get_current_run_tree", return_value=parent_rt),
+        patch.object(spans, "_ls", fake_ls),
+    ):
+        with pytest.raises(Boom):
+            with settlement_span(plan_ids=["plan-1"]) as span:
+                assert span is span_handle
+                raise Boom("from settle body")
+
+    assert exit_calls == [(Boom, "from settle body")]
 
 
 def test_settlement_span_yields_none_when_no_active_run():

--- a/tests/unit/langsmith/test_spans.py
+++ b/tests/unit/langsmith/test_spans.py
@@ -7,6 +7,7 @@ import pytest
 
 from payments_py.langsmith import spans
 from payments_py.langsmith.spans import (
+    abbreviate_token,
     active_run_tree,
     add_metadata,
     build_settle_metadata,
@@ -15,6 +16,32 @@ from payments_py.langsmith.spans import (
     verify_span,
 )
 from payments_py.x402.types import SettleResponse, VerifyResponse
+
+# --------------------------------------------------------------------------- #
+# abbreviate_token
+# --------------------------------------------------------------------------- #
+
+
+def test_abbreviate_token_long_token():
+    token = "eyJ4NDAyVmVyc2lvbiI6Miwicm9sZXMiOlsicGF5ZXIiXX0.stubsig"
+    abbreviated = abbreviate_token(token)
+    assert abbreviated == "eyJ4NDAyVmVyc2lv…bsig"
+    # Short enough to be a metadata field, far shorter than the original.
+    assert len(abbreviated) < len(token) / 2
+    # Original token is not a substring of the abbreviated form.
+    assert token not in abbreviated
+
+
+def test_abbreviate_token_short_token_returned_as_is():
+    # A 20-char token has no abbreviation benefit and is returned unchanged.
+    short = "a" * 20
+    assert abbreviate_token(short) == short
+
+
+def test_abbreviate_token_none_or_empty_returns_none():
+    assert abbreviate_token(None) is None
+    assert abbreviate_token("") is None
+
 
 # --------------------------------------------------------------------------- #
 # build_verify_metadata
@@ -75,6 +102,19 @@ def test_build_verify_metadata_drops_none_and_empty():
     assert "nvm.agent_id" not in md
 
 
+def test_build_verify_metadata_includes_abbreviated_token():
+    token = "eyJ4NDAyVmVyc2lvbiI6Miwicm9sZXMiOlsicGF5ZXIiXX0.stubsig"
+    md = build_verify_metadata(plan_ids=["plan-1"], token=token)
+    assert md["nvm.payment_token"] == "eyJ4NDAyVmVyc2lv…bsig"
+    # Full token never appears.
+    assert token not in md["nvm.payment_token"]
+
+
+def test_build_verify_metadata_omits_payment_token_when_none():
+    md = build_verify_metadata(plan_ids=["plan-1"], token=None)
+    assert "nvm.payment_token" not in md
+
+
 # --------------------------------------------------------------------------- #
 # build_settle_metadata
 # --------------------------------------------------------------------------- #
@@ -119,6 +159,20 @@ def test_build_settle_metadata_drops_none_credits():
     md = build_settle_metadata(settlement=settlement, plan_ids=["plan-1"])
     assert "nvm.credits_redeemed" not in md
     assert "nvm.balance.after" not in md
+
+
+def test_build_settle_metadata_includes_abbreviated_token():
+    settlement = SettleResponse(success=True, transaction="0x1", network="stripe")
+    token = "eyJ4NDAyVmVyc2lvbiI6Miwicm9sZXMiOlsicGF5ZXIiXX0.stubsig"
+    md = build_settle_metadata(settlement=settlement, plan_ids=["plan-1"], token=token)
+    assert md["nvm.payment_token"] == "eyJ4NDAyVmVyc2lv…bsig"
+    assert token not in md["nvm.payment_token"]
+
+
+def test_build_settle_metadata_omits_payment_token_when_none():
+    settlement = SettleResponse(success=True, transaction="0x1", network="stripe")
+    md = build_settle_metadata(settlement=settlement, plan_ids=["plan-1"], token=None)
+    assert "nvm.payment_token" not in md
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/langsmith/test_spans.py
+++ b/tests/unit/langsmith/test_spans.py
@@ -12,6 +12,7 @@ from payments_py.langsmith.spans import (
     add_metadata,
     build_settle_metadata,
     build_verify_metadata,
+    redact_metadata_keys,
     settlement_span,
     verify_span,
 )
@@ -224,6 +225,49 @@ def test_add_metadata_swallows_run_tree_exception():
     rt = MagicMock()
     rt.add_metadata.side_effect = RuntimeError("boom")
     add_metadata(rt, {"k": "v"})  # must not raise
+
+
+# --------------------------------------------------------------------------- #
+# redact_metadata_keys
+# --------------------------------------------------------------------------- #
+
+
+def test_redact_metadata_keys_removes_keys_in_place():
+    metadata = {"payment_token": "eyJfull", "other": "keep", "nvm.payer": "0x"}
+    rt = type("FakeRT", (), {"extra": {"metadata": metadata}})()
+    redact_metadata_keys(rt, "payment_token")
+    assert "payment_token" not in metadata
+    assert metadata == {"other": "keep", "nvm.payer": "0x"}
+
+
+def test_redact_metadata_keys_handles_multiple_keys():
+    metadata = {"a": 1, "b": 2, "c": 3}
+    rt = type("FakeRT", (), {"extra": {"metadata": metadata}})()
+    redact_metadata_keys(rt, "a", "c", "missing")
+    assert metadata == {"b": 2}
+
+
+def test_redact_metadata_keys_no_op_when_run_tree_is_none():
+    redact_metadata_keys(None, "anything")  # must not raise
+
+
+def test_redact_metadata_keys_no_op_when_no_keys():
+    metadata = {"payment_token": "eyJfull"}
+    rt = type("FakeRT", (), {"extra": {"metadata": metadata}})()
+    redact_metadata_keys(rt)
+    assert metadata == {"payment_token": "eyJfull"}
+
+
+def test_redact_metadata_keys_swallows_exceptions():
+    # extra is not a dict -- the helper should silently handle it.
+    rt = MagicMock()
+    rt.extra = None
+    redact_metadata_keys(rt, "payment_token")  # must not raise
+
+
+def test_redact_metadata_keys_handles_missing_metadata_subdict():
+    rt = type("FakeRT", (), {"extra": {}})()
+    redact_metadata_keys(rt, "payment_token")  # must not raise
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/x402/test_langchain_decorator.py
+++ b/tests/unit/x402/test_langchain_decorator.py
@@ -261,12 +261,17 @@ class TestLangSmithSpansIntegration:
                 config={"configurable": {"payment_token": "tok"}},
             )
 
-        # Verify span got verify metadata, settle span got settle metadata.
-        verify_handle.add_metadata.assert_called_once()
-        verify_md = verify_handle.add_metadata.call_args.args[0]
-        assert verify_md["nvm.plan_ids"] == ["plan-123"]
-        assert verify_md["nvm.payer"] == "0x1234567890abcdef"
-        assert "nvm.verify.duration_ms" in verify_md
+        # Verify span got metadata twice — once pre-verify (static fields only)
+        # and once post-verify (augmented with payer + duration). Settle span
+        # gets metadata once after the settle call.
+        assert verify_handle.add_metadata.call_count == 2
+        pre_verify_md = verify_handle.add_metadata.call_args_list[0].args[0]
+        post_verify_md = verify_handle.add_metadata.call_args_list[1].args[0]
+        assert pre_verify_md["nvm.plan_ids"] == ["plan-123"]
+        assert "nvm.payer" not in pre_verify_md
+        assert "nvm.verify.duration_ms" not in pre_verify_md
+        assert post_verify_md["nvm.payer"] == "0x1234567890abcdef"
+        assert "nvm.verify.duration_ms" in post_verify_md
 
         settle_handle.add_metadata.assert_called_once()
         settle_md = settle_handle.add_metadata.call_args.args[0]
@@ -274,9 +279,9 @@ class TestLangSmithSpansIntegration:
         assert settle_md["nvm.tx_hash"] == "0xabc123"
         assert settle_md["nvm.balance.after"] == "99"
 
-        # Parent run tree should have received metadata twice: once after verify,
-        # once after settle. Both calls' payloads should contain nvm.* keys.
-        assert parent_rt.add_metadata.call_count == 2
+        # Parent run tree gets metadata three times: pre-verify, post-verify,
+        # settle. All payloads should carry nvm.* keys.
+        assert parent_rt.add_metadata.call_count == 3
         all_parent_md = {
             k: v
             for call in parent_rt.add_metadata.call_args_list
@@ -301,3 +306,73 @@ class TestLangSmithSpansIntegration:
         assert result == "insight for x"
         mock_payments.facilitator.verify_permissions.assert_called_once()
         mock_payments.facilitator.settle_permissions.assert_called_once()
+
+    def test_failed_probe_still_emits_verify_span_with_nvm_metadata(
+        self, mock_payments
+    ):
+        """Discovery probe (no payment_token) must still produce an nvm:verify span.
+
+        The span is marked failed by the PaymentRequiredError, but it carries the
+        static nvm.* attrs (plan_ids, scheme, agent_id) so the buyer's failed
+        trace is still identifiable as a Nevermined verify failure rather than
+        an opaque LangChain crash.
+        """
+        parent_rt = MagicMock(name="parent_run_tree")
+        verify_handle = MagicMock(name="verify_handle")
+        settle_handle = MagicMock(name="settle_handle")
+        verify_opened = []
+
+        @contextmanager
+        def fake_verify_span(**kwargs):
+            verify_opened.append(kwargs)
+            yield verify_handle
+
+        @contextmanager
+        def fake_settlement_span(**kwargs):
+            yield settle_handle
+
+        @tool
+        @requires_payment(
+            payments=mock_payments,
+            plan_id="plan-123",
+            credits=1,
+            agent_id="agent-x",
+        )
+        def my_tool(topic: str, config: RunnableConfig = None) -> str:
+            """Canned response."""
+            return f"insight for {topic}"
+
+        with (
+            patch.object(decorator_module, "active_run_tree", return_value=parent_rt),
+            patch.object(decorator_module, "verify_span", fake_verify_span),
+            patch.object(decorator_module, "settlement_span", fake_settlement_span),
+        ):
+            with pytest.raises(PaymentRequiredError):
+                # No payment_token — should still open the verify span and tag
+                # the parent + span with the pre-verify nvm.* metadata.
+                my_tool.invoke({"topic": "x"}, config={"configurable": {}})
+
+        # verify_span was opened (before the token check) with the expected
+        # inputs.
+        assert len(verify_opened) == 1
+        assert verify_opened[0]["plan_ids"] == ["plan-123"]
+        assert verify_opened[0]["agent_id"] == "agent-x"
+
+        # Span got pre-verify metadata before the raise.
+        verify_handle.add_metadata.assert_called_once()
+        pre_md = verify_handle.add_metadata.call_args.args[0]
+        assert pre_md["nvm.plan_ids"] == ["plan-123"]
+        assert pre_md["nvm.agent_id"] == "agent-x"
+        # No verification ran yet, so dynamic fields are absent.
+        assert "nvm.payer" not in pre_md
+        assert "nvm.verify.duration_ms" not in pre_md
+
+        # Parent got the same metadata — so the failed trace is still searchable
+        # by nvm.plan_ids in the LangSmith UI.
+        parent_rt.add_metadata.assert_called_once_with(pre_md)
+
+        # Facilitator never invoked (we short-circuit inside the span).
+        mock_payments.facilitator.verify_permissions.assert_not_called()
+        mock_payments.facilitator.settle_permissions.assert_not_called()
+        # Settlement span never opened either.
+        settle_handle.add_metadata.assert_not_called()

--- a/tests/unit/x402/test_langchain_decorator.py
+++ b/tests/unit/x402/test_langchain_decorator.py
@@ -307,6 +307,173 @@ class TestLangSmithSpansIntegration:
         mock_payments.facilitator.verify_permissions.assert_called_once()
         mock_payments.facilitator.settle_permissions.assert_called_once()
 
+    def test_redacts_payment_token_from_parent_run_metadata(self, mock_payments):
+        """Parent run's payment_token (LangChain auto-captured) is stripped.
+
+        LangChain serializes config["configurable"] into the parent tool span's
+        metadata. The full x402 access token grants access to the protected
+        tool until it expires, so the decorator strips it from the parent run
+        before opening any nvm:* child span. The abbreviated nvm.payment_token
+        remains available via build_verify_metadata for correlation.
+        """
+        # Build a fake parent run tree that mirrors what LangChain would set up:
+        # config["configurable"] was captured into extra["metadata"].
+        parent_metadata = {
+            "payment_token": "eyJ4NDAyVmVyc2lvbi.full_secret.dont_leak",
+            "other_key": "preserve",
+        }
+        parent_rt = MagicMock(name="parent_run_tree")
+        parent_rt.extra = {"metadata": parent_metadata}
+
+        @contextmanager
+        def fake_span(**kwargs):
+            yield MagicMock()
+
+        my_tool = _make_protected_tool(mock_payments)
+
+        with (
+            patch.object(decorator_module, "active_run_tree", return_value=parent_rt),
+            patch.object(decorator_module, "verify_span", fake_span),
+            patch.object(decorator_module, "settlement_span", fake_span),
+        ):
+            my_tool.invoke(
+                {"topic": "x"},
+                config={"configurable": {"payment_token": "tok"}},
+            )
+
+        assert "payment_token" not in parent_metadata
+        assert parent_metadata.get("other_key") == "preserve"
+
+    def test_settle_metadata_failure_does_not_strand_receipt(self, mock_payments):
+        """If build_settle_metadata raises, last_settlement() must still update.
+
+        Regression: the on-chain settle has already happened. An observability
+        error after the facilitator call must not orphan the local receipt.
+        """
+        parent_rt = MagicMock(name="parent_run_tree")
+        verify_handle = MagicMock(name="verify_handle")
+        settle_handle = MagicMock(name="settle_handle")
+
+        @contextmanager
+        def fake_verify(**kwargs):
+            yield verify_handle
+
+        @contextmanager
+        def fake_settle(**kwargs):
+            yield settle_handle
+
+        my_tool = _make_protected_tool(mock_payments)
+
+        with (
+            patch.object(decorator_module, "active_run_tree", return_value=parent_rt),
+            patch.object(decorator_module, "verify_span", fake_verify),
+            patch.object(decorator_module, "settlement_span", fake_settle),
+            patch.object(
+                decorator_module,
+                "build_settle_metadata",
+                side_effect=RuntimeError("synthetic build failure"),
+            ),
+        ):
+            result = my_tool.invoke(
+                {"topic": "x"},
+                config={"configurable": {"payment_token": "tok"}},
+            )
+
+        # Tool result returned and receipt persisted despite the metadata error.
+        assert result == "insight for x"
+        assert last_settlement() is not None
+        assert last_settlement().credits_redeemed == "1"
+        assert last_settlement().transaction == "0xabc123"
+
+    def test_verify_metadata_failure_does_not_mask_payment_required(
+        self, mock_payments
+    ):
+        """If build_verify_metadata raises on the invalid path, PaymentRequiredError still propagates.
+
+        Regression: callers depend on the PaymentRequiredError contract. A
+        metadata build failure must not surface as a generic TypeError.
+        """
+        # Force the facilitator to return is_valid=False.
+        mock_payments.facilitator.verify_permissions.return_value = VerifyResponse(
+            is_valid=False,
+            invalid_reason="token expired",
+        )
+        parent_rt = MagicMock(name="parent_run_tree")
+
+        @contextmanager
+        def fake_span(**kwargs):
+            yield MagicMock()
+
+        my_tool = _make_protected_tool(mock_payments)
+
+        with (
+            patch.object(decorator_module, "active_run_tree", return_value=parent_rt),
+            patch.object(decorator_module, "verify_span", fake_span),
+            patch.object(decorator_module, "settlement_span", fake_span),
+            patch.object(
+                decorator_module,
+                "build_verify_metadata",
+                side_effect=RuntimeError("synthetic build failure"),
+            ),
+        ):
+            with pytest.raises(PaymentRequiredError) as excinfo:
+                my_tool.invoke(
+                    {"topic": "x"},
+                    config={"configurable": {"payment_token": "tok"}},
+                )
+
+        # Original contract preserved.
+        assert "token expired" in str(excinfo.value)
+        mock_payments.facilitator.settle_permissions.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_path_emits_verify_and_settle_spans(self, mock_payments):
+        """Async tool path mirrors the sync path -- spans emit on ainvoke().
+
+        Regression guard for a future refactor that might inline payment logic
+        into the sync wrapper and break the async path silently.
+        """
+        verify_calls: list[dict] = []
+        settle_calls: list[dict] = []
+
+        @contextmanager
+        def fake_verify_span(**kwargs):
+            verify_calls.append(kwargs)
+            yield MagicMock(name="verify_span_handle")
+
+        @contextmanager
+        def fake_settlement_span(**kwargs):
+            settle_calls.append(kwargs)
+            yield MagicMock(name="settlement_span_handle")
+
+        @tool
+        @requires_payment(
+            payments=mock_payments,
+            plan_id="plan-123",
+            credits=1,
+            agent_id="agent-x",
+        )
+        async def my_async_tool(topic: str, config: RunnableConfig = None) -> str:
+            """Canned async response."""
+            return f"async insight for {topic}"
+
+        with (
+            patch.object(decorator_module, "verify_span", fake_verify_span),
+            patch.object(decorator_module, "settlement_span", fake_settlement_span),
+        ):
+            result = await my_async_tool.ainvoke(
+                {"topic": "x"},
+                config={"configurable": {"payment_token": "tok"}},
+            )
+
+        assert result == "async insight for x"
+        assert len(verify_calls) == 1
+        assert verify_calls[0]["plan_ids"] == ["plan-123"]
+        assert verify_calls[0]["agent_id"] == "agent-x"
+        assert len(settle_calls) == 1
+        assert settle_calls[0]["plan_ids"] == ["plan-123"]
+        assert settle_calls[0]["agent_id"] == "agent-x"
+
     def test_failed_probe_still_emits_verify_span_with_nvm_metadata(
         self, mock_payments
     ):

--- a/tests/unit/x402/test_langchain_decorator.py
+++ b/tests/unit/x402/test_langchain_decorator.py
@@ -267,17 +267,34 @@ class TestLangSmithSpansIntegration:
         assert verify_handle.add_metadata.call_count == 2
         pre_verify_md = verify_handle.add_metadata.call_args_list[0].args[0]
         post_verify_md = verify_handle.add_metadata.call_args_list[1].args[0]
+
+        # Pre-verify carries the static attrs only (no verification yet).
         assert pre_verify_md["nvm.plan_ids"] == ["plan-123"]
         assert "nvm.payer" not in pre_verify_md
         assert "nvm.verify.duration_ms" not in pre_verify_md
+        assert "nvm.payment_token" not in pre_verify_md
+
+        # Post-verify pins every documented attribute from the verify-span row
+        # of the docs/api/12-langchain-integration.md attribute table.
+        # A future refactor that drops one of these from the decorator wiring
+        # will fail this test loudly instead of silently lying in docs.
+        assert post_verify_md["nvm.plan_ids"] == ["plan-123"]
         assert post_verify_md["nvm.payer"] == "0x1234567890abcdef"
+        assert post_verify_md["nvm.agent_request_id"] == "test-request-id-123"
+        assert post_verify_md["nvm.payment_token"] == "tok"  # ≤20 chars → verbatim
         assert "nvm.verify.duration_ms" in post_verify_md
 
+        # Settle span pins every documented attribute from the settle-span row.
         settle_handle.add_metadata.assert_called_once()
         settle_md = settle_handle.add_metadata.call_args.args[0]
+        assert settle_md["nvm.plan_ids"] == ["plan-123"]
         assert settle_md["nvm.credits_redeemed"] == "1"
-        assert settle_md["nvm.tx_hash"] == "0xabc123"
         assert settle_md["nvm.balance.after"] == "99"
+        assert settle_md["nvm.tx_hash"] == "0xabc123"
+        assert settle_md["nvm.network"] == "eip155:84532"
+        assert settle_md["nvm.payer"] == "0x1234567890abcdef"
+        assert settle_md["nvm.payment_token"] == "tok"
+        assert "nvm.settle.duration_ms" in settle_md
 
         # Parent run tree gets metadata three times: pre-verify, post-verify,
         # settle. All payloads should carry nvm.* keys.
@@ -425,6 +442,75 @@ class TestLangSmithSpansIntegration:
         # Original contract preserved.
         assert "token expired" in str(excinfo.value)
         mock_payments.facilitator.settle_permissions.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_path_raises_payment_required_when_no_token(
+        self, mock_payments
+    ):
+        """Async mirror of test_raises_payment_required_when_no_token.
+
+        Pins the no-token discovery-probe contract on the async path. Without
+        this test, a future async wrapper rewrite (e.g. wrapping
+        ``_verify_payment`` in an ``asyncio.shield`` or thread-pool offload,
+        or moving the parent_rt redact into a sync-only path) would silently
+        regress async failure semantics.
+        """
+
+        @tool
+        @requires_payment(payments=mock_payments, plan_id="plan-123", credits=1)
+        async def my_async_tool(topic: str, config: RunnableConfig = None) -> str:
+            """Canned async response."""
+            return f"result for {topic}"
+
+        with pytest.raises(PaymentRequiredError) as excinfo:
+            await my_async_tool.ainvoke({"topic": "x"}, config={"configurable": {}})
+
+        assert excinfo.value.payment_required is not None
+        accepts = excinfo.value.payment_required.accepts
+        assert accepts[0].plan_id == "plan-123"
+        mock_payments.facilitator.verify_permissions.assert_not_called()
+        mock_payments.facilitator.settle_permissions.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_path_redacts_payment_token_from_parent_run_metadata(
+        self, mock_payments
+    ):
+        """Async mirror of test_redacts_payment_token_from_parent_run_metadata.
+
+        The redact path lives in _verify_payment which both sync and async
+        wrappers call, but pinning it on the async path too prevents a future
+        change that bypasses _verify_payment in the async wrapper from
+        silently losing the credential scrubbing.
+        """
+        parent_metadata = {
+            "payment_token": "eyJ4NDAyVmVyc2lvbi.full_secret.dont_leak",
+            "other_key": "preserve",
+        }
+        parent_rt = MagicMock(name="parent_run_tree")
+        parent_rt.extra = {"metadata": parent_metadata}
+
+        @contextmanager
+        def fake_span(**kwargs):
+            yield MagicMock()
+
+        @tool
+        @requires_payment(payments=mock_payments, plan_id="plan-123", credits=1)
+        async def my_async_tool(topic: str, config: RunnableConfig = None) -> str:
+            """Canned async response."""
+            return f"result for {topic}"
+
+        with (
+            patch.object(decorator_module, "active_run_tree", return_value=parent_rt),
+            patch.object(decorator_module, "verify_span", fake_span),
+            patch.object(decorator_module, "settlement_span", fake_span),
+        ):
+            await my_async_tool.ainvoke(
+                {"topic": "x"},
+                config={"configurable": {"payment_token": "tok"}},
+            )
+
+        assert "payment_token" not in parent_metadata
+        assert parent_metadata.get("other_key") == "preserve"
 
     @pytest.mark.asyncio
     async def test_async_path_emits_verify_and_settle_spans(self, mock_payments):

--- a/tests/unit/x402/test_langchain_decorator.py
+++ b/tests/unit/x402/test_langchain_decorator.py
@@ -1,6 +1,7 @@
 """Unit tests for the LangChain x402 payment decorator and helpers."""
 
-from unittest.mock import MagicMock
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_core.runnables import RunnableConfig
@@ -185,3 +186,118 @@ class TestCreatePaidReactAgent:
         assert (
             handle is False
         ), f"Expected ToolNode.handle_tool_errors=False, got {handle!r}"
+
+
+class TestLangSmithSpansIntegration:
+    """Confirm @requires_payment invokes the LangSmith span helpers correctly."""
+
+    def test_verify_and_settle_spans_are_opened(self, mock_payments):
+        """Both context managers must be called with the resolved plan_ids/agent."""
+        verify_calls: list[dict] = []
+        settle_calls: list[dict] = []
+
+        @contextmanager
+        def fake_verify_span(**kwargs):
+            verify_calls.append(kwargs)
+            yield MagicMock(name="verify_span_handle")
+
+        @contextmanager
+        def fake_settlement_span(**kwargs):
+            settle_calls.append(kwargs)
+            yield MagicMock(name="settlement_span_handle")
+
+        @tool
+        @requires_payment(
+            payments=mock_payments, plan_id="plan-123", credits=1, agent_id="agent-x"
+        )
+        def my_tool(topic: str, config: RunnableConfig = None) -> str:
+            """Canned response."""
+            return f"insight for {topic}"
+
+        with (
+            patch.object(decorator_module, "verify_span", fake_verify_span),
+            patch.object(decorator_module, "settlement_span", fake_settlement_span),
+        ):
+            my_tool.invoke(
+                {"topic": "x"},
+                config={"configurable": {"payment_token": "tok"}},
+            )
+
+        assert len(verify_calls) == 1
+        assert verify_calls[0]["plan_ids"] == ["plan-123"]
+        assert verify_calls[0]["agent_id"] == "agent-x"
+
+        assert len(settle_calls) == 1
+        assert settle_calls[0]["plan_ids"] == ["plan-123"]
+        assert settle_calls[0]["agent_id"] == "agent-x"
+
+    def test_metadata_attached_to_parent_and_child_spans(self, mock_payments):
+        """When a parent run is active, both the child span AND the parent receive nvm.* metadata."""
+        parent_rt = MagicMock(name="parent_run_tree")
+        verify_handle = MagicMock(name="verify_handle")
+        settle_handle = MagicMock(name="settle_handle")
+
+        @contextmanager
+        def fake_verify_span(**kwargs):
+            yield verify_handle
+
+        @contextmanager
+        def fake_settlement_span(**kwargs):
+            yield settle_handle
+
+        @tool
+        @requires_payment(payments=mock_payments, plan_id="plan-123", credits=1)
+        def my_tool(topic: str, config: RunnableConfig = None) -> str:
+            """Canned response."""
+            return f"insight for {topic}"
+
+        with (
+            patch.object(decorator_module, "active_run_tree", return_value=parent_rt),
+            patch.object(decorator_module, "verify_span", fake_verify_span),
+            patch.object(decorator_module, "settlement_span", fake_settlement_span),
+        ):
+            my_tool.invoke(
+                {"topic": "x"},
+                config={"configurable": {"payment_token": "tok"}},
+            )
+
+        # Verify span got verify metadata, settle span got settle metadata.
+        verify_handle.add_metadata.assert_called_once()
+        verify_md = verify_handle.add_metadata.call_args.args[0]
+        assert verify_md["nvm.plan_ids"] == ["plan-123"]
+        assert verify_md["nvm.payer"] == "0x1234567890abcdef"
+        assert "nvm.verify.duration_ms" in verify_md
+
+        settle_handle.add_metadata.assert_called_once()
+        settle_md = settle_handle.add_metadata.call_args.args[0]
+        assert settle_md["nvm.credits_redeemed"] == "1"
+        assert settle_md["nvm.tx_hash"] == "0xabc123"
+        assert settle_md["nvm.balance.after"] == "99"
+
+        # Parent run tree should have received metadata twice: once after verify,
+        # once after settle. Both calls' payloads should contain nvm.* keys.
+        assert parent_rt.add_metadata.call_count == 2
+        all_parent_md = {
+            k: v
+            for call in parent_rt.add_metadata.call_args_list
+            for k, v in call.args[0].items()
+        }
+        assert all_parent_md["nvm.plan_ids"] == ["plan-123"]
+        assert all_parent_md["nvm.payer"] == "0x1234567890abcdef"
+        assert all_parent_md["nvm.credits_redeemed"] == "1"
+        assert all_parent_md["nvm.tx_hash"] == "0xabc123"
+
+    def test_spans_no_op_when_no_active_run(self, mock_payments):
+        """With no LangSmith run active, parent metadata is skipped and tool still works."""
+        my_tool = _make_protected_tool(mock_payments)
+
+        # active_run_tree returns None by default in unit-test environment (no
+        # LANGSMITH_TRACING set). Confirm the tool completes normally.
+        result = my_tool.invoke(
+            {"topic": "x"},
+            config={"configurable": {"payment_token": "tok"}},
+        )
+
+        assert result == "insight for x"
+        mock_payments.facilitator.verify_permissions.assert_called_once()
+        mock_payments.facilitator.settle_permissions.assert_called_once()


### PR DESCRIPTION
## Summary

Implements Sprint 1 of the LangChain partnership epic (nevermined-io/nvm-monorepo#1703). Makes Nevermined verify + settle events first-class citizens of a LangSmith trace.

- New `payments_py.langsmith` module: `verify_span` / `settlement_span` ctx managers + `build_*_metadata` helpers + safety wrappers (`active_run_tree`, `add_metadata`, `redact_metadata_keys`, `abbreviate_token`).
- `@requires_payment` now wraps both verify and settle calls in dedicated child spans, attaches `nvm.*` metadata to both the child and the parent tool span.
- Active `payment_token` redaction: the decorator strips the full x402 access token from the parent tool span's metadata (which LangChain auto-captures from `config["configurable"]`) before opening any `nvm:*` span. Only the abbreviated `nvm.payment_token` (`<first 16>…<last 4>`) reaches Nevermined-emitted attributes.
- New optional extra: `pip install payments-py[langsmith]`. Zero-config opt-in via `LANGSMITH_TRACING=true`.
- Silent no-op when `langsmith` is missing or no LangSmith run is active. Observability failures never propagate into the payment flow.

Implements nevermined-io/nvm-monorepo#1705.

## Trace shape

```
[tool: get_market_insight]
├── [nvm:verify]      attrs: nvm.scheme, nvm.plan_ids, nvm.payer, nvm.agent_id, nvm.agent_request_id, nvm.payment_token (abbrev), nvm.verify.duration_ms
├── <tool body>
└── [nvm:settlement]  attrs: nvm.credits_redeemed, nvm.balance.after, nvm.tx_hash, nvm.network, nvm.payer, nvm.payment_token (abbrev), nvm.settle.duration_ms
```

Full attribute reference table in `docs/api/12-langchain-integration.md` (Observability with LangSmith section) — integration tests now pin every documented attribute (M5 review polish).

## Notes for reviewers

- **Version intentionally unchanged.** Per the `## Release Process` section added to `CLAUDE.md`, the release pipeline (`prepare-release.yml` → `finalize-release.yml` → `release-python.yml`) owns the version bump. Trigger `prepare-release.yml` against this branch after merge with `1.8.0` (new minor — new module + new extra).
- **Docs source.** The new "Observability with LangSmith" section is in `docs/api/12-langchain-integration.md`. It will flow to `docs_mintlify/docs/api-reference/python/langchain-module.mdx` automatically on the next tag via `publish-mintlify-docs.yml`.
- **No breaking changes.** All existing decorator behaviour and tests preserved; the spans hooks are pure additions guarded by langsmith availability + active run.
- **Tutorial PR follows.** `tutorials/langchain-paid-agent-py` will get a follow-up PR adding the `:observability` script + README section + LANGSMITH env-var entries, depending on the released version. (Now drafted: nevermined-io/tutorials#53.)
- **Docs PR follows.** Hand-maintained integration guide + skill reference need a parallel PR. Drafted: nevermined-io/docs#185.

## Test plan

- [x] **56 LangSmith / decorator tests** (37 in `tests/unit/langsmith/test_spans.py` + 19 in `tests/unit/x402/test_langchain_decorator.py`, of which 10 are new in this PR — 9 existed on main).
- [x] **`test_spans.py` covers:** metadata builders (with/without each optional field), `abbreviate_token` (long/short/None), `redact_metadata_keys` (in-place removal, multi-key, missing extra, exception swallow), `active_run_tree` (missing langsmith, no active run, exception in helper), `add_metadata` (None tree, empty md, exception in run tree), `verify_span` / `settlement_span` (no active run, active run, ls.trace setup exception, **body exception propagation** — regression guard for the `generator didn't stop after throw()` bug).
- [x] **`test_langchain_decorator.py` `TestLangSmithSpansIntegration` covers:** verify + settle spans open with correct kwargs, metadata attached to both child spans and parent run tree (with **assertions on every documented `nvm.*` attribute** — M5 review polish), full tool flow with no active LangSmith run, failed discovery probe emits `nvm:verify` span with static metadata, payment_token redacted from parent run, settle metadata failure does NOT strand the receipt (M1 review fix), verify metadata failure does NOT mask `PaymentRequiredError` (M2 review fix), **async path emits spans on `ainvoke()`**, async path raises `PaymentRequiredError` when no token, async path redacts payment_token (M6 review polish).
- [x] Full unit suite: 563 / 563 pass (24 e2e failures pre-existing, network-dependent; 9 skipped expected).
- [x] `poetry run black --check` clean on all touched files.
- [x] **aaitor approval** with inline polish (M1 docs, M2 security, M4 parity test, M5 integration assertions, M6 async coverage, L3 refactor) — all applied in commit `bc9f12b`.
- [ ] Local end-to-end against a real LangSmith project (tutorial wired up via path dep on a follow-up branch — verifying spans + metadata appear correctly in the LangSmith UI before marking this PR ready for review). **User has confirmed locally.**

## Out-of-scope follow-ups filed

Surfaced by the review panel, filed under epic #1703:

- nevermined-io/nvm-monorepo#1745 — LangGraph multi-tool parent-metadata clobber (last-writer-wins on `nvm.*` keys when two `@requires_payment` tools share a parent node).
- nevermined-io/nvm-monorepo#1746 — Versioned cross-SDK span schema so TS-1 (#1709) and this PR can't drift silently.
- nevermined-io/nvm-monorepo#1747 — `abbreviate_token` short-token defense for non-LangChain callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)