### PR TITLE
fix(langchain): mirror TS parity fixes for stale receipt + token leak

### DIFF
--- a/payments_py/x402/langchain/decorator.py
+++ b/payments_py/x402/langchain/decorator.py
@@ -111,14 +111,22 @@ def last_settlement() -> Optional[SettleResponse]:
     ``network``, ``payer``) without threading it back through the
     runnable config (which LangGraph copies per node).
 
-    Returns ``None`` if no settlement has happened yet in this process, or
-    if the most recent invocation raised before reaching the settle phase.
+    Returns ``None`` if no settlement has happened yet in this process, or if
+    the most recent invocation did not reach a *successful* settle — i.e. it
+    raised before the settle phase (a verify failure / ``PaymentRequiredError``)
+    **or** it reached settle but settlement failed (settle errors are swallowed
+    and logged, so the tool still returns its result while ``last_settlement()``
+    stays ``None``). The slot is reset to ``None`` at the start of every
+    invocation, so a prior invocation's receipt is never misattributed to a
+    later call that failed to settle.
 
     .. note::
        This accessor reads from a module-level slot. In multi-tenant
        processes (e.g. a server handling concurrent settlements), the value
        reflects whichever invocation settled most recently — there is no
-       per-call isolation.
+       per-call isolation. Because the slot is also reset on entry, a
+       concurrent invocation that merely *starts* (even one that fails verify)
+       nulls a sibling's freshly written receipt.
     """
     return _LAST_SETTLEMENT["value"]
 
@@ -194,6 +202,19 @@ def _store_in_configurable(config: Any, key: str, value: Any) -> None:
         configurable[key] = value
 
 
+def _remove_from_configurable(config: Any, key: str) -> None:
+    """Remove a key from config["configurable"] if present (no-op otherwise)."""
+    if config is None:
+        return
+    configurable = None
+    if isinstance(config, dict):
+        configurable = config.get("configurable")
+    else:
+        configurable = getattr(config, "configurable", None)
+    if isinstance(configurable, dict):
+        configurable.pop(key, None)
+
+
 def _verify_payment(
     func: Callable,
     kwargs: dict,
@@ -254,6 +275,22 @@ def _verify_payment(
                 "Payment required: missing payment_token in config['configurable']",
                 payment_required,
             )
+
+        # Drop the raw token from configurable now that we hold it in ``token``
+        # (and, below, in ``_VerifiedPayment.token``). LangChain's
+        # ``ensure_config`` re-promotes every configurable scalar into a
+        # runnable's ``metadata`` on EACH invocation, so any traced runnable the
+        # tool body spawns (an LLM call, a sub-chain) sharing this config would
+        # otherwise re-leak the full credential into its own span metadata —
+        # ``redact_metadata_keys`` above only scrubs the parent run-tree once.
+        # This MUST run after extraction (popping earlier would make
+        # ``_extract_payment_token`` return None) and before the tool body runs,
+        # which is guaranteed: ``_verify_payment`` completes before ``func`` is
+        # called. Settlement reads ``_VerifiedPayment.token``, never configurable,
+        # so removal is non-functional. On the ``@tool`` path LangChain hands the
+        # decorator a per-invocation config copy, so this does not mutate a config
+        # the caller reuses across sibling tools.
+        _remove_from_configurable(runnable_config, "payment_token")
 
         credits_pre = _resolve_credits_pre(config.credits, kwargs)
         # For verification, use pre-resolved credits or default to 1

--- a/payments_py/x402/langchain/decorator.py
+++ b/payments_py/x402/langchain/decorator.py
@@ -68,6 +68,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
 from payments_py.langsmith.spans import (
+    abbreviate_token,
     active_run_tree,
     attach_metadata_safely,
     build_settle_metadata,
@@ -288,8 +289,19 @@ def _verify_payment(
                 payment_required,
             )
 
+    # The ``token`` field carries the ABBREVIATED reference, never the raw
+    # credential: this PaymentContext is written into ``config["configurable"]``,
+    # which LangChain can capture into span metadata, so persisting the full
+    # token here would reopen the very leak the parent-tree
+    # ``redact_metadata_keys("payment_token")`` call above closes — and a child
+    # run opened *during* the tool body would capture it before any post-hoc
+    # redaction could run. Settlement uses ``_VerifiedPayment.token`` (the raw
+    # token in the internal container below), never this field, so abbreviating
+    # here is non-functional. ``abbreviate_token`` is the same helper surfaced as
+    # ``nvm.payment_token``; ``or ""`` is belt-and-suspenders past the ``not
+    # token`` guard above and can never fall back to the raw credential.
     payment_context = PaymentContext(
-        token=token,
+        token=abbreviate_token(token) or "",
         payment_required=payment_required,
         credits_to_settle=credits_to_charge,
         verified=True,
@@ -493,6 +505,12 @@ def _execute_with_payment(
     config: _PaymentConfig,
 ) -> Any:
     """Synchronous payment verification, execution, and settlement."""
+    # Reset the module-level receipt slot at the START of every invocation,
+    # before verify. Any failure that does not reach the settle-success write
+    # (a verify failure / PaymentRequiredError, or a swallowed settle failure)
+    # then leaves last_settlement() returning None rather than a stale receipt
+    # from a previous invocation — matching the last_settlement() docstring.
+    _LAST_SETTLEMENT["value"] = None
     runnable_config = _extract_runnable_config(kwargs)
     verified = _verify_payment(func, kwargs, config, runnable_config)
     result = func(*args, **kwargs)
@@ -507,6 +525,10 @@ async def _execute_with_payment_async(
     config: _PaymentConfig,
 ) -> Any:
     """Async payment verification, execution, and settlement."""
+    # Reset the receipt slot at the start of the invocation, before verify —
+    # see _execute_with_payment for the rationale. Both entry points must do
+    # this so the stale-receipt guard holds on the async path too.
+    _LAST_SETTLEMENT["value"] = None
     runnable_config = _extract_runnable_config(kwargs)
     verified = _verify_payment(func, kwargs, config, runnable_config)
     result = await func(*args, **kwargs)

--- a/payments_py/x402/types.py
+++ b/payments_py/x402/types.py
@@ -282,6 +282,20 @@ class PaymentContext:
     Populated by middleware/decorators and made available to handlers:
     - FastAPI: ``request.state.payment_context``
     - Strands: ``tool_context.invocation_state["payment_context"]``
+
+    .. warning::
+       The ``token`` field is **producer-dependent** and must not be assumed to
+       be the functional credential. The FastAPI / Starlette middlewares store
+       the **raw** x402 access token here on purpose: they strip the
+       ``payment-signature`` request header before calling the route handler, so
+       ``payment_context.token`` is the handler's only remaining source for it.
+       The LangChain ``requires_payment`` decorator, by contrast, stores an
+       **abbreviated, non-functional** reference (the same ``<first 16>…<last 4>``
+       form surfaced as ``nvm.payment_token``): its context object is written
+       into ``config["configurable"]``, which tracing frameworks can capture into
+       span metadata, so persisting the raw token there would leak it into nested
+       runs. Code that needs the raw token under the decorator must read it from
+       ``config["configurable"]["payment_token"]``, never from this field.
     """
 
     token: str

