### PR TITLE
feat(langsmith): build_payment_app optional on langgraph-api >= 0.6.15

### DIFF
--- a/payments_py/langsmith/middleware.py
+++ b/payments_py/langsmith/middleware.py
@@ -557,9 +557,13 @@ def build_payment_app(
             Middleware(PaymentMiddleware, payments=payments, routes={...}),
         ])
 
-    On ``langgraph-api >= 0.6.15`` this factory emits a ``DeprecationWarning``
-    pointing at the plain-Starlette form above. It remains useful on older
-    ``langgraph-api`` (where the FastAPI wrapper is still load-bearing). The
+    On ``langgraph-api >= 0.6.15`` this factory emits a ``UserWarning``
+    pointing at the plain-Starlette form above. (``UserWarning`` rather than
+    ``DeprecationWarning`` so the nudge is actually visible at app startup —
+    ``DeprecationWarning`` is suppressed by default outside ``__main__``/pytest;
+    and the factory is not being removed, only made optional.) It remains useful
+    on older ``langgraph-api`` (where the FastAPI wrapper is still load-bearing).
+    The
     middleware class itself (``PaymentMiddleware``) is a Starlette
     ``BaseHTTPMiddleware`` subclass and works on both Starlette and FastAPI —
     only the outer app wrapper ever mattered for the upstream bug.
@@ -597,8 +601,9 @@ def build_payment_app(
             f"langgraph-api >= {fix} (detected "
             f"{'.'.join(str(p) for p in detected)}). Mount PaymentMiddleware "
             f"directly on a plain Starlette http.app instead: "
-            f"app.add_middleware(PaymentMiddleware, payments=..., routes=...).",
-            DeprecationWarning,
+            f"Starlette(middleware=[Middleware(PaymentMiddleware, "
+            f"payments=..., routes=...)]).",
+            UserWarning,
             stacklevel=2,
         )
     app = FastAPI()

--- a/payments_py/langsmith/middleware.py
+++ b/payments_py/langsmith/middleware.py
@@ -30,13 +30,16 @@ more than payment gating.
 import asyncio
 import base64
 import contextlib
+import importlib.metadata
 import inspect
 import logging
 import posixpath
+import re
 import time
+import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Dict, Iterator, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, Iterator, Optional, Tuple, Union
 
 from fastapi import FastAPI
 from starlette.datastructures import MutableHeaders
@@ -497,28 +500,69 @@ class PaymentMiddleware(BaseHTTPMiddleware):
             return _send_payment_required(payment_required, rejection.message)
 
 
