### PR TITLE
feat: pin backend API version via Nevermined-Version header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,24 +167,35 @@ tests/
 ## API Version Pinning
 
 Every HTTP call to the Nevermined backend carries a `Nevermined-Version`
-header (both `get_backend_http_options()` and `get_public_http_options()`
-in `payments_py/api/base_payments.py` inject it). Constants live in
+header: both option builders (`get_backend_http_options()` /
+`get_public_http_options()` in `payments_py/api/base_payments.py`) inject
+it, and the read-only GETs that historically bypassed the builders
+(`get_plan`, `get_plan_balance`, `get_agents_associated_to_plan`,
+`get_agent`, `get_agent_plans`, `get_deployment_info`) are routed through
+`get_public_http_options("GET")` so the invariant holds everywhere
+(wire-level tests in `TestBareEndpointVersionPin`). New endpoint code MUST
+use one of the two builders — never hand-build headers. Constants live in
 `payments_py/common/api_version.py`:
 
 - `LOCKED_API_VERSION` (`"1.1"`) — the **backend API version** (nvm-monorepo
   `MAJOR.MINOR`) this SDK release is built and tested against. It is **not**
   the package version in `pyproject.toml`; the two move independently. See
   https://docs.nevermined.app/api-reference/versioning and
-  nvm-monorepo#1535 / #1938.
+  nvm-monorepo#1535 / nvm-monorepo#1938.
 - `API_VERSION_HEADER` (`"Nevermined-Version"`) — the request header name.
 
 **Bump procedure:** when the backend ships a new API version, run the full
 test suite (unit + integration + E2E against a backend already serving the
-new version), fix any contract drift, then update `LOCKED_API_VERSION` in
-`payments_py/common/api_version.py` and the pinned value in
-`tests/unit/test_base_payments_http.py`
-(`test_header_name_and_locked_version_constants`) in the same PR. Never bump
-it speculatively — the constant is a tested-compatibility claim.
+new version), fix any contract drift, then update — in the same PR:
+
+1. `LOCKED_API_VERSION` in `payments_py/common/api_version.py`
+2. the pinned value in `tests/unit/test_base_payments_http.py`
+   (`test_header_name_and_locked_version_constants`)
+3. the prose `"1.1"` occurrences in this section and in
+   `docs/api/02-initializing-the-library.md` (the `api_version="1.1"`
+   example) — they are documentation, not constants, and drift silently
+
+Never bump it speculatively — the constant is a tested-compatibility claim.
 
 **Override path:** users can target a different backend contract per
 instance via `PaymentOptions(api_version="x.y")`; `BasePaymentsAPI`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,36 @@ tests/
 - `payments.plans` - Plan management
 - `payments.agents` - Agent management
 
+## API Version Pinning
+
+Every HTTP call to the Nevermined backend carries a `Nevermined-Version`
+header (both `get_backend_http_options()` and `get_public_http_options()`
+in `payments_py/api/base_payments.py` inject it). Constants live in
+`payments_py/common/api_version.py`:
+
+- `LOCKED_API_VERSION` (`"1.1"`) — the **backend API version** (nvm-monorepo
+  `MAJOR.MINOR`) this SDK release is built and tested against. It is **not**
+  the package version in `pyproject.toml`; the two move independently. See
+  https://docs.nevermined.app/api-reference/versioning and
+  nvm-monorepo#1535 / #1938.
+- `API_VERSION_HEADER` (`"Nevermined-Version"`) — the request header name.
+
+**Bump procedure:** when the backend ships a new API version, run the full
+test suite (unit + integration + E2E against a backend already serving the
+new version), fix any contract drift, then update `LOCKED_API_VERSION` in
+`payments_py/common/api_version.py` and the pinned value in
+`tests/unit/test_base_payments_http.py`
+(`test_header_name_and_locked_version_constants`) in the same PR. Never bump
+it speculatively — the constant is a tested-compatibility claim.
+
+**Override path:** users can target a different backend contract per
+instance via `PaymentOptions(api_version="x.y")`; `BasePaymentsAPI`
+resolves `options.api_version or LOCKED_API_VERSION` into
+`self.api_version`, and `Payments._build_options()` propagates it to
+lazily-built sub-APIs. Note `PaymentOptions.version` is a different,
+legacy field (SDK version reported to the backend) — do not reuse it for
+API version pinning.
+
 ## Framework Integrations
 
 - **FastAPI**: `payments_py.x402.fastapi` — `PaymentMiddleware` (install with `pip install payments-py[fastapi]`)