--- a/tests/unit/x402/test_langchain_decorator.py
+++ b/tests/unit/x402/test_langchain_decorator.py
@@ -99,6 +99,44 @@ class TestRequiresPaymentDecorator:
 
         assert result == "insight for x"
 
+    def test_payment_context_stores_only_abbreviated_token(self, mock_payments):
+        """The stored payment_context carries the ABBREVIATED token, never the
+        raw credential (nvm-monorepo#1891).
+
+        ``payment_context`` is written into ``config["configurable"]``, which
+        LangChain can capture into span metadata, so a raw token here would let
+        the credential ride into a nested span opened during the tool body — the
+        gap aaitor flagged on the TS port. We invoke the bare ``@requires_payment``
+        wrapper directly (not through ``@tool``, which deep-copies the config) so
+        the decorator mutates the same configurable bag we then read back.
+        """
+        long_token = "j" * 40
+
+        @requires_payment(payments=mock_payments, plan_id="plan-123", credits=1)
+        def my_tool(topic: str, config: RunnableConfig = None) -> str:
+            """Return a canned string."""
+            return f"insight for {topic}"
+
+        config = {"configurable": {"payment_token": long_token}}
+        my_tool(topic="evs", config=config)
+
+        ctx = config["configurable"]["payment_context"]
+        assert ctx is not None
+        # Abbreviated form is <first 16>…<last 4>, the same surfaced as
+        # nvm.payment_token — not the raw 40-char credential.
+        assert ctx.token == f"{'j' * 16}…jjjj"
+        # The raw token must not appear anywhere in the stored context.
+        assert long_token not in repr(ctx)
+        # Settlement still ran with the raw token (internal _VerifiedPayment),
+        # so abbreviating payment_context.token is non-functional.
+        mock_payments.facilitator.settle_permissions.assert_called_once()
+        assert (
+            mock_payments.facilitator.settle_permissions.call_args.kwargs[
+                "x402_access_token"
+            ]
+            == long_token
+        )
+
 
 class TestLastSettlement:
     def test_returns_none_before_any_settlement(self):
