### PR TITLE
fix(langsmith): lazy-load FastAPI middleware so @requires_payment imports without [langsmith]

### DIFF
--- a/payments_py/langsmith/__init__.py
+++ b/payments_py/langsmith/__init__.py
@@ -33,6 +33,12 @@ the span helpers, so eagerly importing the middleware here would force
 (``PaymentMiddleware``, ``RouteConfig``, ``X402_HEADERS``, ``build_payment_app``)
 are resolved lazily via a module-level ``__getattr__`` (PEP 562) and only
 import ``fastapi`` when first referenced.
+
+Caveat: ``from payments_py.langsmith import *`` still imports ``fastapi``,
+because a star-import iterates ``__all__`` (which lists the four middleware
+names) and so references each one. Plain ``import payments_py.langsmith`` and
+the ``@requires_payment`` decorator path -- the case this lazy import exists to
+serve -- are unaffected.
 """
 
 from typing import TYPE_CHECKING, Any
@@ -85,11 +91,17 @@ def __getattr__(name: str) -> Any:
     if name in _MIDDLEWARE_EXPORTS:
         from payments_py.langsmith import middleware
 
-        return getattr(middleware, name)
+        value = getattr(middleware, name)
+        # Cache into the module namespace so subsequent lookups resolve
+        # directly and skip __getattr__ entirely (canonical PEP 562 idiom).
+        globals()[name] = value
+        return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__() -> list[str]:
+    # __all__ is defined below this function; it is read at call time (not at
+    # definition time), so referencing it here is safe.
     return sorted(__all__)
 
 

--- a/payments_py/langsmith/__init__.py
+++ b/payments_py/langsmith/__init__.py
@@ -35,7 +35,7 @@ are resolved lazily via a module-level ``__getattr__`` (PEP 562) and only
 import ``fastapi`` when first referenced.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from payments_py.langsmith.spans import (
     abbreviate_token,
@@ -48,6 +48,18 @@ from payments_py.langsmith.spans import (
     settlement_span,
     verify_span,
 )
+
+if TYPE_CHECKING:
+    # Static-analysis / IDE only: lets Pyright resolve the four lazily
+    # re-exported middleware names (and silences reportUnsupportedDunderAll)
+    # without importing fastapi. This block is never executed at runtime, so
+    # the lazy, fastapi-free import path below is unaffected.
+    from payments_py.langsmith.middleware import (
+        PaymentMiddleware,
+        RouteConfig,
+        X402_HEADERS,
+        build_payment_app,
+    )
 
 # Symbols re-exported from the FastAPI-dependent middleware module. Loaded
 # lazily by __getattr__ below so that importing this package (e.g. via the

--- a/payments_py/langsmith/__init__.py
+++ b/payments_py/langsmith/__init__.py
@@ -23,14 +23,20 @@ LangSmith traces::
         settlement = payments.facilitator.settle_permissions(...)
         if span is not None:
             span.add_metadata(build_settle_metadata(settlement, ["plan-1"]))
+
+Lazy middleware imports. The ``spans`` helpers are pure-Python and import
+eagerly, but the ASGI middleware in ``payments_py.langsmith.middleware``
+depends on ``fastapi``/``starlette``, which only ship with the ``[langsmith]``
+extra. The ``@requires_payment`` decorator pulls in this package solely for
+the span helpers, so eagerly importing the middleware here would force
+``fastapi`` on every tool-time user. To avoid that, the middleware re-exports
+(``PaymentMiddleware``, ``RouteConfig``, ``X402_HEADERS``, ``build_payment_app``)
+are resolved lazily via a module-level ``__getattr__`` (PEP 562) and only
+import ``fastapi`` when first referenced.
 """
 