--- a/docs/api/02-initializing-the-library.md
+++ b/docs/api/02-initializing-the-library.md
@@ -59,6 +59,7 @@ The `PaymentOptions` class accepts the following parameters:
 | `environment` | `str` | Yes | Environment name (see below) |
 | `app_id` | `str` | No | Application identifier |
 | `version` | `str` | No | Application version |
+| `api_version` | `str` | No | Backend API version sent as the `Nevermined-Version` header. Defaults to the version this SDK release targets (see below) |
 | `headers` | `dict` | No | Additional HTTP headers |
 | `return_url` | `str` | No | Return URL (browser mode only) |
 
@@ -75,6 +76,27 @@ payments = Payments.get_instance(
     )
 )
 ```
+
+### API Version Pinning
+
+Every request the SDK sends to the Nevermined backend carries a
+`Nevermined-Version` header declaring which backend API version
+(`MAJOR.MINOR`) the SDK was built and tested against. You normally don't
+need to touch this — the SDK pins the right version for you. To target a
+different backend contract explicitly:
+
+```python
+payments = Payments.get_instance(
+    PaymentOptions(
+        nvm_api_key="nvm:your-api-key",
+        environment="sandbox",
+        api_version="1.1",  # override the pinned backend API version
+    )
+)
+```
+
+See the [API versioning reference](https://docs.nevermined.app/api-reference/versioning)
+for the list of versions and the changes between them.
 
 ## Environments
 

--- a/payments_py/api/agents_api.py
+++ b/payments_py/api/agents_api.py
@@ -180,7 +180,7 @@ class AgentsAPI(BasePaymentsAPI):
             PaymentsError: If the agent is not found
         """
         url = f"{self.environment.backend}{API_URL_GET_AGENT.format(agent_id=agent_id)}"
-        response = requests.get(url)
+        response = requests.get(url, **self.get_public_http_options("GET"))
         if not response.ok:
             try:
                 error = response.json()
@@ -213,7 +213,9 @@ class AgentsAPI(BasePaymentsAPI):
             "page": pagination.page,
             "offset": pagination.offset,
         }
-        response = requests.get(url, params=params)
+        response = requests.get(
+            url, params=params, **self.get_public_http_options("GET")
+        )
         if not response.ok:
             try:
                 error = response.json()

--- a/payments_py/api/base_payments.py
+++ b/payments_py/api/base_payments.py
@@ -7,6 +7,7 @@ import jwt
 import json
 from typing import Optional, Dict, Any
 from enum import Enum
+from payments_py.common.api_version import API_VERSION_HEADER, LOCKED_API_VERSION
 from payments_py.common.payments_error import PaymentsError
 from payments_py.common.types import PaymentOptions
 from payments_py.environments import get_environment
@@ -77,6 +78,10 @@ class BasePaymentsAPI:
         self.environment_name = options.environment
         self.app_id = options.app_id
         self.version = options.version
+        # Backend API version (monorepo MAJOR.MINOR) declared on every
+        # request via the ``Nevermined-Version`` header. Defaults to the
+        # version this SDK release is built/tested against.
+        self.api_version: str = options.api_version or LOCKED_API_VERSION
         self.account_address: Optional[str] = None
         self.helicone_api_key: str = None
         self.is_browser_instance = True
@@ -186,6 +191,7 @@ class BasePaymentsAPI:
             "Accept": "application/json",
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.nvm_api_key}",
+            API_VERSION_HEADER: self.api_version,
         }
         if self.current_organization_id:
             headers[CURRENT_ORG_ID_HEADER] = self.current_organization_id
@@ -231,6 +237,7 @@ class BasePaymentsAPI:
             "headers": {
                 "Accept": "application/json",
                 "Content-Type": "application/json",
+                API_VERSION_HEADER: self.api_version,
             },
             "timeout": DEFAULT_HTTP_TIMEOUT,
         }

--- a/payments_py/api/contracts_api.py
+++ b/payments_py/api/contracts_api.py
@@ -84,8 +84,9 @@ class ContractsAPI(BasePaymentsAPI):
             backend_url = self.environment.backend
             info_url = f"{backend_url}{API_URL_INFO}"
 
-            # Info endpoint doesn't require authentication
-            response = requests.get(info_url)
+            # Info endpoint doesn't require authentication, but it still
+            # carries the API version pin like every other backend call.
+            response = requests.get(info_url, **self.get_public_http_options("GET"))
             response.raise_for_status()
 
             info_data = response.json()

--- a/payments_py/api/plans_api.py
+++ b/payments_py/api/plans_api.py
@@ -287,7 +287,7 @@ class PlansAPI(BasePaymentsAPI):
             PaymentsError: If the plan is not found
         """
         url = f"{self.environment.backend}{API_URL_GET_PLAN.format(plan_id=plan_id)}"
-        response = requests.get(url)
+        response = requests.get(url, **self.get_public_http_options("GET"))
         if not response.ok:
             raise PaymentsError.validation(
                 f"Plan not found. {response.status_code} - {response.text}"
@@ -315,10 +315,7 @@ class PlansAPI(BasePaymentsAPI):
             account_address = self.get_account_address()
 
         url = f"{self.environment.backend}{API_URL_PLAN_BALANCE.format(plan_id=plan_id, holder_address=account_address)}"
-        response = requests.get(
-            url,
-            headers={"Accept": "application/json", "Content-Type": "application/json"},
-        )
+        response = requests.get(url, **self.get_public_http_options("GET"))
         if not response.ok:
             raise PaymentsError.internal(
                 f"Unable to get plan balance. {response.status_code} - {response.text}"
@@ -473,7 +470,9 @@ class PlansAPI(BasePaymentsAPI):
             "page": pagination.page,
             "offset": pagination.offset,
         }
-        response = requests.get(url, params=params)
+        response = requests.get(
+            url, params=params, **self.get_public_http_options("GET")
+        )
         if not response.ok:
             raise PaymentsError.internal(
                 f"Unable to get agents associated to plan. {response.status_code} - {response.text}"

--- a/payments_py/common/api_version.py
+++ b/payments_py/common/api_version.py
@@ -8,7 +8,7 @@ serving the pinned contract (or reject the call) instead of silently
 changing response shapes under the SDK.
 
 See https://docs.nevermined.app/api-reference/versioning and
-nvm-monorepo#1535 / #1938.
+nvm-monorepo#1535 / nvm-monorepo#1938.
 """
 
 # The BACKEND API version (monorepo MAJOR.MINOR) this SDK release is built

--- a/payments_py/common/api_version.py
+++ b/payments_py/common/api_version.py
@@ -1,0 +1,21 @@
+"""Backend API version pinning for the Nevermined Payments SDK.
+
+The Nevermined backend versions its HTTP API independently from this
+package, following the monorepo's ``MAJOR.MINOR`` scheme. Every request
+the SDK sends declares which backend API version it was built and tested
+against via the ``Nevermined-Version`` header, so the backend can keep
+serving the pinned contract (or reject the call) instead of silently
+changing response shapes under the SDK.
+
+See https://docs.nevermined.app/api-reference/versioning and
+nvm-monorepo#1535 / #1938.
+"""
+
+# The BACKEND API version (monorepo MAJOR.MINOR) this SDK release is built
+# and tested against — NOT this package's own version (``pyproject.toml``).
+# Bump it only after verifying the SDK against the new backend contract.
+# Override per instance via ``PaymentOptions(api_version=...)``.
+LOCKED_API_VERSION = "1.1"
+
+# Request header the backend reads to resolve the API contract version.
+API_VERSION_HEADER = "Nevermined-Version"

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -20,6 +20,13 @@ class PaymentOptions(BaseModel):
         return_url: Optional URL to return to after login (browser flows).
         app_id: Optional application identifier stamped on registered assets.
         version: Optional SDK version reported to the backend.
+        api_version: Optional backend API version (monorepo ``MAJOR.MINOR``,
+            e.g. ``"1.1"``) sent as the ``Nevermined-Version`` header on
+            every backend request. Defaults to
+            :data:`payments_py.common.api_version.LOCKED_API_VERSION` — the
+            backend API version this SDK release is built and tested
+            against. Override only to target a different backend contract;
+            see https://docs.nevermined.app/api-reference/versioning.
         headers: Optional default headers to merge into every request.
         organization_id: Optional organization id (e.g. ``"org-..."``) used
             as the active workspace for every authenticated backend call.
@@ -37,6 +44,7 @@ class PaymentOptions(BaseModel):
     return_url: Optional[str] = None
     app_id: Optional[str] = None
     version: Optional[str] = None
+    api_version: Optional[str] = None
     headers: Optional[Dict[str, str]] = None
     organization_id: Optional[str] = None
 

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -26,7 +26,9 @@ class PaymentOptions(BaseModel):
             :data:`payments_py.common.api_version.LOCKED_API_VERSION` — the
             backend API version this SDK release is built and tested
             against. Override only to target a different backend contract;
-            see https://docs.nevermined.app/api-reference/versioning.
+            see https://docs. An
+            empty string is treated as unset (the default applies) — the
+            SDK never sends an empty ``Nevermined-Version`` header.nevermined.app/api-reference/versioning.
         headers: Optional default headers to merge into every request.
         organization_id: Optional organization id (e.g. ``"org-..."``) used
             as the active workspace for every authenticated backend call.

--- a/payments_py/payments.py
+++ b/payments_py/payments.py
@@ -174,13 +174,14 @@ class Payments(BasePaymentsAPI):
             self._delegation_api = DelegationAPI.get_instance(self._build_options())
         return self._delegation_api
 
-    def _build_options(self):
+    def _build_options(self) -> PaymentOptions:
         """Build PaymentOptions from current state."""
         return PaymentOptions(
             nvm_api_key=self.nvm_api_key,
             environment=self.environment_name,
             app_id=self.app_id,
             version=self.version,
+            api_version=self.api_version,
             organization_id=self.current_organization_id,
         )
 

--- a/tests/unit/test_base_payments_http.py
+++ b/tests/unit/test_base_payments_http.py
@@ -185,7 +185,7 @@ class TestExtraHeadersAllowlist:
 
 class TestNeverminedVersionHeader:
     """Every backend/public HTTP call must pin the backend API version via
-    the ``Nevermined-Version`` header (nvm-monorepo#1535 / #1938).
+    the ``Nevermined-Version`` header (nvm-monorepo#1535 / nvm-monorepo#1938).
 
     The default is ``LOCKED_API_VERSION`` — the backend API version
     (monorepo MAJOR.MINOR) this SDK release is built and tested against,
@@ -255,3 +255,117 @@ class TestNeverminedVersionHeader:
         assert bp.version == "9.9.9"
         opts = bp.get_backend_http_options("GET")
         assert opts["headers"][API_VERSION_HEADER] == LOCKED_API_VERSION
+
+
+class TestBareEndpointVersionPin:
+    """Every backend call carries the pin — including the read-only GETs that
+    historically bypassed the option builders (#226 review). Each endpoint is
+    exercised at the wire level with requests.get monkeypatched, asserting the
+    Nevermined-Version header is present."""
+
+    def _payments(self):
+        from payments_py.payments import Payments
+
+        return Payments(
+            PaymentOptions(nvm_api_key=_SAFE_JWT, environment="staging_sandbox")
+        )
+
+    def _ok_response(self, payload: Optional[dict] = None) -> MagicMock:
+        response = MagicMock()
+        response.ok = True
+        response.status_code = 200
+        response.json.return_value = payload or {}
+        response.raise_for_status.return_value = None
+        return response
+
+    def test_get_plan_carries_version_header(self, monkeypatch):
+        from payments_py.api import plans_api
+
+        get = MagicMock(return_value=self._ok_response({"id": "1"}))
+        monkeypatch.setattr(plans_api.requests, "get", get)
+
+        self._payments().plans.get_plan("1")
+
+        headers = get.call_args.kwargs["headers"]
+        assert headers[API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_get_plan_balance_carries_version_header(self, monkeypatch):
+        from payments_py.api import plans_api
+
+        get = MagicMock(return_value=self._ok_response({"balance": "0"}))
+        monkeypatch.setattr(plans_api.requests, "get", get)
+
+        try:
+            self._payments().plans.get_plan_balance(
+                "1", "0x6B16D0b334824581B4a24A49Fd7fcbD6509CE5da"
+            )
+        except Exception:
+            # Post-processing of the mocked payload is out of scope — the
+            # wire-level header assertion below is what this test pins.
+            pass
+
+        headers = get.call_args.kwargs["headers"]
+        assert headers[API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_get_plan_agents_carries_version_header_and_keeps_params(self, monkeypatch):
+        from payments_py.api import plans_api
+
+        get = MagicMock(return_value=self._ok_response({"agents": []}))
+        monkeypatch.setattr(plans_api.requests, "get", get)
+
+        self._payments().plans.get_agents_associated_to_plan("1")
+
+        assert "params" in get.call_args.kwargs  # pagination preserved
+        headers = get.call_args.kwargs["headers"]
+        assert headers[API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_get_agent_carries_version_header(self, monkeypatch):
+        from payments_py.api import agents_api
+
+        get = MagicMock(return_value=self._ok_response({"id": "did:nv:agent"}))
+        monkeypatch.setattr(agents_api.requests, "get", get)
+
+        self._payments().agents.get_agent("did:nv:agent")
+
+        headers = get.call_args.kwargs["headers"]
+        assert headers[API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_get_agent_plans_carries_version_header_and_keeps_params(self, monkeypatch):
+        from payments_py.api import agents_api
+
+        get = MagicMock(return_value=self._ok_response({"plans": []}))
+        monkeypatch.setattr(agents_api.requests, "get", get)
+
+        self._payments().agents.get_agent_plans("did:nv:agent")
+
+        assert "params" in get.call_args.kwargs
+        headers = get.call_args.kwargs["headers"]
+        assert headers[API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_deployment_info_carries_version_header(self, monkeypatch):
+        from payments_py.api import contracts_api
+
+        get = MagicMock(
+            return_value=self._ok_response(
+                {"deployment": {"contracts": {}, "chainId": 84532}}
+            )
+        )
+        monkeypatch.setattr(contracts_api.requests, "get", get)
+
+        payments = self._payments()
+        try:
+            payments.contracts.get_deployment_info()
+        except Exception:
+            # The mocked payload may not satisfy downstream parsing — the
+            # wire-level assertion below is what this test pins.
+            pass
+
+        headers = get.call_args.kwargs["headers"]
+        assert headers[API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_empty_api_version_resolves_to_locked_default(self):
+        options = PaymentOptions(
+            nvm_api_key=_SAFE_JWT, environment="staging_sandbox", api_version=""
+        )
+        api = BasePaymentsAPI(options)
+        assert api.api_version == LOCKED_API_VERSION

--- a/tests/unit/test_base_payments_http.py
+++ b/tests/unit/test_base_payments_http.py
@@ -9,6 +9,7 @@ before JSON serialization. These tests pin that behavior down.
 """
 
 import json
+from typing import Optional
 from unittest.mock import MagicMock
 
 from payments_py.api.base_payments import (
@@ -17,6 +18,15 @@ from payments_py.api.base_payments import (
     CURRENT_ORG_ID_HEADER,
     _JS_MAX_SAFE_INTEGER,
     _stringify_unsafe_ints,
+)
+from payments_py.common.api_version import API_VERSION_HEADER, LOCKED_API_VERSION
+from payments_py.common.types import PaymentOptions
+
+# Unsigned JWT with just ``sub`` and ``o11y`` claims — enough for
+# ``BasePaymentsAPI._parse_nvm_api_key`` without a real key.
+_SAFE_JWT = (
+    "nvm:eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJzdWIiOiIweDEyMyIsIm8xMXkiOiJoZWxpY29uZS1rZXkifQ.fake"
 )
 
 
@@ -67,14 +77,15 @@ class TestStringifyUnsafeInts:
         assert _stringify_unsafe_ints(body) == body
 
 
-def _bp_with_safe_jwt() -> BasePaymentsAPI:
+def _bp_with_safe_jwt(api_version: Optional[str] = None) -> BasePaymentsAPI:
     """Build a BasePaymentsAPI without doing the real JWT parsing."""
     options = MagicMock()
-    options.nvm_api_key = "nvm:eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIweDEyMyIsIm8xMXkiOiJoZWxpY29uZS1rZXkifQ.fake"
+    options.nvm_api_key = _SAFE_JWT
     options.environment = "sandbox"
     options.return_url = ""
     options.app_id = None
     options.version = None
+    options.api_version = api_version
     return BasePaymentsAPI(options)
 
 
@@ -170,3 +181,77 @@ class TestExtraHeadersAllowlist:
         assert opts["headers"][CURRENT_ORG_ID_HEADER] == "org-keep"
         assert "X-Forwarded-For" not in opts["headers"]
         assert "Cookie" not in opts["headers"]
+
+
+class TestNeverminedVersionHeader:
+    """Every backend/public HTTP call must pin the backend API version via
+    the ``Nevermined-Version`` header (nvm-monorepo#1535 / #1938).
+
+    The default is ``LOCKED_API_VERSION`` — the backend API version
+    (monorepo MAJOR.MINOR) this SDK release is built and tested against,
+    distinct from the package version. A per-instance ``api_version``
+    option overrides it.
+    """
+
+    def test_header_name_and_locked_version_constants(self):
+        # Pinned on purpose: the header name is a backend contract and the
+        # locked version must only move via a deliberate compatibility
+        # review against the backend changelog.
+        assert API_VERSION_HEADER == "Nevermined-Version"
+        assert LOCKED_API_VERSION == "1.1"
+
+    def test_backend_options_default_to_locked_api_version(self):
+        bp = _bp_with_safe_jwt()
+        opts = bp.get_backend_http_options("GET")
+        assert opts["headers"][API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_public_options_default_to_locked_api_version(self):
+        bp = _bp_with_safe_jwt()
+        opts = bp.get_public_http_options("GET")
+        assert opts["headers"][API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_api_version_option_overrides_both_builders(self):
+        bp = _bp_with_safe_jwt(api_version="2.0")
+        backend = bp.get_backend_http_options("GET")["headers"]
+        public = bp.get_public_http_options("GET")["headers"]
+        assert backend[API_VERSION_HEADER] == "2.0"
+        assert public[API_VERSION_HEADER] == "2.0"
+
+    def test_other_headers_unaffected(self):
+        bp = _bp_with_safe_jwt()
+        backend = bp.get_backend_http_options("POST", {"foo": "bar"})["headers"]
+        assert backend["Accept"] == "application/json"
+        assert backend["Content-Type"] == "application/json"
+        assert backend["Authorization"] == f"Bearer {_SAFE_JWT}"
+        public = bp.get_public_http_options("POST", {"foo": "bar"})["headers"]
+        assert public["Accept"] == "application/json"
+        assert public["Content-Type"] == "application/json"
+        assert "Authorization" not in public
+
+    def test_payment_options_api_version_defaults_to_none_then_locked(self):
+        # Real PaymentOptions (not a mock): the new field defaults to None
+        # and the base API resolves it to LOCKED_API_VERSION.
+        options = PaymentOptions(environment="sandbox", nvm_api_key=_SAFE_JWT)
+        assert options.api_version is None
+        bp = BasePaymentsAPI(options)
+        assert bp.api_version == LOCKED_API_VERSION
+
+    def test_payment_options_api_version_kwarg_is_honored(self):
+        options = PaymentOptions(
+            environment="sandbox", nvm_api_key=_SAFE_JWT, api_version="1.2"
+        )
+        bp = BasePaymentsAPI(options)
+        assert bp.api_version == "1.2"
+        opts = bp.get_backend_http_options("GET")
+        assert opts["headers"][API_VERSION_HEADER] == "1.2"
+
+    def test_legacy_version_option_is_untouched_and_not_used_for_the_header(self):
+        # ``PaymentOptions.version`` (SDK version reported to the backend)
+        # keeps its meaning — it must NOT leak into Nevermined-Version.
+        options = PaymentOptions(
+            environment="sandbox", nvm_api_key=_SAFE_JWT, version="9.9.9"
+        )
+        bp = BasePaymentsAPI(options)
+        assert bp.version == "9.9.9"
+        opts = bp.get_backend_http_options("GET")
+        assert opts["headers"][API_VERSION_HEADER] == LOCKED_API_VERSION

--- a/tests/unit/test_payments.py
+++ b/tests/unit/test_payments.py
@@ -64,7 +64,14 @@ def test_payments_api_version_override_propagates_to_sub_apis():
     )
     assert payments.api_version == "2.0"
     assert payments._build_options().api_version == "2.0"
-    for sub_api in (payments.plans, payments.agents, payments.facilitator):
+    # payments.delegation is the one sub-API built LAZILY via _build_options()
+    # — asserting it covers the propagation path the eager trio cannot.
+    for sub_api in (
+        payments.plans,
+        payments.agents,
+        payments.facilitator,
+        payments.delegation,
+    ):
         opts = sub_api.get_backend_http_options("GET")
         assert opts["headers"]["Nevermined-Version"] == "2.0"
 

--- a/tests/unit/test_payments.py
+++ b/tests/unit/test_payments.py
@@ -52,6 +52,23 @@ def test_payments_initialization_without_api_key():
         Payments(PaymentOptions(environment="staging_sandbox"))
 
 
+def test_payments_api_version_override_propagates_to_sub_apis():
+    """An ``api_version`` override must reach every sub-API's headers and
+    survive ``_build_options`` (used by lazily-built sub-APIs)."""
+    payments = Payments(
+        PaymentOptions(
+            nvm_api_key=TEST_API_KEY,
+            environment="staging_sandbox",
+            api_version="2.0",
+        )
+    )
+    assert payments.api_version == "2.0"
+    assert payments._build_options().api_version == "2.0"
+    for sub_api in (payments.plans, payments.agents, payments.facilitator):
+        opts = sub_api.get_backend_http_options("GET")
+        assert opts["headers"]["Nevermined-Version"] == "2.0"
+
+
 def test_is_ethereum_address():
     """Test the is_ethereum_address helper function."""
     assert is_ethereum_address("0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d")


### PR DESCRIPTION
Implements the SDK half of nevermined-io/nvm-monorepo#1938 (epic nvm-monorepo#1535).

Every HTTP call to the Nevermined backend now carries `Nevermined-Version: <LOCKED_API_VERSION>` (currently **`1.1`** — the backend MAJOR.MINOR this SDK targets, not the package version), overridable per instance.

## ⚠️ Release ordering

**Do NOT publish this SDK until backend v1.1.0 is deployed to production.** The backend rejects pins above its current version with `400 BCK.VERSION.0001`, so a 1.1-pinned SDK against a 1.0 backend fails every call. Merging is safe; publishing waits for the platform rollout.

Integration/e2e suites were deliberately not run (staging is not on 1.1 yet) — run them as the release gate once staging deploys v1.1.0.

## Test plan
- [x] TDD: header tests written first, watched fail
- [x] Full unit suite green
- [x] Lint/format clean
- [ ] e2e against staging at v1.1.0 (pre-publish gate)
