### PR TITLE
ci: trigger workflows on pull_request to cover fork PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint and Build
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,10 @@
 
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   unit_integration:


### PR DESCRIPTION
## Summary

Both `Tests` and `Lint and Build` are currently `on: [push]`, which GitHub does **not** dispatch on the base repo when a fork PR is opened or pushed. The result: workflows have never run on any fork PR. #181 is the first external contribution and surfaced the gap (it's been sitting with zero status checks since 2026-05-21).

## Change

```yaml
# both .github/workflows/test.yaml and .github/workflows/lint.yml
on:
  push:
    branches: [main]
  pull_request:
```

- **`push: branches: [main]`** preserves the post-merge "main is green" signal. We lose CI on intermediate commits to internal long-lived branches without an open PR — defensible since code without review doesn't really need CI either, but flagging in case it bites someone's pre-PR habits.
- **`pull_request`** fires on every PR open / synchronize / reopen, including fork PRs.

## Why this is safe

GitHub's design **does NOT pass repository secrets** to fork-PR workflow runs ([docs](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-encrypted-secrets-in-a-workflow)). So `TEST_SUBSCRIBER_API_KEY` / `TEST_BUILDER_API_KEY` stay out of contributor code under `pull_request` from a fork. The pytest suite already gracefully skips the keyed paths when env vars are absent — verified locally on #181: `562/562 not-slow tests pass` with no secrets set.

This is in contrast to `pull_request_target` (the dangerous variant), which we are **not** using.

## Spam-defense (one-time UI flip, recommended)

After this merges, please flip:

**Settings → Actions → General → Fork pull request workflows from outside collaborators → "Require approval for all outside collaborators"**

That puts every fork PR's workflow into `action_required` state until a maintainer clicks Approve. Zero unapproved spam runs. ~30s flip.

Cost: actions on `ubuntu-latest` in public repos are free unlimited, so the cost concern is bounded to "annoying queue contention" even without the approval gate — but the gate is the proper fix and worth enabling.

## After merge

Once this lands, the next push (or close+reopen) on #181 fires a `pull_request: synchronize` event → workflow enters `action_required` → one click → CI runs.

## Test plan

- [ ] Merge this
- [ ] Approve the queued workflow run on #181
- [ ] Confirm lint + tests run green on #181 (peterxing's branch)
- [ ] Flip the org Actions "Require approval" setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)