### PR TITLE
feat(x402): send NVM API-key auth header on facilitator verify/settle

### DIFF
--- a/payments_py/x402/facilitator_api.py
+++ b/payments_py/x402/facilitator_api.py
@@ -113,7 +113,11 @@ class FacilitatorAPI(BasePaymentsAPI):
         if max_amount is not None:
             body["maxAmount"] = max_amount
 
-        options = self.get_public_http_options("POST", body)
+        # Send the NVM API-key auth header (Authorization: Bearer <nvm_api_key>).
+        # The backend /verify endpoint runs an OPTIONAL guard that tolerates the
+        # header's absence today, so this is non-breaking; it pre-positions for
+        # the later strict-guard flip. See nevermined-io/nvm-monorepo#1570.
+        options = self.get_backend_http_options("POST", body)
 
         try:
             response = requests.post(url, **options)
@@ -169,7 +173,11 @@ class FacilitatorAPI(BasePaymentsAPI):
         if agent_request_id is not None:
             body["agentRequestId"] = agent_request_id
 
-        options = self.get_public_http_options("POST", body)
+        # Send the NVM API-key auth header (Authorization: Bearer <nvm_api_key>).
+        # The backend /settle endpoint runs an OPTIONAL guard that tolerates the
+        # header's absence today, so this is non-breaking; it pre-positions for
+        # the later strict-guard flip. See nevermined-io/nvm-monorepo#1570.
+        options = self.get_backend_http_options("POST", body)
 
         try:
             response = requests.post(url, **options)

--- a/tests/unit/x402/test_delegation_api_visa.py
+++ b/tests/unit/x402/test_delegation_api_visa.py
@@ -365,6 +365,29 @@ class TestFacilitatorVisa:
         )
 
     @patch("payments_py.x402.facilitator_api.requests.post")
+    def test_settle_sends_current_org_id_header(self, mock_post, mock_options):
+        # Switching to the authed HTTP options means an org-pinned caller now
+        # also sends X-Current-Org-Id, so the money-adjacent settle becomes
+        # org-scoped. See nevermined-io/nvm-monorepo#1570.
+        mock_options.organization_id = "org-123"
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"success": True}
+        mock_post.return_value = mock_response
+
+        FacilitatorAPI(mock_options).settle_permissions(
+            payment_required=_visa_payment_required(),
+            x402_access_token="eyJ.visa.token",
+        )
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["headers"]["X-Current-Org-Id"] == "org-123"
+        # Authorization is still the Bearer key alongside the org scope.
+        assert (
+            kwargs["headers"]["Authorization"] == f"Bearer {mock_options.nvm_api_key}"
+        )
+
+    @patch("payments_py.x402.facilitator_api.requests.post")
     def test_verify_surfaces_backend_code_on_4xx(self, mock_post, mock_options):
         mock_post.return_value = _http_error_response(
             403,

--- a/tests/unit/x402/test_delegation_api_visa.py
+++ b/tests/unit/x402/test_delegation_api_visa.py
@@ -319,6 +319,51 @@ class TestFacilitatorVisa:
         assert result.network == "visa"
         assert result.credits_redeemed == "5"
 
+    # The facilitator verify/settle endpoints carry money side effects
+    # (Stripe/VGS/Braintree on settle), so the SDK now authenticates them with
+    # the NVM API key instead of calling them unauthenticated. The backend's
+    # optional guard tolerates the header today; this pre-positions for the
+    # later strict-guard flip. See nevermined-io/nvm-monorepo#1570.
+    @patch("payments_py.x402.facilitator_api.requests.post")
+    def test_verify_sends_nvm_api_key_authorization_header(
+        self, mock_post, mock_options
+    ):
+        mock_options.organization_id = None
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"isValid": True}
+        mock_post.return_value = mock_response
+
+        FacilitatorAPI(mock_options).verify_permissions(
+            payment_required=_visa_payment_required(),
+            x402_access_token="eyJ.visa.token",
+        )
+
+        _, kwargs = mock_post.call_args
+        assert (
+            kwargs["headers"]["Authorization"] == f"Bearer {mock_options.nvm_api_key}"
+        )
+
+    @patch("payments_py.x402.facilitator_api.requests.post")
+    def test_settle_sends_nvm_api_key_authorization_header(
+        self, mock_post, mock_options
+    ):
+        mock_options.organization_id = None
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"success": True}
+        mock_post.return_value = mock_response
+
+        FacilitatorAPI(mock_options).settle_permissions(
+            payment_required=_visa_payment_required(),
+            x402_access_token="eyJ.visa.token",
+        )
+
+        _, kwargs = mock_post.call_args
+        assert (
+            kwargs["headers"]["Authorization"] == f"Bearer {mock_options.nvm_api_key}"
+        )
+
     @patch("payments_py.x402.facilitator_api.requests.post")
     def test_verify_surfaces_backend_code_on_4xx(self, mock_post, mock_options):
         mock_post.return_value = _http_error_response(


### PR DESCRIPTION
## Description

Switch `FacilitatorAPI.verify_permissions` and `settle_permissions` (`payments_py/x402/facilitator_api.py`) from the public (no-auth) HTTP options to the authed ones, so the SDK now sends `Authorization: Bearer <nvm_api_key>` on the x402 `/verify` and `/settle` facilitator calls.

The authed options also emit `X-Current-Org-Id` for org-pinned callers (`set_organization_id(...)`), so verify/settle now become org-scoped for those callers — not just `Authorization`.

Part of nevermined-io/nvm-monorepo#1570 (rollout step 2: SDKs send the NVM API-key header on x402 verify/settle; non-breaking — backend's optional guard tolerates it; enables the later strict-guard flip).

**Why non-breaking:** the backend `/verify`+`/settle` currently run the OPTIONAL `NvmApiHashKeyGuard` (accepts the header if present, tolerates absence), and the SDK's `nvm_api_key` is required at instantiation (always valid). Sending it now is harmless; it pre-positions for the later (breaking, separately-gated) backend flip to the strict guard.

No user-facing API change — method signatures are unchanged (internal HTTP-option swap), so no `docs/api/` update is required.

## Is this PR related with an open issue?

Related to Issue nevermined-io/nvm-monorepo#1570

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation (no doc change needed — signatures unchanged)

#### Funny gif

![](https://media.giphy.com/media/3o7TKtnuHOHHUjR38Y/giphy.gif)
