### PR TITLE
docs: fix get_fiat_price_config amount units (6-decimal, not cents)

### DIFF
--- a/docs/api/03-payment-plans.md
+++ b/docs/api/03-payment-plans.md
@@ -146,7 +146,7 @@ price_config = get_native_token_price_config(
 from payments_py.plans import get_fiat_price_config
 
 price_config = get_fiat_price_config(
-    amount=999,  # $9.99 in cents
+    amount=9_990_000,  # $9.99 (6-decimal units, not cents)
     receiver="0xBuilderAddress"
 )
 ```
@@ -158,11 +158,13 @@ from payments_py.plans import get_fiat_price_config
 from payments_py.common.types import Currency
 
 price_config = get_fiat_price_config(
-    amount=2900,  # €29.00 in euro cents
+    amount=29_000_000,  # €29.00 (6-decimal units, not cents)
     receiver="0xBuilderAddress",
     currency=Currency.EUR
 )
 ```
+
+> Fiat amounts are in **6-decimal units** (the USDC convention used across the Nevermined protocol), **not** cents — `10_000_000` = $10.00. The server-side minimum is **$1.00** (`1_000_000`); smaller amounts are rejected with `BCK.PROTOCOL.0047`.
 
 ### EURC Token Price (Euro Stablecoin)
 

--- a/payments_py/plans.py
+++ b/payments_py/plans.py
@@ -30,7 +30,10 @@ def get_fiat_price_config(
     Get a fixed fiat price configuration for a plan.
 
     Args:
-        amount: The amount in the smallest unit of the fiat currency
+        amount: The amount in 6-decimal units (the USDC convention used across
+            the Nevermined protocol), NOT cents. E.g. 2_000_000 = $2.00; the
+            server-side minimum is $1.00 (1_000_000), and smaller amounts are
+            rejected with BCK.PROTOCOL.0047.
         receiver: The address that will receive the payment
         currency: Fiat currency code in ISO 4217 format (default: 'USD'). Any code accepted by Stripe.
 

--- a/payments_py/plans.py
+++ b/payments_py/plans.py
@@ -31,9 +31,9 @@ def get_fiat_price_config(
 
     Args:
         amount: The amount in 6-decimal units (the USDC convention used across
-            the Nevermined protocol), NOT cents. E.g. 2_000_000 = $2.00; the
-            server-side minimum is $1.00 (1_000_000), and smaller amounts are
-            rejected with BCK.PROTOCOL.0047.
+            the Nevermined protocol), NOT cents. E.g. ``2_000_000`` = $2.00; the
+            server-side minimum is $1.00 (``1_000_000``), and smaller amounts are
+            rejected with ``BCK.PROTOCOL.0047``.
         receiver: The address that will receive the payment
         currency: Fiat currency code in ISO 4217 format (default: 'USD'). Any code accepted by Stripe.
 


### PR DESCRIPTION
## What

`get_fiat_price_config` was documented as taking the amount in **cents / the smallest unit of the fiat currency** (`999` = $9.99, `2900` = €29.00), but it takes **6-decimal units** (the USDC convention used across the Nevermined protocol). Under the cents reading, `2900` is actually **€0.0029** — below the $1.00 minimum, and rejected by the backend with `BCK.PROTOCOL.0047`. (The TypeScript SDK's `getFiatPriceConfig` docstring already documents this correctly.)

## Change

- **`docs/api/03-payment-plans.md`** (hand-written guide, mirrored into the public Mintlify `api-reference/python` on release): USD `999` → `9_990_000`, EUR `2900` → `29_000_000`, plus a note on the convention + the $1.00 minimum / `BCK.PROTOCOL.0047`.
- **`payments_py/plans.py`**: corrected the `get_fiat_price_config` docstring (it feeds the auto-generated `docs/reference/` via mkdocstrings) from *"the smallest unit of the fiat currency"* to the 6-decimal convention, with the minimum and error code.

Docs/docstring only — no runtime behavior changes. `black --check` passes; `plans.py` parses. The genuinely-cents `spending_limit_cents` delegation examples and the unit-test pass-through values were left as-is.

## Why it matters

Surfaced in review of [nevermined-io/docs#218](https://github.com/nevermined-io/docs/pull/218), which fixed the convention in the agent skill and the development guide. This PR fixes the `payments-py` source the public docs mirror. Companion PR for the TS SDK: nevermined-io/payments#378.
