### PR TITLE
feat: add provider filter to list_payment_methods

### DIFF
--- a/docs/api/11-x402.md
+++ b/docs/api/11-x402.md
@@ -181,12 +181,20 @@ delegation = payments.delegation.create_delegation(
 )
 print(f"Delegation ID: {delegation.delegation_id}")
 
-# List enrolled payment methods (for card delegation)
+# List enrolled payment methods (every provider)
 methods = payments.delegation.list_payment_methods()
 for method in methods:
     print(f"{method.brand} ****{method.last4} (expires {method.exp_month}/{method.exp_year})")
     # e.g., "visa ****4242 (expires 12/2027)"
+
+# Restrict the result to a single provider with the optional `provider` kwarg
+stripe_methods = payments.delegation.list_payment_methods(provider="stripe")
 ```
+
+`list_payment_methods()` accepts an optional `provider` keyword argument
+(`'stripe' | 'braintree' | 'visa' | 'erc4337'`). When set, it is forwarded as a
+`?provider=` query string and only methods backed by that provider are returned.
+Omit it (the default) to return methods from every provider.
 
 `PaymentMethodSummary` fields:
 

--- a/payments_py/x402/delegation_api.py
+++ b/payments_py/x402/delegation_api.py
@@ -98,9 +98,17 @@ class DelegationAPI(BasePaymentsAPI):
         """Get an instance of the DelegationAPI class."""
         return cls(options)
 
-    def list_payment_methods(self) -> List[PaymentMethodSummary]:
+    def list_payment_methods(
+        self, provider: Optional[DelegationProvider] = None
+    ) -> List[PaymentMethodSummary]:
         """
         List the user's enrolled payment methods for card delegation.
+
+        Args:
+            provider: When set, return only methods backed by this provider
+                ('stripe' | 'braintree' | 'visa' | 'erc4337'). Forwarded as a
+                ``?provider=`` query string. Omit to return methods from every
+                provider (default).
 
         Returns:
             A list of payment method summaries
@@ -110,9 +118,10 @@ class DelegationAPI(BasePaymentsAPI):
         """
         url = f"{self.environment.backend}/api/v1/payment-methods"
         options = self.get_backend_http_options("GET")
+        params = {"provider": provider} if provider else None
 
         try:
-            response = requests.get(url, **options)
+            response = requests.get(url, params=params, **options)
             response.raise_for_status()
             data = response.json()
             return [PaymentMethodSummary.model_validate(pm) for pm in data]

--- a/tests/unit/x402/test_delegation_api.py
+++ b/tests/unit/x402/test_delegation_api.py
@@ -94,3 +94,44 @@ class TestDelegationAPIListPaymentMethods:
         assert methods[0].brand == "visa"
         assert methods[1].id == "pm_2"
         assert methods[1].brand == "mastercard"
+
+    @patch("payments_py.x402.delegation_api.requests.get")
+    def test_forwards_provider_query_param_when_set(self, mock_get, mock_options):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        api = DelegationAPI(mock_options)
+        api.list_payment_methods(provider="stripe")
+
+        # The provider is forwarded as a ?provider= query param via requests' params.
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"] == {"provider": "stripe"}
+
+    @patch("payments_py.x402.delegation_api.requests.get")
+    def test_omits_provider_query_param_when_not_set(self, mock_get, mock_options):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        api = DelegationAPI(mock_options)
+        api.list_payment_methods()
+
+        # No provider → params is None so the default "all methods" behaviour holds.
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"] is None
+
+    @patch("payments_py.x402.delegation_api.requests.get")
+    def test_forwards_erc4337_provider(self, mock_get, mock_options):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        api = DelegationAPI(mock_options)
+        api.list_payment_methods(provider="erc4337")
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"] == {"provider": "erc4337"}


### PR DESCRIPTION
Part of nevermined-io/nvm-monorepo#1549. Backend: nevermined-io/nvm-monorepo#1715 (must land first).

Adds an optional `provider` kwarg to `list_payment_methods()`; forwarded as the `?provider=` query param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)