### PR TITLE
feat(x402): require currency, add delegation planId, deprecate inline create-on-the-fly

### DIFF
--- a/docs/api/07-querying-an-agent.md
+++ b/docs/api/07-querying-an-agent.md
@@ -21,7 +21,7 @@ payments = Payments.get_instance(
     PaymentOptions(nvm_api_key="nvm:subscriber-key", environment="sandbox")
 )
 
-# Generate access token (basic — auto-creates delegation)
+# Generate access token (basic — no delegation config needed for credit/fiat plans)
 result = payments.x402.get_x402_access_token(
     plan_id="your-plan-id",
     agent_id="agent-id"  # Optional but recommended

--- a/docs/api/07-querying-an-agent.md
+++ b/docs/api/07-querying-an-agent.md
@@ -41,32 +41,25 @@ print(f"Access Token: {access_token[:50]}...")
 
 ### Token Generation with Delegation
 
-For erc4337 (crypto) plans, token generation now uses delegations. Two patterns are supported:
+For erc4337 (crypto) plans, token generation uses delegations. The supported
+flow is **create-first**: create the delegation once, then reference it by
+`delegation_id` on every token request. Delegations are plan-agnostic by
+default, so a single delegation can back token requests across many plans.
 
 ```python
 from payments_py.x402 import X402TokenOptions, DelegationConfig, CreateDelegationPayload
 
-# Pattern A — Auto-create delegation (simple)
-result = payments.x402.get_x402_access_token(
-    plan_id="your-plan-id",
-    agent_id="agent-id",
-    token_options=X402TokenOptions(
-        delegation_config=DelegationConfig(
-            spending_limit_cents=10000,  # $100
-            duration_secs=604800         # 1 week
-        )
-    )
-)
-
-# Pattern B — Explicit create + reuse (for sharing across plans)
+# Step 1 — create the delegation once. `currency` is required.
 delegation = payments.delegation.create_delegation(
     CreateDelegationPayload(
         provider="erc4337",
-        spending_limit_cents=10000,
-        duration_secs=604800
+        spending_limit_cents=10000,  # $100
+        duration_secs=604800,        # 1 week
+        currency="usdc",
     )
 )
 
+# Step 2 — request a token referencing the delegation id (reusable across plans).
 result = payments.x402.get_x402_access_token(
     plan_id="your-plan-id",
     agent_id="agent-id",
@@ -77,6 +70,11 @@ result = payments.x402.get_x402_access_token(
     )
 )
 ```
+
+> **Deprecated:** passing `spending_limit_cents` / `duration_secs` (or a payment
+> method) directly to `get_x402_access_token` — inline "create-on-the-fly" —
+> still works but emits a `DeprecationWarning` and will be removed in a future
+> release. Create the delegation first as shown above.
 
 ## Make Requests to Agents
 

--- a/docs/api/11-x402.md
+++ b/docs/api/11-x402.md
@@ -79,24 +79,13 @@ access_token = result['accessToken']
 # With delegation config (crypto — erc4337)
 from payments_py.x402 import X402TokenOptions, DelegationConfig, CreateDelegationPayload
 
-# Pattern A — auto-create delegation
-result = payments.x402.get_x402_access_token(
-    plan_id="your-plan-id",
-    agent_id="agent-id",
-    token_options=X402TokenOptions(
-        delegation_config=DelegationConfig(
-            spending_limit_cents=10000,  # $100
-            duration_secs=604800          # 1 week
-        )
-    )
-)
-
-# Pattern B — explicit create + reuse across plans
+# Create the delegation once (currency is required), then reuse it across plans.
 delegation = payments.delegation.create_delegation(
     CreateDelegationPayload(
         provider="erc4337",
-        spending_limit_cents=10000,
-        duration_secs=604800
+        spending_limit_cents=10000,  # $100
+        duration_secs=604800,         # 1 week
+        currency="usdc",
     )
 )
 result = payments.x402.get_x402_access_token(
@@ -108,43 +97,64 @@ result = payments.x402.get_x402_access_token(
 )
 ```
 
+> **Deprecated:** passing `spending_limit_cents` / `duration_secs` directly to
+> `get_x402_access_token` (inline create-on-the-fly, a `DelegationConfig` with no
+> `delegation_id`) emits a `DeprecationWarning` and will be removed in a future
+> release. Create the delegation first as shown above, then pass only
+> `delegation_id`.
+
 ### Card-Delegation Token Generation
 
-For fiat plans using `nvm:card-delegation`, pass `X402TokenOptions` with a `DelegationConfig`:
+For fiat plans using `nvm:card-delegation`, create the card delegation once
+(`currency` is required), then request the token by `delegation_id`:
 
 ```python
-from payments_py.x402 import X402TokenOptions, DelegationConfig
+from payments_py.x402 import X402TokenOptions, DelegationConfig, CreateDelegationPayload
 
-# USD card delegation
+# Step 1 — create a USD card delegation (currency is required).
+usd_delegation = payments.delegation.create_delegation(
+    CreateDelegationPayload(
+        provider="stripe",
+        provider_payment_method_id="pm_1AbCdEfGhIjKlM",
+        spending_limit_cents=10000,  # $100.00
+        duration_secs=2592000,       # 30 days
+        currency="usd",
+        max_transactions=100,
+    )
+)
+
+# Step 2 — request the token referencing the delegation id.
 result = payments.x402.get_x402_access_token(
     plan_id="your-plan-id",
     agent_id="agent-id",
     token_options=X402TokenOptions(
         scheme="nvm:card-delegation",
         delegation_config=DelegationConfig(
-            provider_payment_method_id="pm_1AbCdEfGhIjKlM",
-            spending_limit_cents=10000,  # $100.00
-            duration_secs=2592000,       # 30 days
-            currency="usd",
-            max_transactions=100
-        )
+            delegation_id=usd_delegation.delegation_id
+        ),
     )
 )
 access_token = result['accessToken']
 
-# EUR card delegation
+# EUR card delegation — same flow, currency="eur".
+eur_delegation = payments.delegation.create_delegation(
+    CreateDelegationPayload(
+        provider="stripe",
+        provider_payment_method_id="pm_1AbCdEfGhIjKlM",
+        spending_limit_cents=10000,  # €100.00 (in euro cents)
+        duration_secs=2592000,       # 30 days
+        currency="eur",
+        max_transactions=100,
+    )
+)
 eur_result = payments.x402.get_x402_access_token(
     plan_id="your-plan-id",
     agent_id="agent-id",
     token_options=X402TokenOptions(
         scheme="nvm:card-delegation",
         delegation_config=DelegationConfig(
-            provider_payment_method_id="pm_1AbCdEfGhIjKlM",
-            spending_limit_cents=10000,  # €100.00 (in euro cents)
-            duration_secs=2592000,       # 30 days
-            currency="eur",
-            max_transactions=100
-        )
+            delegation_id=eur_delegation.delegation_id
+        ),
     )
 )
 ```
@@ -171,12 +181,13 @@ Create delegations and list enrolled payment methods:
 ```python
 from payments_py.x402 import CreateDelegationPayload
 