+# langgraph-api version that fixed the OpenAPI-docstring crash on non-FastAPI
+# http.app wrappers. In <0.6.15, ``SchemaGenerator.get_schema`` caught only
+# ``AssertionError`` around ``parse_docstring``, so a YAML ``ScannerError`` from
+# an internal endpoint docstring with an unsafe colon propagated and crashed
+# startup. 0.6.15 broadened the catch to ``except Exception`` (degrades to a
+# plain description + a logged warning), so a plain Starlette ``http.app`` boots
+# cleanly. Empirically bisected (0.6.14 crashes, 0.6.15 boots) and verified
+# end-to-end on 0.8.7 — see nevermined-io/nvm-monorepo#1762.
+_LANGGRAPH_API_DOCSTRING_FIX: Tuple[int, int, int] = (0, 6, 15)
+
+
+def _langgraph_api_version() -> Optional[Tuple[int, ...]]:
+    """Return the installed ``langgraph-api`` version as an int tuple, or None.
+
+    Best-effort and fully defensive: returns ``None`` if the package is absent
+    or the version string can't be parsed (e.g. an exotic pre-release). Only the
+    leading integer of each of the first three dot components is used, so
+    ``"0.6.15"`` → ``(0, 6, 15)`` and ``"0.6.15rc1"`` → ``(0, 6, 15)``.
+    """
+    try:
+        raw = importlib.metadata.version("langgraph-api")
+        parts = []
+        for component in raw.split(".")[:3]:
+            match = re.match(r"\d+", component)
+            parts.append(int(match.group()) if match else 0)
+        return tuple(parts)
+    except Exception:
+        return None
+
+
 def build_payment_app(
     payments: Any,
     routes: Optional[Dict[str, Union[RouteConfig, dict]]] = None,
 ) -> Any:
     """Build a FastAPI app pre-wired with PaymentMiddleware for LangSmith Deployment.
 
-    This is the recommended entry point. The returned FastAPI instance is
-    intended to be mounted via the http.app field of langgraph.json.
+    Convenience factory. The returned FastAPI instance is intended to be mounted
+    via the ``http.app`` field of ``langgraph.json``.
 
-    Why a FastAPI wrapper. ``langgraph-api`` 0.5.x crashed on plain
-    Starlette ``http.app`` wrappers because its ``update_openapi_spec``
-    fell through to Starlette's ``SchemaGenerator``, which YAML-parses
-    every endpoint docstring (``api/mcp.py`` and an a2a docstring both
-    had YAML-unsafe colons that tripped the parser). FastAPI dodges this
-    via ``app.openapi()``. The specific tripper docstrings were
-    rewritten in newer ``langgraph-api`` versions, but the code-path
-    structure is unchanged and we have not empirically validated that
-    no OTHER docstring would trip it; this factory remains the
-    recommended path until that spike lands. The middleware class
-    itself (``PaymentMiddleware``) is a Starlette ``BaseHTTPMiddleware``
-    subclass and works on both Starlette and FastAPI — only the outer
-    app wrapper matters for the upstream bug.
+    Not required on ``langgraph-api >= 0.6.15``. ``langgraph-api`` 0.5.x–0.6.14
+    crashed on plain Starlette ``http.app`` wrappers because its
+    ``update_openapi_spec`` fell through to Starlette's ``SchemaGenerator``,
+    which YAML-parses every endpoint docstring; internal endpoint docstrings with
+    YAML-unsafe colons tripped the parser, and ``get_schema`` only caught
+    ``AssertionError`` — so the ``ScannerError`` crashed startup. FastAPI dodged
+    this via ``app.openapi()``. 0.6.15 broadened that catch to
+    ``except Exception`` (the bad docstring degrades to a plain description and a
+    logged warning), so a **plain Starlette** ``http.app`` now boots cleanly:
+
+        from starlette.applications import Starlette
+        from starlette.middleware import Middleware
+        from payments_py.langsmith import PaymentMiddleware, RouteConfig
+
+        app = Starlette(middleware=[
+            Middleware(PaymentMiddleware, payments=payments, routes={...}),
+        ])
+
+    On ``langgraph-api >= 0.6.15`` this factory emits a ``DeprecationWarning``
+    pointing at the plain-Starlette form above. It remains useful on older
+    ``langgraph-api`` (where the FastAPI wrapper is still load-bearing). The
+    middleware class itself (``PaymentMiddleware``) is a Starlette
+    ``BaseHTTPMiddleware`` subclass and works on both Starlette and FastAPI —
+    only the outer app wrapper ever mattered for the upstream bug.
 
     Args:
         payments: A configured payments_py.Payments instance.
@@ -545,6 +589,18 @@ def build_payment_app(
         # langgraph.json
         # { "http": { "app": "./nvm_app.py:app" } }
     """
