### PR TITLE
ci: skip e2e job on fork PRs (missing repo secrets)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,6 +36,11 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: unit_integration
+    # Skip on fork PRs: GitHub does not pass repo secrets to fork-PR runs, so
+    # TEST_SUBSCRIBER_API_KEY / TEST_BUILDER_API_KEY are empty and every test
+    # fails identically when the SDK tries to parse the empty key. Run on push
+    # events (main) and on pull_request events from same-repo branches.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Follow-up to #204. With `pull_request` triggers now firing for fork PRs, the `e2e` job fails for an irrelevant reason: GitHub does not pass repo secrets to fork-PR workflow runs (same property that makes the trigger safe — no secret exfil). The e2e suite reads `TEST_SUBSCRIBER_API_KEY` / `TEST_BUILDER_API_KEY` at fixture setup, gets empty strings, and the SDK key parser throws `Invalid NVM API Key: not enough values to unpack` on every test. **64 errors / 5 failures, identical exception — no test-specific signal.**

Surfaced on #181 (the first external contributor PR, currently red on `e2e` purely because of this).

## Change

Add an `if:` conditional to the `e2e` job:

```yaml
e2e:
  runs-on: ubuntu-latest
  needs: unit_integration
  # Skip on fork PRs: GitHub does not pass repo secrets to fork-PR runs, so
  # TEST_SUBSCRIBER_API_KEY / TEST_BUILDER_API_KEY are empty and every test
  # fails identically when the SDK tries to parse the empty key. Run on push
  # events (main) and on pull_request events from same-repo branches.
  if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
  continue-on-error: true
  ...
```

Reads as: run on push events to main, OR on `pull_request` events where the PR head is in the same repo as the base (internal branches). Fork PRs skip the job — the check shows as "Skipped" instead of misleading-red.

## What still runs on fork PRs

- ✅ **`Lint and Build`** — no secrets needed.
- ✅ **`Tests / unit_integration`** — the suite already gracefully skips key-requiring tests when env vars are absent (verified locally on #181: `562/562 not-slow` pass with no keys).

## What's skipped on fork PRs

- ⏭️ **`Tests / e2e`** — would 100% fail without keys.

The e2e job is meant to exercise the real Nevermined sandbox; without the credentials, it has nothing to test. Skipping is the correct signal, not a false failure.

## Verification on #181 after merge

After this merges, the next `pull_request: synchronize` on #181 (a push to peterxing's branch, or another "Update branch" click) will show:
- ✅ `Lint and Build`
- ✅ `Tests / unit_integration`
- ⏭️ `Tests / e2e` (skipped)

PR can then merge against a clean rollup.

## Test plan

- [ ] Merge this
- [ ] Trigger a re-run on #181 (Update branch or contributor push)
- [ ] Confirm `e2e` shows as "Skipped" with no failures reported
- [ ] On the next internal PR (any branch in the base repo), confirm `e2e` still runs with secrets injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)