-# Create a crypto delegation
+# Create a crypto delegation (currency is required)
 delegation = payments.delegation.create_delegation(
     CreateDelegationPayload(
         provider="erc4337",
         spending_limit_cents=10000,
-        duration_secs=604800
+        duration_secs=604800,
+        currency="usdc",
     )
 )
 print(f"Delegation ID: {delegation.delegation_id}")

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -214,7 +214,11 @@ from payments_py.x402.langchain import (
     last_settlement,
     requires_payment,
 )
-from payments_py.x402.types import DelegationConfig, X402TokenOptions
+from payments_py.x402.types import (
+    CreateDelegationPayload,
+    DelegationConfig,
+    X402TokenOptions,
+)
 
 load_dotenv()
 payments = Payments.get_instance(
@@ -233,19 +237,24 @@ try:
 except PaymentRequiredError as err:
     accept = err.payment_required.accepts[0]
 
-# 3. Acquire a token against the discovered plan.
+# 3. Create a delegation once (currency is required), then acquire a token
+#    against the discovered plan by referencing the delegation id.
 pm = next(m for m in payments.delegation.list_payment_methods()
           if m.provider == accept.network)
+delegation = payments.delegation.create_delegation(
+    CreateDelegationPayload(
+        provider=pm.provider,
+        provider_payment_method_id=pm.id,
+        spending_limit_cents=10000,
+        duration_secs=3600,
+        currency="usd",
+    )
+)
 token = payments.x402.get_x402_access_token(
     accept.plan_id,
     token_options=X402TokenOptions(
         scheme=accept.scheme,
-        delegation_config=DelegationConfig(
-            provider_payment_method_id=pm.id,
-            spending_limit_cents=10000,
-            duration_secs=3600,
-            currency="usd",
-        ),
+        delegation_config=DelegationConfig(delegation_id=delegation.delegation_id),
     ),
 )["accessToken"]
 

--- a/payments_py/x402/token.py
+++ b/payments_py/x402/token.py
@@ -108,8 +108,8 @@ class X402TokenAPI(BasePaymentsAPI):
         Passing spending limits / a payment method here instead (inline
         create-on-the-fly, i.e. a ``delegation_config`` with no
         ``delegation_id``) is **deprecated** (#1674): this method emits a
-        ``DeprecationWarning`` and the backend logs its own deprecation
-        warning. The inline path will be removed in a future release.
+        ``FutureWarning`` and the backend logs its own deprecation warning.
+        The inline path will be removed in a future release.
 
         Args:
             plan_id: The unique identifier of the payment plan
@@ -121,7 +121,9 @@ class X402TokenAPI(BasePaymentsAPI):
                 - accessToken: The X402 access token string
 
         Raises:
-            PaymentsError: If the request fails
+            PaymentsError: If the request fails, or (``code='validation'``) if
+                ``delegation_config.delegation_id`` is an empty string — pass a
+                valid delegation UUID or omit the field.
 
         Example:
             ```python
@@ -176,7 +178,23 @@ class X402TokenAPI(BasePaymentsAPI):
         # Add delegation config for both erc4337 and card-delegation schemes
         if token_options and token_options.delegation_config:
             delegation_config = token_options.delegation_config
+            # An empty-string delegation_id is neither a valid reuse (it's not a
+            # UUID) nor "absent": model_dump(exclude_none=True) keeps "" (empty
+            # is not None), so it would serialize `delegationId: ""` and 4xx at
+            # the backend, while _is_inline_create would (mis)read it as inline.
+            # Fail fast with a clear client-input error instead (symmetric with
+            # the TS SDK guard, payments#379).
+            if delegation_config.delegation_id == "":
+                raise PaymentsError.validation(
+                    "delegation_id must not be an empty string — pass a valid "
+                    "delegation UUID or omit the field."
+                )
             if _is_inline_create(delegation_config):
+                # FutureWarning (not DeprecationWarning): DeprecationWarning is
+                # filtered out by default outside __main__, so agents running
+                # under FastAPI / gunicorn / Celery / Docker workers would never
+                # see the nudge. FutureWarning is shown by default → true runtime
+                # parity with the TS SDK's console.warn.
                 warnings.warn(
                     "Passing spending limits / a payment method to "
                     "get_x402_access_token (inline delegation create-on-the-fly) "
@@ -184,7 +202,7 @@ class X402TokenAPI(BasePaymentsAPI):
                     "Create the delegation first with "
                     "payments.delegation.create_delegation(...) and pass only "
                     "DelegationConfig(delegation_id=...) here.",
-                    DeprecationWarning,
+                    FutureWarning,
                     stacklevel=2,
                 )
             body["delegationConfig"] = delegation_config.model_dump(

--- a/payments_py/x402/token.py
+++ b/payments_py/x402/token.py
@@ -178,13 +178,17 @@ class X402TokenAPI(BasePaymentsAPI):
         # Add delegation config for both erc4337 and card-delegation schemes
         if token_options and token_options.delegation_config:
             delegation_config = token_options.delegation_config
-            # An empty-string delegation_id is neither a valid reuse (it's not a
-            # UUID) nor "absent": model_dump(exclude_none=True) keeps "" (empty
-            # is not None), so it would serialize `delegationId: ""` and 4xx at
-            # the backend, while _is_inline_create would (mis)read it as inline.
-            # Fail fast with a clear client-input error instead (symmetric with
-            # the TS SDK guard, payments#379).
-            if delegation_config.delegation_id == "":
+            # An empty- or whitespace-only delegation_id is neither a valid
+            # reuse (it's not a UUID) nor "absent": model_dump(exclude_none=True)
+            # keeps it (it is not None), so it would serialize a blank
+            # `delegationId` and 4xx at the backend, while _is_inline_create
+            # would (mis)read it as inline. Fail fast with a clear client-input
+            # error instead. Strip first to match the TS SDK guard's
+            # `.trim() === ''` (payments#379) — exact cross-SDK symmetry.
+            if (
+                delegation_config.delegation_id is not None
+                and delegation_config.delegation_id.strip() == ""
+            ):
                 raise PaymentsError.validation(
                     "delegation_id must not be an empty string — pass a valid "
                     "delegation UUID or omit the field."

--- a/payments_py/x402/token.py
+++ b/payments_py/x402/token.py
@@ -7,6 +7,7 @@ Tokens are used to authorize payment verification and settlement.
 
 import base64
 import json
+import warnings
 import requests
 from typing import Dict, Any, Optional
 from payments_py.common.payments_error import PaymentsError
@@ -14,7 +15,31 @@ from payments_py.common.types import PaymentOptions
 from payments_py.api.base_payments import BasePaymentsAPI
 from payments_py.api.nvm_api import API_URL_CREATE_PERMISSION
 from payments_py.x402.schemes import get_default_network
-from payments_py.x402.types import X402TokenOptions
+from payments_py.x402.types import DelegationConfig, X402TokenOptions
+
+
+def _is_inline_create(delegation_config: DelegationConfig) -> bool:
+    """Whether a delegation config asks the backend to create a delegation
+    on the fly (the deprecated path) rather than reusing an existing one.
+
+    The supported flow is create-first: create the delegation via
+    ``POST /delegation/create`` and pass only ``delegation_id`` here. A config
+    that carries no ``delegation_id`` but does carry an inline-create signal
+    (a payment-method reference or spending limits) triggers the backend's
+    deprecated create-on-the-fly path, which logs its own deprecation warning
+    server-side (#1674) and will be removed in a future release.
+    """
+    if delegation_config.delegation_id:
+        return False
+    return any(
+        value is not None
+        for value in (
+            delegation_config.card_id,
+            delegation_config.provider_payment_method_id,
+            delegation_config.spending_limit_cents,
+            delegation_config.duration_secs,
+        )
+    )
 
 
 def decode_access_token(access_token: str) -> Optional[Dict[str, Any]]:
@@ -71,14 +96,20 @@ class X402TokenAPI(BasePaymentsAPI):
         token_options: Optional[X402TokenOptions] = None,
     ) -> Dict[str, Any]:
         """
-        Create a delegation and get an X402 access token for the given plan.
+        Get an X402 access token for the given plan against a delegation.
 
         This token allows the agent to verify and settle delegations on behalf
         of the subscriber.
 
-        For erc4337 scheme, you must pass ``token_options.delegation_config`` with either:
-        - ``delegation_id`` to reuse an existing delegation, or
-        - ``spending_limit_cents`` + ``duration_secs`` to auto-create a new one.
+        Supported flow (**create-first**): create the delegation once via
+        ``payments.delegation.create_delegation(...)`` and pass only its
+        ``delegation_id`` here via ``token_options.delegation_config``.
+
+        Passing spending limits / a payment method here instead (inline
+        create-on-the-fly, i.e. a ``delegation_config`` with no
+        ``delegation_id``) is **deprecated** (#1674): this method emits a
+        ``DeprecationWarning`` and the backend logs its own deprecation
+        warning. The inline path will be removed in a future release.
 
         Args:
             plan_id: The unique identifier of the payment plan
@@ -94,22 +125,21 @@ class X402TokenAPI(BasePaymentsAPI):
 
         Example:
             ```python
-            # Pattern A - auto-create delegation
-            result = payments.x402.get_x402_access_token(
-                plan_id, agent_id,
-                token_options=X402TokenOptions(
-                    delegation_config=DelegationConfig(
-                        spending_limit_cents=10000, duration_secs=604800
-                    )
+            # Create the delegation once (currency is required), then reuse it.
+            delegation = payments.delegation.create_delegation(
+                CreateDelegationPayload(
+                    provider="erc4337",
+                    spending_limit_cents=10000,
+                    duration_secs=604800,
+                    currency="usdc",
                 )
             )
 
-            # Pattern B - reuse existing delegation
             result = payments.x402.get_x402_access_token(
                 plan_id, agent_id,
                 token_options=X402TokenOptions(
                     delegation_config=DelegationConfig(
-                        delegation_id="existing-delegation-uuid"
+                        delegation_id=delegation.delegation_id
                     )
                 )
             )
@@ -145,7 +175,19 @@ class X402TokenAPI(BasePaymentsAPI):
 
         # Add delegation config for both erc4337 and card-delegation schemes
         if token_options and token_options.delegation_config:
-            body["delegationConfig"] = token_options.delegation_config.model_dump(
+            delegation_config = token_options.delegation_config
+            if _is_inline_create(delegation_config):
+                warnings.warn(
+                    "Passing spending limits / a payment method to "
+                    "get_x402_access_token (inline delegation create-on-the-fly) "
+                    "is deprecated and will be removed in a future release. "
+                    "Create the delegation first with "
+                    "payments.delegation.create_delegation(...) and pass only "
+                    "DelegationConfig(delegation_id=...) here.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            body["delegationConfig"] = delegation_config.model_dump(
                 by_alias=True, exclude_none=True
             )
 

--- a/payments_py/x402/types.py
+++ b/payments_py/x402/types.py
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
 CardProvider = Literal["stripe", "braintree", "visa"]
 # All delegation providers — card providers above plus the crypto path.
 DelegationProvider = Literal["stripe", "braintree", "visa", "erc4337"]
+# Currencies accepted by POST /api/v1/delegation/create. Mirrors the backend
+# DTO enum (apps/api/src/delegation/dto/create-delegation.dto.ts, #1677): fiat
+# 'usd'/'eur' for Stripe/Braintree/Visa, stablecoin 'usdc'/'eurc' for erc4337.
+# Validated at runtime by Pydantic on model construction.
+DelegationCurrency = Literal["usd", "eur", "usdc", "eurc"]
 
 
 class X402Resource(BaseModel):
@@ -314,18 +319,27 @@ class DelegationConfig(BaseModel):
     """
     Configuration for delegation-based payments (both crypto and card schemes).
 
-    To reuse an existing delegation supply ``delegation_id``.
+    The supported flow is **create-first**: create the delegation once via
+    ``payments.delegation.create_delegation(...)`` and then reference it here
+    with ``delegation_id``. Supplying spending limits / a payment method here
+    instead (inline create-on-the-fly) is **deprecated** — see
+    ``X402TokenAPI.get_x402_access_token``, which warns at runtime.
+
+    To reuse an existing delegation supply ``delegation_id`` (preferred).
     To reuse an existing card (PaymentMethod entity) supply ``card_id``.
-    When creating a brand-new delegation provide ``provider_payment_method_id``,
-    ``spending_limit_cents``, and ``duration_secs``.
+    The deprecated inline path provides ``provider_payment_method_id``,
+    ``spending_limit_cents``, ``duration_secs``, and ``currency``.
 
     Attributes:
         card_id: PaymentMethod entity UUID -- preferred way to reference an enrolled card
-        delegation_id: Existing delegation UUID to reuse instead of creating a new one
-        provider_payment_method_id: Stripe payment method ID (e.g., 'pm_...'). Required only for new delegations.
-        spending_limit_cents: Maximum spending limit in cents. Required only for new delegations.
-        duration_secs: Duration of the delegation in seconds. Required only for new delegations.
-        currency: Currency code (default: 'usd')
+        delegation_id: Existing delegation UUID to reuse instead of creating a new one (preferred)
+        provider_payment_method_id: Stripe payment method ID (e.g., 'pm_...'). Deprecated inline-create only.
+        spending_limit_cents: Maximum spending limit in cents. Deprecated inline-create only.
+        duration_secs: Duration of the delegation in seconds. Deprecated inline-create only.
+        currency: Currency code ('usd' | 'eur' | 'usdc' | 'eurc'). Required by the
+            backend for the deprecated inline-create path (no silent default).
+        plan_id: Plan ID to scope the delegation to. Optional and plan-agnostic by
+            default (#1534); set it to bind the delegation to a single plan.
         merchant_account_id: Stripe Connect merchant account ID
         max_transactions: Maximum number of transactions allowed
         api_key_id: NVM API Key ID to scope the delegation to
@@ -338,7 +352,8 @@ class DelegationConfig(BaseModel):
     )
     spending_limit_cents: Optional[int] = Field(None, alias="spendingLimitCents")
     duration_secs: Optional[int] = Field(None, alias="durationSecs")
-    currency: Optional[str] = None
+    currency: Optional[DelegationCurrency] = None
+    plan_id: Optional[str] = Field(None, alias="planId")
     merchant_account_id: Optional[str] = Field(None, alias="merchantAccountId")
     max_transactions: Optional[int] = Field(None, alias="maxTransactions")
     api_key_id: Optional[str] = Field(None, alias="apiKeyId")
@@ -364,8 +379,11 @@ class CreateDelegationPayload(BaseModel):
             'pm_...', Braintree vault token, or Visa Agentic token id 'vat_...')
         spending_limit_cents: Maximum spending limit in cents
         duration_secs: Duration of the delegation in seconds
-        currency: Currency code (default: 'usd')
-        plan_id: Plan ID to scope the delegation to
+        currency: Currency code ('usd' | 'eur' | 'usdc' | 'eurc'). **Required** —
+            the backend no longer applies a silent 'usd'/'usdc' default (#1677).
+        plan_id: Plan ID to scope the delegation to. Optional and plan-agnostic by
+            default (#1534) — EXCEPT provider='visa', where the backend REQUIRES it
+            (the VGS mandate is merchant-scoped, derived from the plan owner).
         merchant_account_id: Merchant account ID (Stripe Connect acct_xxx or Braintree merchantId)
         max_transactions: Maximum number of transactions allowed
         api_key_id: NVM API Key ID to scope the delegation to
@@ -377,7 +395,7 @@ class CreateDelegationPayload(BaseModel):
     )
     spending_limit_cents: int = Field(..., alias="spendingLimitCents")
     duration_secs: int = Field(..., alias="durationSecs")
-    currency: Optional[str] = None
+    currency: DelegationCurrency
     plan_id: Optional[str] = Field(None, alias="planId")
     merchant_account_id: Optional[str] = Field(None, alias="merchantAccountId")
     max_transactions: Optional[int] = Field(None, alias="maxTransactions")

--- a/tests/e2e/test_a2a_client_e2e.py
+++ b/tests/e2e/test_a2a_client_e2e.py
@@ -77,6 +77,7 @@ def delegation_config(payments_subscriber: Payments):
             provider="erc4337",
             spending_limit_cents=100000,
             duration_secs=604800,
+            currency="usdc",
         )
     )
     return DelegationConfig(delegation_id=delegation.delegation_id)

--- a/tests/e2e/test_a2a_e2e.py
+++ b/tests/e2e/test_a2a_e2e.py
@@ -756,6 +756,7 @@ class TestA2AE2EFlow:
                 provider="erc4337",
                 spending_limit_cents=100000,
                 duration_secs=604800,
+                currency="usdc",
             )
         )
         cls.delegation_id = delegation.delegation_id

--- a/tests/e2e/test_pay_as_you_go_x402_e2e.py
+++ b/tests/e2e/test_pay_as_you_go_x402_e2e.py
@@ -190,6 +190,7 @@ class TestPayAsYouGoFlow:
                 provider="erc4337",
                 spending_limit_cents=100000,
                 duration_secs=604800,
+                currency="usdc",
             )
         )
         TestPayAsYouGoFlow.delegation_id = delegation.delegation_id

--- a/tests/e2e/test_payments_e2e.py
+++ b/tests/e2e/test_payments_e2e.py
@@ -454,6 +454,7 @@ class TestE2ESubscriberAgentFlow:
                 provider="erc4337",
                 spending_limit_cents=100000,
                 duration_secs=604800,
+                currency="usdc",
             )
         )
         agent_access_params = retry_with_backoff(

--- a/tests/e2e/test_x402_card_delegation_braintree_e2e.py
+++ b/tests/e2e/test_x402_card_delegation_braintree_e2e.py
@@ -121,6 +121,7 @@ class TestX402BraintreeCardDelegationFlow:
                     provider_payment_method_id=pm.id,
                     spending_limit_cents=10000,
                     duration_secs=604800,
+                    currency="usd",
                 )
             ),
             label="Braintree Delegation Creation",

--- a/tests/e2e/test_x402_card_delegation_stripe_e2e.py
+++ b/tests/e2e/test_x402_card_delegation_stripe_e2e.py
@@ -102,6 +102,7 @@ class TestX402CardDelegationFlow:
                     provider_payment_method_id=card.id,
                     spending_limit_cents=10000,
                     duration_secs=604800,
+                    currency="usd",
                 )
             ),
             label="Stripe Delegation Creation",

--- a/tests/e2e/test_x402_card_delegation_stripe_e2e.py
+++ b/tests/e2e/test_x402_card_delegation_stripe_e2e.py
@@ -159,6 +159,7 @@ class TestX402CardDelegationFlow:
                         provider_payment_method_id=card.id,
                         spending_limit_cents=5000,
                         duration_secs=3600,
+                        currency="usd",
                     ),
                 ),
             ),

--- a/tests/e2e/test_x402_e2e.py
+++ b/tests/e2e/test_x402_e2e.py
@@ -336,6 +336,7 @@ class TestX402DelegationFlow:
                     delegation_config=DelegationConfig(
                         spending_limit_cents=50000,
                         duration_secs=3600,
+                        currency="usdc",
                     )
                 ),
             ),

--- a/tests/e2e/test_x402_e2e.py
+++ b/tests/e2e/test_x402_e2e.py
@@ -158,6 +158,7 @@ class TestX402DelegationFlow:
                     provider="erc4337",
                     spending_limit_cents=100000,  # $1000 USDC
                     duration_secs=604800,  # 1 week
+                    currency="usdc",
                 )
             ),
             label="Crypto Delegation Creation",

--- a/tests/unit/x402/test_delegation_api.py
+++ b/tests/unit/x402/test_delegation_api.py
@@ -131,6 +131,16 @@ class TestDelegationConfigPlanId:
         config = DelegationConfig(delegation_id="deleg-1")
         assert config.plan_id is None
 
+    def test_rejects_unknown_currency(self):
+        # currency is enum-typed on the inline config too (deprecated path).
+        with pytest.raises(ValidationError):
+            DelegationConfig(
+                provider_payment_method_id="pm_123",
+                spending_limit_cents=10000,
+                duration_secs=604800,
+                currency="gbp",  # type: ignore[arg-type]
+            )
+
 
 class TestDelegationAPIListPaymentMethods:
     """Tests for DelegationAPI.list_payment_methods."""

--- a/tests/unit/x402/test_delegation_api.py
+++ b/tests/unit/x402/test_delegation_api.py
@@ -3,8 +3,10 @@
 from unittest.mock import patch, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from payments_py.x402.delegation_api import DelegationAPI, PaymentMethodSummary
+from payments_py.x402.types import CreateDelegationPayload, DelegationConfig
 
 
 @pytest.fixture
@@ -59,6 +61,75 @@ class TestPaymentMethodSummary:
         data = pm.model_dump(by_alias=True)
         assert data["expMonth"] == 1
         assert data["expYear"] == 2030
+
+
+class TestCreateDelegationPayloadValidation:
+    """The create-delegation payload mirrors the backend DTO (#1677, #1534):
+    currency is required (no silent default) and plan_id is optional /
+    plan-agnostic by default."""
+
+    def test_currency_is_required(self):
+        with pytest.raises(ValidationError) as excinfo:
+            CreateDelegationPayload(
+                provider="erc4337",
+                spending_limit_cents=10000,
+                duration_secs=604800,
+            )
+        assert any(e["loc"] == ("currency",) for e in excinfo.value.errors())
+
+    def test_rejects_unknown_currency(self):
+        with pytest.raises(ValidationError):
+            CreateDelegationPayload(
+                provider="stripe",
+                provider_payment_method_id="pm_123",
+                spending_limit_cents=10000,
+                duration_secs=604800,
+                currency="gbp",  # type: ignore[arg-type]
+            )
+
+    def test_accepts_supported_currencies(self):
+        for currency in ("usd", "eur", "usdc", "eurc"):
+            payload = CreateDelegationPayload(
+                provider="erc4337",
+                spending_limit_cents=10000,
+                duration_secs=604800,
+                currency=currency,  # type: ignore[arg-type]
+            )
+            assert payload.currency == currency
+
+    def test_plan_id_is_optional_and_serialized_under_alias(self):
+        # Plan-agnostic by default: omitting plan_id is valid and excluded.
+        agnostic = CreateDelegationPayload(
+            provider="erc4337",
+            spending_limit_cents=10000,
+            duration_secs=604800,
+            currency="usdc",
+        )
+        assert agnostic.plan_id is None
+        assert "planId" not in agnostic.model_dump(by_alias=True, exclude_none=True)
+
+        # Opt-in plan binding serializes under the camelCase wire alias.
+        bound = CreateDelegationPayload(
+            provider="visa",
+            provider_payment_method_id="vat_1abc",
+            spending_limit_cents=10000,
+            duration_secs=604800,
+            currency="usd",
+            plan_id="42",
+        )
+        assert bound.model_dump(by_alias=True)["planId"] == "42"
+
+
+class TestDelegationConfigPlanId:
+    """plan_id is additive on the token-request delegation config too (#1534)."""
+
+    def test_plan_id_serializes_under_alias(self):
+        config = DelegationConfig(delegation_id="deleg-1", plan_id="42")
+        assert config.model_dump(by_alias=True, exclude_none=True)["planId"] == "42"
+
+    def test_plan_id_optional(self):
+        config = DelegationConfig(delegation_id="deleg-1")
+        assert config.plan_id is None
 
 
 class TestDelegationAPIListPaymentMethods:

--- a/tests/unit/x402/test_delegation_api_visa.py
+++ b/tests/unit/x402/test_delegation_api_visa.py
@@ -154,6 +154,7 @@ class TestCreateDelegationVisa:
             providerPaymentMethodId="vat_1abc23def45",
             spendingLimitCents=10_000,
             durationSecs=3_600,
+            currency="usd",
             planId="42",
         )
         result = DelegationAPI(mock_options).create_delegation(payload)
@@ -168,6 +169,7 @@ class TestCreateDelegationVisa:
         assert body["providerPaymentMethodId"] == "vat_1abc23def45"
         assert body["spendingLimitCents"] == 10_000
         assert body["durationSecs"] == 3_600
+        assert body["currency"] == "usd"
         assert body["planId"] == "42"
 
     @patch("payments_py.x402.delegation_api.requests.post")
@@ -190,6 +192,7 @@ class TestCreateDelegationVisa:
             providerPaymentMethodId="vat_1abc23def45",
             spendingLimitCents=1_000,
             durationSecs=3_600,
+            currency="usd",
         )
         with pytest.raises(PaymentsError) as excinfo:
             DelegationAPI(mock_options).create_delegation(payload)
@@ -223,6 +226,7 @@ class TestCreateDelegationVisa:
                 providerPaymentMethodId="vat_1abc23def45",
                 spendingLimitCents=1_000,
                 durationSecs=3_600,
+                currency="usd",
             )
         )
 
@@ -481,6 +485,7 @@ class TestErrorEnvelopeCoverage:
                     providerPaymentMethodId="vat_1abc23def45",
                     spendingLimitCents=1_000,
                     durationSecs=3_600,
+                    currency="usd",
                 )
             )
 
@@ -503,6 +508,7 @@ class TestErrorEnvelopeCoverage:
                     providerPaymentMethodId="vat_1abc23def45",
                     spendingLimitCents=1_000,
                     durationSecs=3_600,
+                    currency="usd",
                 )
             )
 
