### PR TITLE
fix(docs): preserve #anchor fragments when converting internal links to Mintlify

### DIFF
--- a/scripts/convert_to_mintlify.py
+++ b/scripts/convert_to_mintlify.py
@@ -185,9 +185,13 @@ def dedent_content(content: str) -> str:
 def convert_internal_links(content: str) -> str:
     """Convert internal markdown links to Mintlify format."""
     for source, target in LINK_MAPPING.items():
-        # Match [text](filename.md) or [text](../path/filename.md)
-        pattern = rf"\[([^\]]+)\]\([^)]*{re.escape(source)}\)"
-        replacement = rf"[\1]({target})"
+        # Match [text](filename.md) or [text](../path/filename.md), preserving any
+        # trailing #anchor fragment (e.g. filename.md#section) so deep links survive
+        # the rewrite. Without the optional group the anchored form fails to match,
+        # the relative .md path leaks through into the generated Card/link, and the
+        # docs-site link-rot check fails (filename.md does not exist there).
+        pattern = rf"\[([^\]]+)\]\([^)]*{re.escape(source)}(#[^)]*)?\)"
+        replacement = rf"[\1]({target}\2)"
         content = re.sub(pattern, replacement, content)
 
     return content

--- a/tests/unit/test_convert_to_mintlify.py
+++ b/tests/unit/test_convert_to_mintlify.py
@@ -1,0 +1,56 @@
+"""Regression tests for the MkDocs->Mintlify converter's internal-link rewriting.
+
+The converter (``scripts/convert_to_mintlify.py``) rewrites payments-py's relative
+``NN-name.md`` cross-links to absolute docs-site paths. A deep link carrying an
+``#anchor`` fragment (e.g. ``09-mcp-integration.md#mcp-oauth-and-x402-discovery``)
+must keep its anchor through the rewrite -- otherwise the relative ``.md`` path
+leaks into the generated docs site and the Mintlify link-rot check fails (the
+relative file does not exist there). See nevermined-io/docs#208.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "convert_to_mintlify.py"
+_spec = importlib.util.spec_from_file_location("convert_to_mintlify", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+convert = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(convert)
+
+
+def test_unanchored_internal_link_is_rewritten():
+    md = "- [MCP Integration](09-mcp-integration.md) - x402 with MCP servers"
+    out = convert.convert_internal_links(md)
+    assert "(/docs/api-reference/python/mcp-module)" in out
+    assert "09-mcp-integration.md" not in out
+
+
+def test_anchored_internal_link_keeps_its_fragment():
+    md = "[MCP OAuth and x402 Discovery](09-mcp-integration.md#mcp-oauth-and-x402-discovery)"
+    out = convert.convert_internal_links(md)
+    assert "(/docs/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery)" in out
+    assert "09-mcp-integration.md" not in out
+
+
+def test_relative_path_prefix_with_anchor_is_rewritten():
+    md = "see [rel](../api/09-mcp-integration.md#mcp-oauth-and-x402-discovery) here"
+    out = convert.convert_internal_links(md)
+    assert "(/docs/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery)" in out
+
+
+def test_next_steps_anchored_link_becomes_card_with_docs_site_href():
+    # End-to-end through the real pipeline order: links are rewritten first, then
+    # the Next Steps section is turned into Cards. The anchored deep link must end
+    # up as an absolute docs-site href, never the relative .md form.
+    md = (
+        "## Next Steps\n\n"
+        "- [MCP Integration](09-mcp-integration.md) - x402 with MCP servers\n"
+        "- [MCP OAuth and x402 Discovery](09-mcp-integration.md#mcp-oauth-and-x402-discovery)"
+        " - Experimental MCP payment discovery metadata\n"
+    )
+    out = convert.convert_next_steps_to_cards(convert.convert_internal_links(md))
+    assert (
+        'href="/docs/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery"'
+        in out
+    )
+    assert "09-mcp-integration.md" not in out


### PR DESCRIPTION
## Problem

The auto-generated docs PR against `nevermined-io/docs` fails Mintlify's **link-rot** check (e.g. [docs#208](https://github.com/nevermined-io/docs/pull/208) for v1.11.0): *"Found 1 broken link"*.

The broken link is the new **MCP OAuth and x402 Discovery** card in `x402-module.mdx`, generated as:

```mdx
<Card ... href="09-mcp-integration.md#mcp-oauth-and-x402-discovery">
```

`09-mcp-integration.md` is a payments-py source filename — it does not exist as a path in the docs site.

## Root cause

`scripts/convert_to_mintlify.py` → `convert_internal_links` only matched cross-links whose filename was immediately followed by `)`:

```python
pattern = rf"\[([^\]]+)\]\([^)]*{re.escape(source)}\)"   # no room for #anchor
replacement = rf"[\1]({target})"                          # and would drop the anchor
```

So the **un-anchored** sibling link (`09-mcp-integration.md`) rewrote correctly to `/docs/api-reference/python/mcp-module`, but the **anchored deep link** (`09-mcp-integration.md#mcp-oauth-and-x402-discovery`) never matched, passed through untouched, and `convert_next_steps_to_cards` (which runs right after) baked the relative `.md` path into the Card.

This is a **converter** bug, not a docs-repo bug: the source markdown link is correct for payments-py's own mkdocs site (relative links resolve there) — only the Mintlify translation needed to handle the `#anchor` form.

## Fix

Capture an optional `#anchor` fragment and re-append it to the rewritten target:

```python
pattern = rf"\[([^\]]+)\]\([^)]*{re.escape(source)}(#[^)]*)?\)"
replacement = rf"[\1]({target}\2)"
```

`09-mcp-integration.md#mcp-oauth-and-x402-discovery` → `/docs/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery`.

## Verification

- New unit regression tests (`tests/unit/test_convert_to_mintlify.py`): anchored, un-anchored, relative-prefix, and the full Next-Steps→Card pipeline — 4 passed.
- Ran the real converter on `docs/api` (13 files, 0 errors): the generated `x402-module.mdx` now emits `href="/docs/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery"` with no relative `.md` leaks; the un-anchored sibling card is unchanged.
- `black --check` clean.

## Note on docs#208

The docs workflow checks out payments-py **at the release tag**, so re-running it for v1.11.0 would re-use the old converter. This fix takes effect on the next tagged release, whose regenerated docs PR will carry the corrected link. (docs#208 itself can be superseded by that PR, or its one link corrected manually.)