+    detected = _langgraph_api_version()
+    if detected is not None and detected >= _LANGGRAPH_API_DOCSTRING_FIX:
+        fix = ".".join(str(p) for p in _LANGGRAPH_API_DOCSTRING_FIX)
+        warnings.warn(
+            f"build_payment_app's FastAPI wrapper is no longer required on "
+            f"langgraph-api >= {fix} (detected "
+            f"{'.'.join(str(p) for p in detected)}). Mount PaymentMiddleware "
+            f"directly on a plain Starlette http.app instead: "
+            f"app.add_middleware(PaymentMiddleware, payments=..., routes=...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     app = FastAPI()
     app.add_middleware(PaymentMiddleware, payments=payments, routes=routes or {})
     return app

--- a/tests/unit/langsmith/test_middleware.py
+++ b/tests/unit/langsmith/test_middleware.py
@@ -8,6 +8,7 @@ matching, and the settle-failure-still-returns-200 contract.
 
 import base64
 import json
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,6 +23,7 @@ from payments_py.langsmith import (
     X402_HEADERS,
     build_payment_app,
 )
+from payments_py.langsmith import middleware as ls_middleware
 from payments_py.x402.types import SettleResponse, VerifyResponse
 
 
@@ -463,3 +465,62 @@ class TestBuildPaymentApp:
         client = TestClient(app)
         # No routes + no env vars -> pass through
         assert client.get("/x").status_code == 200
+
+
+class TestBuildPaymentAppDeprecationWarning:
+    """build_payment_app warns it's optional on langgraph-api >= 0.6.15.
+
+    The spike (nvm-monorepo#1762) bisected the OpenAPI-docstring crash fix to
+    langgraph-api 0.6.15 (``get_schema`` broadened its catch to
+    ``except Exception``), so a plain Starlette http.app boots without the
+    FastAPI wrapper. #1763 surfaces that via a DeprecationWarning.
+    """
+
+    def test_warns_at_fix_version(self, mock_payments, monkeypatch):
+        monkeypatch.setattr(ls_middleware, "_langgraph_api_version", lambda: (0, 6, 15))
+        with pytest.warns(DeprecationWarning, match="no longer required"):
+            build_payment_app(payments=mock_payments, routes=None)
+
+    def test_warns_on_newer_version(self, mock_payments, monkeypatch):
+        monkeypatch.setattr(ls_middleware, "_langgraph_api_version", lambda: (0, 8, 7))
+        with pytest.warns(DeprecationWarning, match="PaymentMiddleware directly"):
+            build_payment_app(payments=mock_payments, routes=None)
+
+    def test_no_warning_below_fix_version(self, mock_payments, monkeypatch, recwarn):
+        monkeypatch.setattr(ls_middleware, "_langgraph_api_version", lambda: (0, 6, 14))
+        app = build_payment_app(payments=mock_payments, routes=None)
+        assert isinstance(app, FastAPI)
+        assert not [
+            w for w in recwarn.list if issubclass(w.category, DeprecationWarning)
+        ]
+
+    def test_no_warning_when_version_undetected(
+        self, mock_payments, monkeypatch, recwarn
+    ):
+        # langgraph-api absent / unparseable -> None -> silent, still returns app.
+        monkeypatch.setattr(ls_middleware, "_langgraph_api_version", lambda: None)
+        app = build_payment_app(payments=mock_payments, routes=None)
+        assert isinstance(app, FastAPI)
+        assert not [
+            w for w in recwarn.list if issubclass(w.category, DeprecationWarning)
+        ]
+
+
+class TestLanggraphApiVersionDetection:
+    """_langgraph_api_version parses the installed version defensively."""
+
+    def test_parses_three_components(self, monkeypatch):
+        monkeypatch.setattr("importlib.metadata.version", lambda name: "0.6.15")
+        assert ls_middleware._langgraph_api_version() == (0, 6, 15)
+
+    def test_parses_prerelease_component(self, monkeypatch):
+        # A pre-release suffix on the patch component is stripped to its int.
+        monkeypatch.setattr("importlib.metadata.version", lambda name: "0.6.15rc1")
+        assert ls_middleware._langgraph_api_version() == (0, 6, 15)
+
+    def test_returns_none_when_not_installed(self, monkeypatch):
+        def _raise(name):
+            raise PackageNotFoundError(name)
+
+        monkeypatch.setattr("importlib.metadata.version", _raise)
+        assert ls_middleware._langgraph_api_version() is None

--- a/tests/unit/langsmith/test_middleware.py
+++ b/tests/unit/langsmith/test_middleware.py
@@ -467,32 +467,62 @@ class TestBuildPaymentApp:
         assert client.get("/x").status_code == 200
 
 
-class TestBuildPaymentAppDeprecationWarning:
+def _our_optional_warnings(recwarn):
+    """Only the build_payment_app 'no longer required' UserWarnings.
+
+    Scoped by message so unrelated UserWarnings from FastAPI/Starlette can't
+    make the assertions pass or fail spuriously.
+    """
+    return [
+        w
+        for w in recwarn.list
+        if issubclass(w.category, UserWarning)
+        and "no longer required" in str(w.message)
+    ]
+
+
+class TestBuildPaymentAppOptionalWarning:
     """build_payment_app warns it's optional on langgraph-api >= 0.6.15.
 
     The spike (nvm-monorepo#1762) bisected the OpenAPI-docstring crash fix to
     langgraph-api 0.6.15 (``get_schema`` broadened its catch to
     ``except Exception``), so a plain Starlette http.app boots without the
-    FastAPI wrapper. #1763 surfaces that via a DeprecationWarning.
+    FastAPI wrapper. #1763 surfaces that via a UserWarning (visible by default,
+    unlike DeprecationWarning, so the nudge actually reaches deployers).
     """
 
     def test_warns_at_fix_version(self, mock_payments, monkeypatch):
         monkeypatch.setattr(ls_middleware, "_langgraph_api_version", lambda: (0, 6, 15))
-        with pytest.warns(DeprecationWarning, match="no longer required"):
+        with pytest.warns(UserWarning, match="no longer required"):
             build_payment_app(payments=mock_payments, routes=None)
 
-    def test_warns_on_newer_version(self, mock_payments, monkeypatch):
+    def test_warning_points_at_plain_starlette_form(self, mock_payments, monkeypatch):
         monkeypatch.setattr(ls_middleware, "_langgraph_api_version", lambda: (0, 8, 7))
-        with pytest.warns(DeprecationWarning, match="PaymentMiddleware directly"):
+        with pytest.warns(UserWarning, match=r"Starlette\(middleware="):
             build_payment_app(payments=mock_payments, routes=None)
 
-    def test_no_warning_below_fix_version(self, mock_payments, monkeypatch, recwarn):
-        monkeypatch.setattr(ls_middleware, "_langgraph_api_version", lambda: (0, 6, 14))
+    @pytest.mark.parametrize(
+        "detected,should_warn",
+        [
+            ((0, 6, 15), True),  # exactly the fix version
+            ((0, 8, 7), True),  # newer 3-component
+            ((0, 7), True),  # 2-component, above fix
+            ((0, 6), False),  # 2-component == 0.6.0 < 0.6.15
+            ((1,), True),  # 1-component major bump
+            ((0,), False),  # 1-component, below
+            ((0, 6, 14), False),  # the last crashing patch
+        ],
+    )
+    def test_warning_gate_across_tuple_shapes(
+        self, mock_payments, monkeypatch, recwarn, detected, should_warn
+    ):
+        """Pin the tuple-prefix comparison against the (0,6,15) sentinel so a
+        future "harden the version compare" refactor can't silently regress the
+        2-/1-component cases (e.g. break the "0.7" path)."""
+        monkeypatch.setattr(ls_middleware, "_langgraph_api_version", lambda: detected)
         app = build_payment_app(payments=mock_payments, routes=None)
-        assert isinstance(app, FastAPI)
-        assert not [
-            w for w in recwarn.list if issubclass(w.category, DeprecationWarning)
-        ]
+        assert isinstance(app, FastAPI)  # always built, warning or not
+        assert bool(_our_optional_warnings(recwarn)) == should_warn
 
     def test_no_warning_when_version_undetected(
         self, mock_payments, monkeypatch, recwarn
@@ -501,9 +531,15 @@ class TestBuildPaymentAppDeprecationWarning:
         monkeypatch.setattr(ls_middleware, "_langgraph_api_version", lambda: None)
         app = build_payment_app(payments=mock_payments, routes=None)
         assert isinstance(app, FastAPI)
-        assert not [
-            w for w in recwarn.list if issubclass(w.category, DeprecationWarning)
-        ]
+        assert not _our_optional_warnings(recwarn)
+
+    def test_warns_via_real_version_detection(self, mock_payments, monkeypatch):
+        """End-to-end: patch only importlib.metadata.version and let the real
+        parse -> compare -> warn seam run (the other tests stub
+        _langgraph_api_version wholesale, never exercising the parser here)."""
+        monkeypatch.setattr("importlib.metadata.version", lambda name: "0.8.7")
+        with pytest.warns(UserWarning, match="no longer required"):
+            build_payment_app(payments=mock_payments, routes=None)
 
 
 class TestLanggraphApiVersionDetection:
@@ -516,6 +552,14 @@ class TestLanggraphApiVersionDetection:
     def test_parses_prerelease_component(self, monkeypatch):
         # A pre-release suffix on the patch component is stripped to its int.
         monkeypatch.setattr("importlib.metadata.version", lambda name: "0.6.15rc1")
+        assert ls_middleware._langgraph_api_version() == (0, 6, 15)
+
+    def test_parses_non_digit_and_extra_components(self, monkeypatch):
+        # A component with no leading digit degrades to 0 (the else-0 branch)...
+        monkeypatch.setattr("importlib.metadata.version", lambda name: "0.6.rc1")
+        assert ls_middleware._langgraph_api_version() == (0, 6, 0)
+        # ...and a 4th component is dropped by the [:3] slice.
+        monkeypatch.setattr("importlib.metadata.version", lambda name: "0.6.15.post1")
         assert ls_middleware._langgraph_api_version() == (0, 6, 15)
 
     def test_returns_none_when_not_installed(self, monkeypatch):


### PR DESCRIPTION
## What

Resolves the final two Sprint-3 follow-ups of epic nevermined-io/nvm-monorepo#1703: the empirical spike **nvm-monorepo#1762** and its gated code change **nvm-monorepo#1763**.

## Spike result (#1762)

**A plain Starlette `http.app` boots cleanly on `langgraph-api` 0.8.7.** Verified end-to-end against a real install (`langgraph dev` with a plain-Starlette `http.app`):

| Probe | Result |
|---|---|
| `GET /ok` | 200 |
| `GET /openapi.json` | 200 (spec generated) |
| ungated `POST /threads` | 200 (passes through) |
| gated `POST /threads/{id}/runs/wait` (no `payment_signature`) | **402** (PaymentMiddleware composed + enforced) |

The internal endpoint docstrings with YAML-unsafe colons (e.g. `/assistants/{assistant_id}` "Query params:") **still exist**, and the `SchemaGenerator` path is **still taken** for non-FastAPI apps — but they no longer crash startup. `langgraph_api/utils/__init__.py::SchemaGenerator.get_schema` broadened its catch around `parse_docstring` from `except AssertionError` to `except Exception` (the bad docstring degrades to a plain description + a logged warning).

**Bisected the fix to `langgraph-api 0.6.15`** (downloaded each wheel, inspected `get_schema`): `0.6.14` crashes, `0.6.15` boots. So the FastAPI wrapper is no longer load-bearing on `>= 0.6.15` — it's now a convenience.

## Changes

- **`build_payment_app` docstring** rewritten: "not required on `langgraph-api >= 0.6.15`", with the plain-Starlette form shown inline.
- **DeprecationWarning (#1763):** `build_payment_app` now detects the installed `langgraph-api` at runtime and, when `>= 0.6.15`, emits a `DeprecationWarning` pointing users at mounting `PaymentMiddleware` directly on a Starlette `http.app`. On `< 0.6.15` (wrapper still required) it's silent.
- **`_langgraph_api_version()`** — fully defensive: returns `None` (silent, no warning, app still built) if `langgraph-api` is absent or the version string is exotic. Construction never breaks.

## Tests

+7: warning fires at/above 0.6.15, silent below it and when undetected; version parser handles 3-component, pre-release suffix (`0.6.15rc1` → `(0, 6, 15)`), and absent package. `black --check` clean; full unit suite green (**571 passed**). Also verified end-to-end: the modified factory against a real `langgraph-api 0.8.7` fires the warning with the detected version.

## Notes

- No upstream filing needed — the "plain Starlette still crashes" branch of the spike did not occur.
- The tutorial (`langchain-langsmith-deployment-py`) keeps using `build_payment_app` (still valid); switching it to plain Starlette is optional cleanup, deferred.

> ℹ️ Linked issues live in `nvm-monorepo`, so GitHub's auto-close won't fire cross-repo on merge — they'll be closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)