@@ -530,6 +536,7 @@ class TestErrorEnvelopeCoverage:
                     providerPaymentMethodId="vat_1abc23def45",
                     spendingLimitCents=1_000,
                     durationSecs=3_600,
+                    currency="usd",
                 )
             )
 

--- a/tests/unit/x402/test_token.py
+++ b/tests/unit/x402/test_token.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from payments_py.common.payments_error import PaymentsError
 from payments_py.x402.token import X402TokenAPI, decode_access_token
 from payments_py.x402.types import (
     DelegationConfig,
@@ -143,7 +144,7 @@ class TestInlineCreateDeprecationWarning:
             ),
         )
 
-        with pytest.warns(DeprecationWarning, match="create_delegation"):
+        with pytest.warns(FutureWarning, match="create_delegation"):
             api.get_x402_access_token("plan-fiat", token_options=token_options)
 
         # The request still goes through — the path is deprecated, not removed.
@@ -169,7 +170,7 @@ class TestInlineCreateDeprecationWarning:
             delegation_config=DelegationConfig(card_id="card-uuid-1"),
         )
 
-        with pytest.warns(DeprecationWarning, match="create_delegation"):
+        with pytest.warns(FutureWarning, match="create_delegation"):
             api.get_x402_access_token("plan-fiat", token_options=token_options)
 
     @patch("payments_py.x402.token.requests.post")