-from payments_py.langsmith.middleware import (
-    PaymentMiddleware,
-    RouteConfig,
-    X402_HEADERS,
-    build_payment_app,
-)
+from typing import Any
+
 from payments_py.langsmith.spans import (
     abbreviate_token,
     active_run_tree,
@@ -42,6 +48,38 @@ from payments_py.langsmith.spans import (
     settlement_span,
     verify_span,
 )
+
+# Symbols re-exported from the FastAPI-dependent middleware module. Loaded
+# lazily by __getattr__ below so that importing this package (e.g. via the
+# @requires_payment decorator) does not require the [langsmith] extra.
+_MIDDLEWARE_EXPORTS = frozenset(
+    {
+        "PaymentMiddleware",
+        "RouteConfig",
+        "X402_HEADERS",
+        "build_payment_app",
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve middleware re-exports (PEP 562).
+
+    Importing ``payments_py.langsmith.middleware`` pulls in ``fastapi``, so we
+    defer it until one of its symbols is actually referenced. A missing
+    ``fastapi`` therefore surfaces as an ``ImportError`` at first reference of a
+    middleware symbol, not at package import time.
+    """
+    if name in _MIDDLEWARE_EXPORTS:
+        from payments_py.langsmith import middleware
+
+        return getattr(middleware, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 __all__ = [
     "PaymentMiddleware",

--- a/tests/unit/langsmith/test_lazy_middleware_import.py
+++ b/tests/unit/langsmith/test_lazy_middleware_import.py
@@ -120,6 +120,27 @@ def test_middleware_symbols_resolve_lazily(monkeypatch, symbol):
     assert "payments_py.langsmith.middleware" in sys.modules
 
 
+def test_from_import_resolves_middleware_symbols(monkeypatch):
+    """The headline ``from payments_py.langsmith import …`` form works.
+
+    PEP 562 ``__getattr__`` fires for ``from package import name`` too, not just
+    attribute access — this pins the exact user-facing import promised in the
+    acceptance criteria against future regression. ``importlib.__import__`` with
+    a ``fromlist`` is what the ``from … import`` statement compiles to, so it
+    exercises the same code path after a fresh (cache-cleared) package import.
+    """
+    _fresh_import(monkeypatch)
+
+    pkg = importlib.__import__(
+        "payments_py.langsmith",
+        fromlist=["PaymentMiddleware", "build_payment_app"],
+    )
+    from payments_py.langsmith import middleware
+
+    assert pkg.PaymentMiddleware is middleware.PaymentMiddleware
+    assert pkg.build_payment_app is middleware.build_payment_app
+
+
 def test_unknown_attribute_raises_attribute_error(monkeypatch):
     """``__getattr__`` only handles known exports; others raise AttributeError."""
     module = _fresh_import(monkeypatch)

--- a/tests/unit/langsmith/test_lazy_middleware_import.py
+++ b/tests/unit/langsmith/test_lazy_middleware_import.py
@@ -96,10 +96,14 @@ def test_requires_payment_imports_without_fastapi(monkeypatch):
 
 
 def test_referencing_middleware_symbol_without_fastapi_raises(monkeypatch):
-    """Touching a middleware re-export with no ``fastapi`` raises ImportError."""
+    """Touching a middleware re-export with no ``fastapi`` raises the missing-dep error.
+
+    ``ModuleNotFoundError`` is the precise type (a subclass of ``ImportError``)
+    raised when ``fastapi`` cannot be imported.
+    """
     module = _fresh_import(monkeypatch, blocked={"fastapi"})
 
-    with pytest.raises(ImportError):
+    with pytest.raises(ModuleNotFoundError):
         _ = module.PaymentMiddleware
 
 
@@ -124,21 +128,20 @@ def test_from_import_resolves_middleware_symbols(monkeypatch):
     """The headline ``from payments_py.langsmith import …`` form works.
 
     PEP 562 ``__getattr__`` fires for ``from package import name`` too, not just
-    attribute access — this pins the exact user-facing import promised in the
-    acceptance criteria against future regression. ``importlib.__import__`` with
-    a ``fromlist`` is what the ``from … import`` statement compiles to, so it
-    exercises the same code path after a fresh (cache-cleared) package import.
+    attribute access. This pins the exact user-facing import promised in the
+    acceptance criteria against future regression. We run the literal
+    ``from … import`` statement (which compiles to the ``IMPORT_FROM`` bytecode
+    the real user code uses) *after* ``_fresh_import`` has cleared the package
+    from ``sys.modules``, so the statement re-imports it and resolves both names
+    through ``__getattr__``.
     """
     _fresh_import(monkeypatch)
 
-    pkg = importlib.__import__(
-        "payments_py.langsmith",
-        fromlist=["PaymentMiddleware", "build_payment_app"],
-    )
+    from payments_py.langsmith import PaymentMiddleware, build_payment_app
     from payments_py.langsmith import middleware
 
-    assert pkg.PaymentMiddleware is middleware.PaymentMiddleware
-    assert pkg.build_payment_app is middleware.build_payment_app
+    assert PaymentMiddleware is middleware.PaymentMiddleware
+    assert build_payment_app is middleware.build_payment_app
 
 
 def test_unknown_attribute_raises_attribute_error(monkeypatch):

--- a/tests/unit/langsmith/test_lazy_middleware_import.py
+++ b/tests/unit/langsmith/test_lazy_middleware_import.py
@@ -1,0 +1,151 @@
+"""Unit tests for the lazy (PEP 562) middleware import in ``payments_py.langsmith``.
+
+The ``@requires_payment`` decorator imports ``payments_py.langsmith.spans`` for
+its ``nvm:verify``/``nvm:settlement`` spans, which resolves the
+``payments_py.langsmith`` package. Historically the package ``__init__`` eagerly
+re-exported the FastAPI-based middleware, so importing it (and therefore using
+``@requires_payment`` at tool time) required the ``[langsmith]`` extra even when
+no HTTP app was in play (issue #1825).
+
+These tests pin the fixed behaviour:
+
+* importing the package and ``requires_payment`` does NOT import the
+  FastAPI-dependent middleware module;
+* the package imports even when ``fastapi`` is unavailable;
+* referencing a middleware re-export triggers the lazy import (and would raise
+  ``ImportError`` if ``fastapi`` were missing);
+* introspection (``__all__``/``dir``) still lists every public symbol.
+"""
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def _fresh_import(monkeypatch, blocked=()):
+    """Re-import ``payments_py.langsmith`` (and its submodules) from scratch.
+
+    Any module name listed in ``blocked`` raises ``ModuleNotFoundError`` on
+    import, simulating an environment where that dependency is not installed.
+    Returns the freshly imported ``payments_py.langsmith`` module.
+    """
+    for name in list(sys.modules):
+        if name == "payments_py.langsmith" or name.startswith("payments_py.langsmith."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    if blocked:
+        real_import = builtins.__import__
+
+        def _guarded_import(name, *args, **kwargs):
+            top = name.split(".")[0]
+            if name in blocked or top in blocked:
+                raise ModuleNotFoundError(f"No module named {top!r}")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _guarded_import)
+        # Hide any already-imported copies so the guard is actually exercised.
+        for name in list(sys.modules):
+            if name in blocked or name.split(".")[0] in blocked:
+                monkeypatch.delitem(sys.modules, name, raising=False)
+
+    return importlib.import_module("payments_py.langsmith")
+
+
+def test_importing_package_does_not_import_middleware(monkeypatch):
+    """Importing the package must not pull in the FastAPI middleware module."""
+    _fresh_import(monkeypatch)
+    assert "payments_py.langsmith.middleware" not in sys.modules
+
+
+def test_requires_payment_imports_without_middleware(monkeypatch):
+    """``from payments_py.x402.langchain import requires_payment`` is light."""
+    for name in list(sys.modules):
+        if name.startswith("payments_py.langsmith") or name.startswith(
+            "payments_py.x402.langchain"
+        ):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    from payments_py.x402.langchain import requires_payment  # noqa: F401
+
+    assert "payments_py.langsmith.middleware" not in sys.modules
+
+
+def test_package_imports_without_fastapi(monkeypatch):
+    """The package must import even when ``fastapi`` is not installed."""
+    module = _fresh_import(monkeypatch, blocked={"fastapi"})
+
+    # Spans helpers are eagerly available and FastAPI-free.
+    assert callable(module.settlement_span)
+    assert callable(module.verify_span)
+    assert "payments_py.langsmith.middleware" not in sys.modules
+
+
+def test_requires_payment_imports_without_fastapi(monkeypatch):
+    """The langchain decorator path imports without ``fastapi`` present."""
+    _fresh_import(monkeypatch, blocked={"fastapi"})
+    for name in list(sys.modules):
+        if name.startswith("payments_py.x402.langchain"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    langchain = importlib.import_module("payments_py.x402.langchain")
+
+    assert hasattr(langchain, "requires_payment")
+    assert "payments_py.langsmith.middleware" not in sys.modules
+
+
+def test_referencing_middleware_symbol_without_fastapi_raises(monkeypatch):
+    """Touching a middleware re-export with no ``fastapi`` raises ImportError."""
+    module = _fresh_import(monkeypatch, blocked={"fastapi"})
+
+    with pytest.raises(ImportError):
+        _ = module.PaymentMiddleware
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    ["PaymentMiddleware", "RouteConfig", "X402_HEADERS", "build_payment_app"],
+)
+def test_middleware_symbols_resolve_lazily(monkeypatch, symbol):
+    """Each middleware re-export resolves via the lazy import when available."""
+    module = _fresh_import(monkeypatch)
+    assert "payments_py.langsmith.middleware" not in sys.modules
+
+    resolved = getattr(module, symbol)
+
+    from payments_py.langsmith import middleware
+
+    assert resolved is getattr(middleware, symbol)
+    assert "payments_py.langsmith.middleware" in sys.modules
+
+
+def test_unknown_attribute_raises_attribute_error(monkeypatch):
+    """``__getattr__`` only handles known exports; others raise AttributeError."""
+    module = _fresh_import(monkeypatch)
+
+    with pytest.raises(AttributeError):
+        _ = module.DefinitelyNotAThing
+
+
+def test_all_lists_every_public_symbol(monkeypatch):
+    """``__all__`` and ``dir`` still advertise the full public surface."""
+    module = _fresh_import(monkeypatch)
+
+    expected = {
+        "PaymentMiddleware",
+        "RouteConfig",
+        "X402_HEADERS",
+        "build_payment_app",
+        "abbreviate_token",
+        "active_run_tree",
+        "add_metadata",
+        "attach_metadata_safely",
+        "build_settle_metadata",
+        "build_verify_metadata",
+        "redact_metadata_keys",
+        "settlement_span",
+        "verify_span",
+    }
+    assert set(module.__all__) == expected
+    assert expected.issubset(set(dir(module)))


### PR DESCRIPTION
## Description

The `payments_py.langsmith` package `__init__` eagerly re-exported the
FastAPI-based middleware module. Because the `@requires_payment` decorator
imports `payments_py.langsmith.spans` for its `nvm:verify`/`nvm:settlement`
spans — which resolves the `payments_py.langsmith` package — every tool-time
user was forced to install `payments-py[langsmith]` (which carries
`fastapi`/`starlette`) even when running no HTTP app:

```
from payments_py.x402.langchain import requires_payment
# ModuleNotFoundError: No module named 'fastapi'   (without the [langsmith] extra)
```

**Fix (option (a) from the issue):** move the middleware re-exports
(`PaymentMiddleware`, `RouteConfig`, `X402_HEADERS`, `build_payment_app`) out
of the eager top-level import and behind a module-level `__getattr__` (PEP 562).
They now import `fastapi` only when one of those symbols is first referenced.
The pure-Python `spans` helpers stay eagerly imported. `__all__` is unchanged
and a `__dir__` keeps introspection/IDE completion listing the full surface, so
`from payments_py.langsmith import PaymentMiddleware, build_payment_app` works
exactly as before when the extra is installed. A missing `fastapi` now surfaces
as an `ImportError` at first reference of a middleware symbol (correct), not at
package import time.

### Acceptance criteria (all verified)

- `pip install payments-py` (no extras) → `from payments_py.x402.langchain import requires_payment` succeeds.
- `pip install payments-py[langsmith]` → `from payments_py.langsmith import PaymentMiddleware, build_payment_app` works unchanged.
- Existing `[langsmith]` unit tests pass (66 in `tests/unit/langsmith/`; 545 in `tests/unit` overall).
- The `langchain-research-agent-py` tutorial can drop the `[langsmith]` extra and still import. (Tutorial intentionally not modified in this PR — only the import path is fixed.)

### Tests

New `tests/unit/langsmith/test_lazy_middleware_import.py` (11 cases) covers:
importing the package / `requires_payment` does not load the middleware module;
the package imports with `fastapi` blocked from `sys.modules`; referencing a
middleware symbol without `fastapi` raises `ImportError`; each re-export resolves
lazily; unknown attrs raise `AttributeError`; and `__all__`/`dir()` advertise the
full public surface.

## Is this PR related with an open issue?

Part of epic nevermined-io/nvm-monorepo#1703
Closes nevermined-io/nvm-monorepo#1825

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation (no doc changes needed — the public import surface is unchanged; `docs/api/13-langsmith-deployment.md` examples continue to work)

#### Funny gif

![lazy loading](https://media.giphy.com/media/DBfYJqH5AYY9q/giphy.gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)