@@ -149,6 +187,60 @@ class TestLastSettlement:
         my_tool = _make_protected_tool(mock_payments)
         with pytest.raises(PaymentRequiredError):
             my_tool.invoke({"topic": "x"}, config={"configurable": {}})
+        assert last_settlement() is None
+
+    def test_none_after_prior_success_then_failed_settle(self, mock_payments):
+        """Regression for the stale-receipt bug (nvm-monorepo#1890).
+
+        Tool A settles, then tool B's settle throws (swallowed). Without
+        resetting the slot on each invocation, last_settlement() would still
+        return A's receipt and misattribute it to B. The wrapper resets the slot
+        at the START of every invocation, so a failed settle after a prior
+        success leaves it None — matching the last_settlement() docstring.
+        """
+        my_tool = _make_protected_tool(mock_payments)
+
+        # First invocation settles successfully and populates the slot.
+        my_tool.invoke(
+            {"topic": "a"}, config={"configurable": {"payment_token": "tok"}}
+        )
+        assert last_settlement().credits_redeemed == "1"
+
+        # Second invocation's settle throws (swallowed); the slot must not
+        # retain A's receipt.
+        mock_payments.facilitator.settle_permissions.side_effect = RuntimeError("boom")
+        result = my_tool.invoke(
+            {"topic": "b"}, config={"configurable": {"payment_token": "tok"}}
+        )
+
+        assert result == "insight for b"
+        assert last_settlement() is None
+
+    def test_none_after_prior_success_then_verify_failure(self, mock_payments):
+        """Regression for the stale-receipt bug (nvm-monorepo#1890), verify path.
+
+        A verify failure raises PaymentRequiredError before reaching settle. The
+        start-of-invocation reset must clear a prior invocation's receipt so the
+        slot is None for ANY pre-settle failure, not just settle failures.
+        """
+        my_tool = _make_protected_tool(mock_payments)
+
+        # First invocation settles successfully and populates the slot.
+        my_tool.invoke(
+            {"topic": "a"}, config={"configurable": {"payment_token": "tok"}}
+        )
+        assert last_settlement().credits_redeemed == "1"
+
+        # Second invocation fails verification before reaching settle.
+        mock_payments.facilitator.verify_permissions.return_value = VerifyResponse(
+            is_valid=False,
+            invalid_reason="Insufficient credits",
+        )
+        with pytest.raises(PaymentRequiredError):
+            my_tool.invoke(
+                {"topic": "b"}, config={"configurable": {"payment_token": "tok"}}
+            )
+
         assert last_settlement() is None
 
 