@@ -189,7 +190,7 @@ class TestInlineCreateDeprecationWarning:
             ),
         )
 
-        with pytest.warns(DeprecationWarning, match="create_delegation"):
+        with pytest.warns(FutureWarning, match="create_delegation"):
             api.get_x402_access_token("plan-crypto", token_options=token_options)
 
     @patch("payments_py.x402.token.requests.post")
@@ -267,6 +268,64 @@ class TestInlineCreateDeprecationWarning:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             api.get_x402_access_token("plan-crypto")
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_api_key_id_only_does_not_warn(self, mock_post, mock_options):
+        """api_key_id is scoping metadata, not an inline-create signal: a config
+        with only api_key_id and NO delegation_id (and no card/limits) is not a
+        create-on-the-fly request, so it must stay silent. The backend resolves
+        the delegation from the api_key scope."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"accessToken": "erc-token"}
+        mock_post.return_value = mock_response
+
+        api = X402TokenAPI(mock_options)
+        token_options = X402TokenOptions(
+            delegation_config=DelegationConfig(api_key_id="key-1"),
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            api.get_x402_access_token("plan-crypto", token_options=token_options)
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_spending_limit_zero_is_an_inline_signal(self, mock_post, mock_options):
+        """spending_limit_cents=0 (falsy but not None) is still an inline-create
+        signal — pins the predicate's `is not None` check against a refactor to
+        truthiness, which would wrongly skip the warning for a 0 limit."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"accessToken": "erc-token"}
+        mock_post.return_value = mock_response
+
+        api = X402TokenAPI(mock_options)
+        token_options = X402TokenOptions(
+            delegation_config=DelegationConfig(spending_limit_cents=0),
+        )
+
+        with pytest.warns(FutureWarning, match="create_delegation"):
+            api.get_x402_access_token("plan-crypto", token_options=token_options)
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_empty_string_delegation_id_raises_validation_error(
+        self, mock_post, mock_options
+    ):
+        """An empty-string delegation_id is neither a valid reuse nor absent —
+        it would serialize delegationId: "" and 4xx at the backend. The SDK
+        fails fast with a client-input validation error (no HTTP call)."""
+        api = X402TokenAPI(mock_options)
+        token_options = X402TokenOptions(
+            delegation_config=DelegationConfig(delegation_id=""),
+        )
+
+        with pytest.raises(PaymentsError) as excinfo:
+            api.get_x402_access_token("plan-crypto", token_options=token_options)
+
+        assert excinfo.value.code == "validation"
+        assert "empty string" in str(excinfo.value)
+        # Fails before any backend round-trip.
+        mock_post.assert_not_called()
 
 
 class TestDecodeAccessToken:

--- a/tests/unit/x402/test_token.py
+++ b/tests/unit/x402/test_token.py
@@ -307,16 +307,19 @@ class TestInlineCreateDeprecationWarning:
         with pytest.warns(FutureWarning, match="create_delegation"):
             api.get_x402_access_token("plan-crypto", token_options=token_options)
 
+    @pytest.mark.parametrize("blank_id", ["", "   "])
     @patch("payments_py.x402.token.requests.post")
-    def test_empty_string_delegation_id_raises_validation_error(
-        self, mock_post, mock_options
+    def test_blank_delegation_id_raises_validation_error(
+        self, mock_post, mock_options, blank_id
     ):
-        """An empty-string delegation_id is neither a valid reuse nor absent —
-        it would serialize delegationId: "" and 4xx at the backend. The SDK
-        fails fast with a client-input validation error (no HTTP call)."""
+        """An empty- or whitespace-only delegation_id is neither a valid reuse
+        nor absent — it would serialize a blank delegationId and 4xx at the
+        backend. The SDK strips and fails fast with a client-input validation
+        error (no HTTP call). Whitespace-only pins the .strip() symmetry with
+        the TS SDK's .trim() guard (payments#379)."""
         api = X402TokenAPI(mock_options)
         token_options = X402TokenOptions(
-            delegation_config=DelegationConfig(delegation_id=""),
+            delegation_config=DelegationConfig(delegation_id=blank_id),
         )
 
         with pytest.raises(PaymentsError) as excinfo:

--- a/tests/unit/x402/test_token.py
+++ b/tests/unit/x402/test_token.py
@@ -150,6 +150,8 @@ class TestInlineCreateDeprecationWarning:
         call_args = mock_post.call_args
         body = json.loads(call_args.kwargs.get("data", "{}"))
         assert body["delegationConfig"]["providerPaymentMethodId"] == "pm_123"
+        # The now-required currency survives serialization onto the wire.
+        assert body["delegationConfig"]["currency"] == "usd"
 
     @patch("payments_py.x402.token.requests.post")
     def test_inline_create_via_card_id_warns(self, mock_post, mock_options):
@@ -187,7 +189,7 @@ class TestInlineCreateDeprecationWarning:
             ),
         )
 
