### PR TITLE
docs: fix Sprint 3 chapter cross-links + register chapter 13 in mintlify sync

### DIFF
--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -4,7 +4,7 @@ This guide covers the LangChain and LangGraph integration shipped in the `[langc
 
 For the conceptual walk-through (two integration approaches, the discovery-first flow, dynamic credits patterns), see the [LangChain integration guide](/docs/integrate/add-to-your-agent/langchain). For a runnable end-to-end demo, see the [`langchain-paid-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-paid-agent-py) tutorial.
 
-> Looking to gate a **LangSmith Deployment** entry point (`/threads/{id}/runs/wait` etc.) rather than individual tools? See [chapter 13 — LangSmith Deployment Middleware](./13-langsmith-deployment.md). The two integrations are complementary: chapter 12 protects tools the agent calls; chapter 13 protects the agent's HTTP entry point.
+> Looking to gate a **LangSmith Deployment** entry point (`/threads/{id}/runs/wait` etc.) rather than individual tools? See [LangSmith Deployment Middleware](./13-langsmith-deployment.md). The two integrations are complementary: the decorator covered here protects tools the agent calls; the LangSmith Deployment middleware protects the agent's HTTP entry point.
 
 ## Installation
 

--- a/docs/api/13-langsmith-deployment.md
+++ b/docs/api/13-langsmith-deployment.md
@@ -170,4 +170,4 @@ Verification failures (missing token, invalid signature, insufficient credits) r
 
 - [x402 Protocol](./11-x402.md) for envelope and header semantics.
 - [LangChain Integration](./12-langchain-integration.md) for the `@requires_payment` decorator (tool-time gating).
-- [`payments_py.langsmith.spans`](../reference/langsmith.md) for the observability helpers used internally.
+- `payments_py.langsmith.spans` for the observability helpers used internally (verify_span, settlement_span, attach_metadata_safely).

--- a/docs/api/13-langsmith-deployment.md
+++ b/docs/api/13-langsmith-deployment.md
@@ -2,7 +2,7 @@
 
 A Starlette ASGI middleware (`PaymentMiddleware`) that gates a LangGraph agent deployed to **LangSmith Deployment** (formerly LangGraph Platform) with the Nevermined x402 payment flow. Use the `build_payment_app` factory for one-line wiring via the `http.app` field in `langgraph.json`.
 
-For tool-time gating inside an agent (`@requires_payment` decorator), see [chapter 12](./12-langchain-integration.md). The two integrations are complementary — chapter 12 is for protecting tools the agent calls; this chapter is for protecting the agent's HTTP entry point.
+For tool-time gating inside an agent (`@requires_payment` decorator), see [LangChain Integration](./12-langchain-integration.md). The two integrations are complementary — that page is for protecting tools the agent calls; this page is for protecting the agent's HTTP entry point.
 
 ## Installation
 