--- a/tests/unit/x402/test_langchain_decorator.py
+++ b/tests/unit/x402/test_langchain_decorator.py
@@ -99,16 +99,23 @@ class TestRequiresPaymentDecorator:
 
         assert result == "insight for x"
 
-    def test_payment_context_stores_only_abbreviated_token(self, mock_payments):
-        """The stored payment_context carries the ABBREVIATED token, never the
-        raw credential (nvm-monorepo#1891).
+    def test_no_raw_token_survives_in_configurable(self, mock_payments):
+        """Neither payment_context.token nor the raw payment_token key leaks the
+        full credential into config["configurable"] (nvm-monorepo#1891 + the
+        residual child-runnable leak aaitor flagged on PR #219).
 
-        ``payment_context`` is written into ``config["configurable"]``, which
-        LangChain can capture into span metadata, so a raw token here would let
-        the credential ride into a nested span opened during the tool body — the
-        gap aaitor flagged on the TS port. We invoke the bare ``@requires_payment``
-        wrapper directly (not through ``@tool``, which deep-copies the config) so
-        the decorator mutates the same configurable bag we then read back.
+        Two leak surfaces are closed:
+        - ``payment_context.token`` stores the ABBREVIATED reference, not the raw
+          token (the field is non-functional; settle uses the internal
+          ``_VerifiedPayment.token``).
+        - the raw ``payment_token`` key is POPPED from configurable after
+          extraction, so a traced child runnable the tool body spawns can't have
+          LangChain's ``ensure_config`` re-promote it into the child's span
+          metadata.
+
+        We invoke the bare ``@requires_payment`` wrapper directly (not through
+        ``@tool``, which deep-copies the config) so the decorator mutates the same
+        configurable bag we then read back.
         """
         long_token = "j" * 40
 
@@ -120,15 +127,20 @@ class TestRequiresPaymentDecorator:
         config = {"configurable": {"payment_token": long_token}}
         my_tool(topic="evs", config=config)
 
-        ctx = config["configurable"]["payment_context"]
+        configurable = config["configurable"]
+        ctx = configurable["payment_context"]
         assert ctx is not None
         # Abbreviated form is <first 16>…<last 4>, the same surfaced as
         # nvm.payment_token — not the raw 40-char credential.
         assert ctx.token == f"{'j' * 16}…jjjj"
-        # The raw token must not appear anywhere in the stored context.
-        assert long_token not in repr(ctx)
+        # Sweep every PaymentContext field — guards future leak surfaces too.
+        for name, value in vars(ctx).items():
+            assert long_token not in str(value), f"raw token leaked in .{name}"
+        # The raw payment_token key was removed from configurable, so any child
+        # runnable sharing this config sees no credential to re-promote.
+        assert "payment_token" not in configurable
         # Settlement still ran with the raw token (internal _VerifiedPayment),
-        # so abbreviating payment_context.token is non-functional.
+        # so removing it from configurable is non-functional.
         mock_payments.facilitator.settle_permissions.assert_called_once()
         assert (
             mock_payments.facilitator.settle_permissions.call_args.kwargs[
@@ -241,6 +253,40 @@ class TestLastSettlement:
                 {"topic": "b"}, config={"configurable": {"payment_token": "tok"}}
             )
 
+        assert last_settlement() is None
+
+    @pytest.mark.asyncio
+    async def test_none_after_prior_success_then_failed_settle_async(
+        self, mock_payments
+    ):
+        """Async twin of the stale-receipt reset (nvm-monorepo#1890).
+
+        The reset lives in _execute_with_payment_async too. Both sync regressions
+        drive ``.invoke``; without this, dropping ONLY the async reset line would
+        silently regress every ``async def`` tool to stale receipts and the suite
+        would still pass.
+        """
+
+        @tool
+        @requires_payment(payments=mock_payments, plan_id="plan-123", credits=1)
+        async def my_tool(topic: str, config: RunnableConfig = None) -> str:
+            """Return a canned string."""
+            return f"insight for {topic}"
+
+        # First invocation settles successfully and populates the slot.
+        await my_tool.ainvoke(
+            {"topic": "a"}, config={"configurable": {"payment_token": "tok"}}
+        )
+        assert last_settlement().credits_redeemed == "1"
+
+        # Second invocation's settle throws (swallowed); the slot must not
+        # retain A's receipt on the async path either.
+        mock_payments.facilitator.settle_permissions.side_effect = RuntimeError("boom")
+        result = await my_tool.ainvoke(
+            {"topic": "b"}, config={"configurable": {"payment_token": "tok"}}
+        )
+
+        assert result == "insight for b"
         assert last_settlement() is None
 
 


### PR DESCRIPTION
## What

Two parity follow-ups in `payments_py/x402/langchain/decorator.py`, mirroring fixes already merged on the TypeScript side (`@nevermined-io/payments` PRs #370 and #371) and tracked under epic nevermined-io/nvm-monorepo#1703. A second commit folds in aaitor's review.

### 1. Reset `last_settlement()` at invocation start — nevermined-io/nvm-monorepo#1890

The module-level receipt slot was only written on settle-success and never reset. After a prior successful settle, a subsequent invocation that failed before/at settle (a verify `PaymentRequiredError`, or a swallowed settle failure) left `last_settlement()` returning the **prior** call's receipt — misattributing its `transaction` / `credits_redeemed`.

**Fix:** reset the slot to `None` at the start of both the sync and async entry points, before verify, so any pre-settle failure yields `None`. The public `last_settlement()` docstring is updated to cover the swallowed-settle-failure case. Mirrors TS `95326a8`.

### 2. Stop leaking the raw token through `config.configurable` — nevermined-io/nvm-monorepo#1891 (+ residual leak from review)

Two leak surfaces, both closed:

- **`payment_context.token`** now stores `abbreviate_token(token)` (the non-functional `<first 16>…<last 4>` form surfaced as `nvm.payment_token`), not the raw credential. Mirrors TS `6bc08a6`.
- **the raw `payment_token` key** is now popped from `config.configurable` immediately after extraction. LangChain's `ensure_config` re-promotes configurable scalars into each runnable's `metadata`, so a traced child runnable spawned by the tool body would otherwise re-leak the full credential into its own span — `redact_metadata_keys` only scrubs the parent run-tree once. (Surfaced by aaitor's review; reverse-parity tracked for TS in nevermined-io/nvm-monorepo#1901.)

Settlement reads the raw token from the internal `_VerifiedPayment` container, never `configurable` or `payment_context.token`, so both removals are non-functional. On the `@tool` path LangChain hands the decorator a per-invocation config copy, so sibling tools are unaffected.

## Note on the shared `PaymentContext` type

Unlike the TS `PaymentContext` (langchain-local), the Python one is **shared** with the FastAPI/Starlette middlewares, which legitimately store the **raw** token (they strip the `payment-signature` header, so it's the handler's only source). So the `PaymentContext.token` docstring (`x402/types.py`) gains a **producer-aware** warning rather than a blanket "always abbreviated" claim. No middleware behaviour changed.

## Tests

- +2 stale-receipt regressions (sync: `prior-success → failed-settle → None`, `… → verify-failure → None`) **+1 async** (`…_async`) so the async reset line can't silently regress
- +1 leak test: `payment_context.token` is abbreviated, **every** `PaymentContext` field is swept for the raw token, the raw `payment_token` key is gone from `configurable`, and settle still ran with the raw token

`black --check` clean; targeted unit suites green (60 passed in ~0.5s). Package version intentionally **not** bumped — the release pipeline owns it.

> ℹ️ The linked issues live in `nvm-monorepo`, so GitHub's auto-close won't fire cross-repo on merge — they'll be closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)