-        with pytest.warns(DeprecationWarning, match="deprecated"):
+        with pytest.warns(DeprecationWarning, match="create_delegation"):
             api.get_x402_access_token("plan-crypto", token_options=token_options)
 
     @patch("payments_py.x402.token.requests.post")
@@ -204,6 +206,53 @@ class TestInlineCreateDeprecationWarning:
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")  # any warning becomes a test failure
+            api.get_x402_access_token("plan-crypto", token_options=token_options)
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_delegation_id_with_leftover_inline_fields_does_not_warn(
+        self, mock_post, mock_options
+    ):
+        """Migration footgun guard: a caller who switched to create-first but
+        left stale spending limits in their config must stay SILENT — the
+        delegation_id takes precedence (reuse), so the inline fields are inert.
+        Pins the predicate's early-return against a future refactor."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"accessToken": "erc-token"}
+        mock_post.return_value = mock_response
+
+        api = X402TokenAPI(mock_options)
+        token_options = X402TokenOptions(
+            delegation_config=DelegationConfig(
+                delegation_id="deleg-123",
+                spending_limit_cents=10000,
+                duration_secs=604800,
+            ),
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            api.get_x402_access_token("plan-crypto", token_options=token_options)
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_delegation_id_with_api_key_id_does_not_warn(self, mock_post, mock_options):
+        """api_key_id-scoped reuse is a documented pattern: {delegation_id,
+        api_key_id} is still a reuse, not an inline create — stays silent."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"accessToken": "erc-token"}
+        mock_post.return_value = mock_response
+
+        api = X402TokenAPI(mock_options)
+        token_options = X402TokenOptions(
+            delegation_config=DelegationConfig(
+                delegation_id="deleg-123",
+                api_key_id="key-1",
+            ),
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             api.get_x402_access_token("plan-crypto", token_options=token_options)
 
     @patch("payments_py.x402.token.requests.post")

--- a/tests/unit/x402/test_token.py
+++ b/tests/unit/x402/test_token.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+import warnings
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -117,6 +118,106 @@ class TestTokenWithOptions:
         assert body["accepted"]["scheme"] == "nvm:erc4337"
         assert "delegationConfig" not in body
         assert "sessionKeyConfig" not in body
+
+
+class TestInlineCreateDeprecationWarning:
+    """The token request must nudge callers off the deprecated inline
+    create-on-the-fly path (a delegation_config with no delegation_id) and
+    toward the create-first flow (#1674)."""
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_inline_create_via_payment_method_warns(self, mock_post, mock_options):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"accessToken": "card-token"}
+        mock_post.return_value = mock_response
+
+        api = X402TokenAPI(mock_options)
+        token_options = X402TokenOptions(
+            scheme="nvm:card-delegation",
+            delegation_config=DelegationConfig(
+                provider_payment_method_id="pm_123",
+                spending_limit_cents=10000,
+                duration_secs=604800,
+                currency="usd",
+            ),
+        )
+
+        with pytest.warns(DeprecationWarning, match="create_delegation"):
+            api.get_x402_access_token("plan-fiat", token_options=token_options)
+
+        # The request still goes through — the path is deprecated, not removed.
+        call_args = mock_post.call_args
+        body = json.loads(call_args.kwargs.get("data", "{}"))
+        assert body["delegationConfig"]["providerPaymentMethodId"] == "pm_123"
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_inline_create_via_card_id_warns(self, mock_post, mock_options):
+        """Referencing an enrolled card by its PaymentMethod entity UUID (card_id)
+        with no delegation_id still asks the backend to create a delegation on
+        the fly — the deprecated path."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"accessToken": "card-token"}
+        mock_post.return_value = mock_response
+
+        api = X402TokenAPI(mock_options)
+        token_options = X402TokenOptions(
+            scheme="nvm:card-delegation",
+            delegation_config=DelegationConfig(card_id="card-uuid-1"),
+        )
+
+        with pytest.warns(DeprecationWarning, match="create_delegation"):
+            api.get_x402_access_token("plan-fiat", token_options=token_options)
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_inline_create_via_spending_limits_warns(self, mock_post, mock_options):
+        """erc4337 auto-create (spending limits only, no payment method and no
+        delegation_id) is also the deprecated inline path."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"accessToken": "erc-token"}
+        mock_post.return_value = mock_response
+
+        api = X402TokenAPI(mock_options)
+        token_options = X402TokenOptions(
+            delegation_config=DelegationConfig(
+                spending_limit_cents=10000,
+                duration_secs=604800,
+            ),
+        )
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            api.get_x402_access_token("plan-crypto", token_options=token_options)
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_reuse_by_delegation_id_does_not_warn(self, mock_post, mock_options):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"accessToken": "erc-token"}
+        mock_post.return_value = mock_response
+
+        api = X402TokenAPI(mock_options)
+        token_options = X402TokenOptions(
+            delegation_config=DelegationConfig(delegation_id="deleg-123"),
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning becomes a test failure
+            api.get_x402_access_token("plan-crypto", token_options=token_options)
+
+    @patch("payments_py.x402.token.requests.post")
+    def test_no_delegation_config_does_not_warn(self, mock_post, mock_options):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"accessToken": "token"}
+        mock_post.return_value = mock_response
+
+        api = X402TokenAPI(mock_options)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            api.get_x402_access_token("plan-crypto")
 
 
 class TestDecodeAccessToken:


### PR DESCRIPTION
## Description

Python SDK (`payments-py`) side of the merged x402 hardening delegation contract
(`nevermined-io/nvm-monorepo#1674` / `#1677` / `#1534`), in parity with the TS SDK
(`nevermined-io/payments#379`). Mirrors the backend `CreateDelegationDto`.

**Changes (`payments_py/x402/types.py`, `token.py`):**

1. **`currency` is now REQUIRED** on `CreateDelegationPayload` and typed as a
   `DelegationCurrency = Literal["usd", "eur", "usdc", "eurc"]` enum. The backend no
   longer applies a silent `usd`/`usdc` default (`#1677`), so the SDK now surfaces the
   requirement at construction time. **Coordinated breaking change** — callers must pass
   `currency` explicitly.
2. **Add optional `plan_id` to `DelegationConfig`** (the token-request delegation config).
   Additive and plan-agnostic by default (`#1534`); set it to bind the delegation to a
   single plan. (`CreateDelegationPayload.plan_id` already existed.)
3. **Deprecation warning for inline create-on-the-fly.** `get_x402_access_token` now emits
   a `DeprecationWarning` when called with a `DelegationConfig` that has no `delegation_id`
   but carries an inline-create signal (`card_id` / `provider_payment_method_id` /
   `spending_limit_cents` / `duration_secs`). The supported flow is **create-first**:
   create the delegation via `payments.delegation.create_delegation(...)`, then request the
   token referencing only `DelegationConfig(delegation_id=...)`. The request still
   succeeds — the path is deprecated, not removed (parity with the backend, which keeps the
   inline path working and logs its own server-side deprecation warning, `#1674`).

**Docs:** updated the SDK's own hand-written `docs/api/` examples (07, 11, 12) to the
create-first pattern with required `currency`, plus the model/method docstrings (the
auto-generated `docs/reference/` is sourced from those docstrings). `mkdocs build` is green.
Central narrative docs are tracked separately in `nevermined-io/nvm-monorepo#1913`.

**Release:** no `pyproject.toml` version bump — the release pipeline owns it.

## Is this PR related with an open issue?

Related to Issue #224

Part of `nevermined-io/nvm-monorepo#1549`. Closes #224.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

#### Funny gif

![currency required now](https://media.giphy.com/media/3o7TKsQ8UQzD9b9dKw/giphy.gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)