@@ -154,7 +154,7 @@ app = FastAPI(
 
 ## Observability
 
-When `LANGSMITH_TRACING=true` is set, the middleware opens a top-level `nvm:x402-request` trace per gated request, with `nvm:verify` and `nvm:settlement` child spans nested under it. Both child spans carry the `nvm.*` metadata from [chapter 12 §Observability](./12-langchain-integration.md#observability) (plan_ids, scheme, network, payer, credits_redeemed, balance.after, tx_hash, payment_token abbreviated, verify/settle durations). The same metadata is also attached to the parent trace.
+When `LANGSMITH_TRACING=true` is set, the middleware opens a top-level `nvm:x402-request` trace per gated request, with `nvm:verify` and `nvm:settlement` child spans nested under it. Both child spans carry the same `nvm.*` metadata the decorator emits (plan_ids, scheme, network, payer, credits_redeemed, balance.after, tx_hash, payment_token abbreviated, verify/settle durations) — see the Observability section in [LangChain Integration](./12-langchain-integration.md). The same metadata is also attached to the parent trace.
 
 The graph's own LangGraph-emitted trace appears as a sibling top-level trace, not a child of `nvm:x402-request` — `langgraph-api` initiates the graph trace at the graph-invocation boundary, independent of our middleware's trace context.
 
@@ -168,6 +168,6 @@ Verification failures (missing token, invalid signature, insufficient credits) r
 
 ## See also
 
-- [Chapter 11 — x402 Protocol](./11-x402.md) for envelope and header semantics.
-- [Chapter 12 — LangChain Integration](./12-langchain-integration.md) for the `@requires_payment` decorator (tool-time gating).
+- [x402 Protocol](./11-x402.md) for envelope and header semantics.
+- [LangChain Integration](./12-langchain-integration.md) for the `@requires_payment` decorator (tool-time gating).
 - [`payments_py.langsmith.spans`](../reference/langsmith.md) for the observability helpers used internally.

--- a/scripts/convert_to_mintlify.py
+++ b/scripts/convert_to_mintlify.py
@@ -12,6 +12,17 @@ import argparse
 from pathlib import Path
 from typing import Optional
 
+# Adding a new chapter requires FOUR edits, not one:
+#   1. Create the source file under `docs/api/<NN>-<slug>.md`.
+#   2. Add an entry to FILE_MAPPING below with `target`, `icon`, and `description`.
+#   3. Add an entry to LINK_MAPPING further down so cross-references convert
+#      to clean Mintlify URLs (the chapter 12 -> chapter 13 link will
+#      otherwise ship to Mintlify with a `.md` suffix visible to readers).
+#   4. Add an entry to `mkdocs.yml`'s nav array so the chapter is reachable
+#      on the published mkdocs site.
+# Missing any of (2)-(4) silently no-ops on the next mintlify sync — the
+# chapter exists upstream but never reaches docs_mintlify. PR #202 was the
+# v1.9.0 retroactive fix for chapter 13 missing exactly this set of edits.
 # Mapping of source files to target names and metadata
 FILE_MAPPING = {
     "01-installation.md": {

--- a/scripts/convert_to_mintlify.py
+++ b/scripts/convert_to_mintlify.py
@@ -74,6 +74,11 @@ FILE_MAPPING = {
         "icon": "link-simple",
         "description": "Decorator, helpers, and exceptions for protecting LangChain and LangGraph tools",
     },
+    "13-langsmith-deployment.md": {
+        "target": "langsmith-deployment-module.mdx",
+        "icon": "graduation-cap",
+        "description": "Starlette middleware for gating a LangGraph agent deployed to LangSmith Deployment with x402",
+    },
 }
 
 # Link mapping for internal references
@@ -90,6 +95,7 @@ LINK_MAPPING = {
     "10-a2a-integration.md": "/docs/api-reference/python/a2a-module",
     "11-x402.md": "/docs/api-reference/python/x402-module",
     "12-langchain-integration.md": "/docs/api-reference/python/langchain-module",
+    "13-langsmith-deployment.md": "/docs/api-reference/python/langsmith-deployment-module",
 }
 
 


### PR DESCRIPTION
## Summary

Two doc issues visible on the live Mintlify site after the v1.9.0 release:

1. **\"Chapter N\" wording in cross-links** — readers only see page titles on Mintlify, no chapter numbers. Rewrite to use page-title references.
2. **Chapter 13 was silently skipped by the mintlify sync** — \`scripts/convert_to_mintlify.py\`'s FILE_MAPPING/LINK_MAPPING stopped at chapter 12. The v1.9.0 sync workflow ran successfully but emitted no MDX for chapter 13, and left the raw \`./13-langsmith-deployment.md\` link (with \`.md\` extension) in the converted chapter 12 page.

## Changes

- \`docs/api/12-langchain-integration.md\` — cross-link references LangSmith Deployment by page title, not chapter number.
- \`docs/api/13-langsmith-deployment.md\` — all four \"chapter N\" references rewritten to page-title references. Hash-anchor link dropped (the converter regex doesn't preserve fragments) in favor of prose pointing at the section by name.
- \`scripts/convert_to_mintlify.py\` — chapter 13 added to FILE_MAPPING + LINK_MAPPING.

## Verification

Locally ran the converter and confirmed:
- \`langchain-module.mdx\` links to \`/docs/api-reference/python/langsmith-deployment-module\` (no \`.md\`)
- \`langsmith-deployment-module.mdx\` generated, all internal links resolved
- No remaining \"chapter\" wording in either converted MDX

## Follow-up

A companion docs_mintlify PR will backfill the missing MDX + nav entry for the v1.9.0 release that's already live. Future v* tags will sync chapter 13 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)