### PR TITLE
feat: list your own plans & agents (user-scoped listing)

### DIFF
--- a/docs/api/03-payment-plans.md
+++ b/docs/api/03-payment-plans.md
@@ -245,6 +245,28 @@ credits_config = get_non_expirable_duration_config()
 
 ## Retrieve Plans
 
+### List Your Plans
+
+List the plans **you** published. This is caller-scoped account management — it
+returns only the plans the authenticated account created, never other users'
+plans (Nevermined is not a marketplace, so there is no global plan search).
+Useful for finding and managing your own plans (e.g. spotting duplicates).
+
+```python
+from payments_py.common.types import PaginationOptions
+
+# Your own plans
+result = payments.plans.get_user_plans(
+    pagination=PaginationOptions(page=1, offset=10)
+)
+print(f"Total: {result['total']}")
+for plan in result["plans"]:
+    print(plan["id"])
+
+# Every plan in an organization you belong to
+org_plans = payments.plans.get_user_plans(org_id="org-acme")
+```
+
 ### Get a Single Plan
 
 ```python

--- a/docs/api/04-agents.md
+++ b/docs/api/04-agents.md
@@ -178,6 +178,28 @@ The `:agentId` and `:taskId` placeholders will be replaced with actual values du
 
 ## Retrieve Agents
 
+### List Your Agents
+
+List the agents **you** published. This is caller-scoped account management — it
+returns only the agents the authenticated account created, never other users'
+agents (Nevermined is not a marketplace, so there is no global agent search).
+Useful for finding and managing your own agents (e.g. spotting duplicates).
+
+```python
+from payments_py.common.types import PaginationOptions
+
+# Your own agents
+result = payments.agents.get_user_agents(
+    pagination=PaginationOptions(page=1, offset=10)
+)
+print(f"Total: {result['total']}")
+for agent in result["agents"]:
+    print(agent["id"])
+
+# Every agent in an organization you belong to
+org_agents = payments.agents.get_user_agents(org_id="org-acme")
+```
+
 ### Get a Single Agent
 
 ```python

--- a/payments_py/api/agents_api.py
+++ b/payments_py/api/agents_api.py
@@ -240,8 +240,9 @@ class AgentsAPI(BasePaymentsAPI):
 
         Args:
             org_id: Optional organization id. When set, returns every agent in
-                that organization (requires active membership); when omitted,
-                returns the agents authored by the caller.
+                that organization (the backend rejects orgs you are not an
+                active member of); when omitted, returns the agents authored by
+                the caller.
             pagination: Optional pagination options (page, offset, sort_by,
                 sort_order).
 
@@ -273,7 +274,8 @@ class AgentsAPI(BasePaymentsAPI):
         if not response.ok:
             try:
                 error = response.json()
-            except Exception:
+            except ValueError:
+                # Non-JSON error body (e.g. a gateway HTML 502).
                 error = {"message": response.text, "code": response.status_code}
             raise PaymentsError.from_backend("Unable to get user agents", error)
         return response.json()

--- a/payments_py/api/agents_api.py
+++ b/payments_py/api/agents_api.py
@@ -18,6 +18,7 @@ from payments_py.api.base_payments import BasePaymentsAPI
 from payments_py.api.organizations_api import resolve_publication_headers
 from payments_py.api.nvm_api import (
     API_URL_REGISTER_AGENT,
+    API_URL_GET_USER_AGENTS,
     API_URL_GET_AGENT,
     API_URL_ADD_PLAN_AGENT,
     API_URL_REMOVE_PLAN_AGENT,
@@ -222,6 +223,59 @@ class AgentsAPI(BasePaymentsAPI):
             except Exception:
                 error = {"message": response.text, "code": response.status_code}
             raise PaymentsError.from_backend("Unable to get agent plans", error)
+        return response.json()
+
+    def get_user_agents(
+        self,
+        org_id: Optional[str] = None,
+        pagination: Optional[PaginationOptions] = None,
+    ) -> Dict[str, Any]:
+        """
+        List the AI agents published by the current user.
+
+        Returns only the agents the authenticated account created — this is
+        account management ("my agents"), not a marketplace search, and never
+        returns other users' agents. Pass ``org_id`` to list every agent in an
+        organization you are a member of instead.
+
+        Args:
+            org_id: Optional organization id. When set, returns every agent in
+                that organization (requires active membership); when omitted,
+                returns the agents authored by the caller.
+            pagination: Optional pagination options (page, offset, sort_by,
+                sort_order).
+
+        Returns:
+            A paginated result of the shape
+            ``{"total", "page", "offset", "agents": [...]}``.
+
+        Raises:
+            PaymentsError: If the request fails.
+        """
+        if pagination is None:
+            pagination = PaginationOptions()
+
+        url = f"{self.environment.backend}{API_URL_GET_USER_AGENTS}"
+        params: Dict[str, Any] = {
+            "page": pagination.page,
+            "offset": pagination.offset,
+        }
+        if pagination.sort_by:
+            params["sortBy"] = pagination.sort_by
+        if pagination.sort_order:
+            params["sortOrder"] = pagination.sort_order
+        if org_id:
+            params["orgId"] = org_id
+
+        response = requests.get(
+            url, params=params, **self.get_backend_http_options("GET")
+        )
+        if not response.ok:
+            try:
+                error = response.json()
+            except Exception:
+                error = {"message": response.text, "code": response.status_code}
+            raise PaymentsError.from_backend("Unable to get user agents", error)
         return response.json()
 
     def add_plan_to_agent(self, plan_id: str, agent_id: str) -> Dict[str, Any]:

--- a/payments_py/api/nvm_api.py
+++ b/payments_py/api/nvm_api.py
@@ -9,7 +9,8 @@ from typing import Optional, Dict, Any
 API_URL_REGISTER_PLAN = "/api/v1/protocol/plans"
 # GET: the caller's own plans (?orgId= scopes to an org the caller belongs to).
 # Distinct from the global /all-plans surface — this never returns other users' plans.
-API_URL_GET_USER_PLANS = "/api/v1/protocol/plans"
+# Same path as registration (GET vs POST); alias to avoid literal drift.
+API_URL_GET_USER_PLANS = API_URL_REGISTER_PLAN
 API_URL_GET_PLAN = "/api/v1/protocol/plans/{plan_id}"
 API_URL_PLAN_BALANCE = "/api/v1/protocol/plans/{plan_id}/balance/{holder_address}"
 API_URL_ORDER_PLAN = "/api/v1/protocol/plans/{plan_id}/order"
@@ -22,7 +23,8 @@ API_URL_REDEEM_PLAN = "/api/v1/protocol/plans/redeem"
 # Agent endpoints
 API_URL_REGISTER_AGENT = "/api/v1/protocol/agents"
 # GET: the caller's own agents (?orgId= scopes to an org the caller belongs to).
-API_URL_GET_USER_AGENTS = "/api/v1/protocol/agents"
+# Same path as registration (GET vs POST); alias to avoid literal drift.
+API_URL_GET_USER_AGENTS = API_URL_REGISTER_AGENT
 API_URL_GET_AGENT = "/api/v1/protocol/agents/{agent_id}"
 API_URL_SEARCH_AGENTS = "/api/v1/protocol/agents/search"
 API_URL_ADD_PLAN_AGENT = "/api/v1/protocol/agents/{agent_id}/plan/{plan_id}"

--- a/payments_py/api/nvm_api.py
+++ b/payments_py/api/nvm_api.py
@@ -7,6 +7,9 @@ from typing import Optional, Dict, Any
 
 # Plan endpoints
 API_URL_REGISTER_PLAN = "/api/v1/protocol/plans"
+# GET: the caller's own plans (?orgId= scopes to an org the caller belongs to).
+# Distinct from the global /all-plans surface — this never returns other users' plans.
+API_URL_GET_USER_PLANS = "/api/v1/protocol/plans"
 API_URL_GET_PLAN = "/api/v1/protocol/plans/{plan_id}"
 API_URL_PLAN_BALANCE = "/api/v1/protocol/plans/{plan_id}/balance/{holder_address}"
 API_URL_ORDER_PLAN = "/api/v1/protocol/plans/{plan_id}/order"
@@ -18,6 +21,8 @@ API_URL_REDEEM_PLAN = "/api/v1/protocol/plans/redeem"
 
 # Agent endpoints
 API_URL_REGISTER_AGENT = "/api/v1/protocol/agents"
+# GET: the caller's own agents (?orgId= scopes to an org the caller belongs to).
+API_URL_GET_USER_AGENTS = "/api/v1/protocol/agents"
 API_URL_GET_AGENT = "/api/v1/protocol/agents/{agent_id}"
 API_URL_SEARCH_AGENTS = "/api/v1/protocol/agents/search"
 API_URL_ADD_PLAN_AGENT = "/api/v1/protocol/agents/{agent_id}/plan/{plan_id}"

--- a/payments_py/api/plans_api.py
+++ b/payments_py/api/plans_api.py
@@ -308,12 +308,14 @@ class PlansAPI(BasePaymentsAPI):
         returns other users' plans. Pass ``org_id`` to list every plan in an
         organization you are a member of instead.
 
-        Equivalent to ``plans.getPlans()`` in the TypeScript SDK.
+        Analogous to ``plans.getPlans()`` in the TypeScript SDK; this method
+        also accepts ``org_id`` to scope the listing to an organization.
 
         Args:
             org_id: Optional organization id. When set, returns every plan in
-                that organization (requires active membership); when omitted,
-                returns the plans authored by the caller.
+                that organization (the backend rejects orgs you are not an
+                active member of); when omitted, returns the plans authored by
+                the caller.
             pagination: Optional pagination options (page, offset, sort_by,
                 sort_order).
 
@@ -345,7 +347,8 @@ class PlansAPI(BasePaymentsAPI):
         if not response.ok:
             try:
                 error = response.json()
-            except Exception:
+            except ValueError:
+                # Non-JSON error body (e.g. a gateway HTML 502).
                 error = {"message": response.text, "code": response.status_code}
             raise PaymentsError.from_backend("Unable to get user plans", error)
         return response.json()

--- a/payments_py/api/plans_api.py
+++ b/payments_py/api/plans_api.py
@@ -18,6 +18,7 @@ from payments_py.api.base_payments import BasePaymentsAPI
 from payments_py.api.organizations_api import resolve_publication_headers
 from payments_py.api.nvm_api import (
     API_URL_REGISTER_PLAN,
+    API_URL_GET_USER_PLANS,
     API_URL_GET_PLAN,
     API_URL_PLAN_BALANCE,
     API_URL_ORDER_PLAN,
@@ -292,6 +293,61 @@ class PlansAPI(BasePaymentsAPI):
             raise PaymentsError.validation(
                 f"Plan not found. {response.status_code} - {response.text}"
             )
+        return response.json()
+
+    def get_user_plans(
+        self,
+        org_id: Optional[str] = None,
+        pagination: Optional[PaginationOptions] = None,
+    ) -> Dict[str, Any]:
+        """
+        List the payment plans published by the current user.
+
+        Returns only the plans the authenticated account created — this is
+        account management ("my plans"), not a marketplace search, and never
+        returns other users' plans. Pass ``org_id`` to list every plan in an
+        organization you are a member of instead.
+
+        Equivalent to ``plans.getPlans()`` in the TypeScript SDK.
+
+        Args:
+            org_id: Optional organization id. When set, returns every plan in
+                that organization (requires active membership); when omitted,
+                returns the plans authored by the caller.
+            pagination: Optional pagination options (page, offset, sort_by,
+                sort_order).
+
+        Returns:
+            A paginated result of the shape
+            ``{"total", "page", "offset", "plans": [...]}``.
+
+        Raises:
+            PaymentsError: If the request fails.
+        """
+        if pagination is None:
+            pagination = PaginationOptions()
+
+        url = f"{self.environment.backend}{API_URL_GET_USER_PLANS}"
+        params: Dict[str, Any] = {
+            "page": pagination.page,
+            "offset": pagination.offset,
+        }
+        if pagination.sort_by:
+            params["sortBy"] = pagination.sort_by
+        if pagination.sort_order:
+            params["sortOrder"] = pagination.sort_order
+        if org_id:
+            params["orgId"] = org_id
+
+        response = requests.get(
+            url, params=params, **self.get_backend_http_options("GET")
+        )
+        if not response.ok:
+            try:
+                error = response.json()
+            except Exception:
+                error = {"message": response.text, "code": response.status_code}
+            raise PaymentsError.from_backend("Unable to get user plans", error)
         return response.json()
 
     def get_plan_balance(

--- a/tests/unit/test_user_scoped_listing.py
+++ b/tests/unit/test_user_scoped_listing.py
@@ -1,0 +1,141 @@
+"""Unit tests for user-scoped listing.
+
+``plans.get_user_plans`` / ``agents.get_user_agents`` wrap the authenticated,
+caller-scoped ``GET /api/v1/protocol/{plans,agents}`` endpoints — "my plans" /
+"my agents" account management, not a marketplace search. They must:
+  * send the Authorization header (the backend derives "me" from the key),
+  * forward pagination as ``page``/``offset``/``sortBy``/``sortOrder``,
+  * forward ``orgId`` only when an org is requested,
+  * raise ``PaymentsError`` on a non-2xx response.
+"""
+
+from urllib.parse import parse_qs, urlparse
+
+import jwt
+import pytest
+import requests_mock
+
+from payments_py.common.payments_error import PaymentsError
+from payments_py.common.types import PaginationOptions, PaymentOptions
+from payments_py.environments import Environments
+from payments_py.payments import Payments
+
+BACKEND = Environments["sandbox"].backend.rstrip("/")
+
+# A throwaway, locally-signed JWT — NOT a real credential. `_parse_nvm_api_key`
+# needs a decodable key carrying `sub` + `o11y`, so we mint one per test run
+# instead of committing a sandbox key.
+_FAKE_API_KEY = "nvm:" + jwt.encode(
+    {"sub": "0x0000000000000000000000000000000000000001", "o11y": "test-o11y"},
+    "unit-test-secret-not-a-real-credential-0123456789",
+    algorithm="HS256",
+)
+
+
+def _payments():
+    return Payments.get_instance(
+        PaymentOptions(nvm_api_key=_FAKE_API_KEY, environment="sandbox")
+    )
+
+
+class TestGetUserPlans:
+    def test_returns_paginated_plans(self):
+        body = {
+            "total": 2,
+            "page": 1,
+            "offset": 10,
+            "plans": [{"id": "plan-1"}, {"id": "plan-2"}],
+        }
+        payments = _payments()
+        with requests_mock.Mocker() as m:
+            m.get(f"{BACKEND}/api/v1/protocol/plans", json=body)
+            result = payments.plans.get_user_plans()
+
+        assert result["total"] == 2
+        assert [p["id"] for p in result["plans"]] == ["plan-1", "plan-2"]
+        # Authenticated request — the bearer token is what scopes it to "me".
+        assert m.last_request.headers["Authorization"] == f"Bearer {_FAKE_API_KEY}"
+        qs = parse_qs(urlparse(m.last_request.url).query)
+        assert qs["page"] == ["1"]
+        assert qs["offset"] == ["10"]
+        assert "orgId" not in qs
+
+    def test_scopes_to_org_when_org_id_set(self):
+        payments = _payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/protocol/plans",
+                json={"total": 0, "page": 1, "offset": 10, "plans": []},
+            )
+            payments.plans.get_user_plans(org_id="org-acme")
+
+        qs = parse_qs(urlparse(m.last_request.url).query)
+        assert qs["orgId"] == ["org-acme"]
+
+    def test_forwards_pagination(self):
+        payments = _payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/protocol/plans",
+                json={"total": 0, "page": 2, "offset": 25, "plans": []},
+            )
+            payments.plans.get_user_plans(
+                pagination=PaginationOptions(
+                    page=2, offset=25, sort_by="created", sort_order="asc"
+                )
+            )
+
+        qs = parse_qs(urlparse(m.last_request.url).query)
+        assert qs["page"] == ["2"]
+        assert qs["offset"] == ["25"]
+        assert qs["sortBy"] == ["created"]
+        assert qs["sortOrder"] == ["asc"]
+
+    def test_raises_on_error(self):
+        payments = _payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/protocol/plans",
+                status_code=500,
+                json={"message": "boom"},
+            )
+            with pytest.raises(PaymentsError):
+                payments.plans.get_user_plans()
+
+
+class TestGetUserAgents:
+    def test_returns_paginated_agents(self):
+        body = {"total": 1, "page": 1, "offset": 10, "agents": [{"id": "agent-1"}]}
+        payments = _payments()
+        with requests_mock.Mocker() as m:
+            m.get(f"{BACKEND}/api/v1/protocol/agents", json=body)
+            result = payments.agents.get_user_agents()
+
+        assert result["total"] == 1
+        assert result["agents"][0]["id"] == "agent-1"
+        assert m.last_request.headers["Authorization"] == f"Bearer {_FAKE_API_KEY}"
+        qs = parse_qs(urlparse(m.last_request.url).query)
+        assert "orgId" not in qs
+
+    def test_scopes_to_org_when_org_id_set(self):
+        payments = _payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/protocol/agents",
+                json={"total": 0, "page": 1, "offset": 10, "agents": []},
+            )
+            payments.agents.get_user_agents(org_id="org-acme")
+
+        qs = parse_qs(urlparse(m.last_request.url).query)
+        assert qs["orgId"] == ["org-acme"]
+
+    def test_raises_on_error(self):
+        payments = _payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/protocol/agents",
+                status_code=500,
+                json={"message": "boom"},
+            )
+            with pytest.raises(PaymentsError):
+                payments.agents.get_user_agents()

--- a/tests/unit/test_user_scoped_listing.py
+++ b/tests/unit/test_user_scoped_listing.py
@@ -129,6 +129,25 @@ class TestGetUserAgents:
         qs = parse_qs(urlparse(m.last_request.url).query)
         assert qs["orgId"] == ["org-acme"]
 
+    def test_forwards_pagination(self):
+        payments = _payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/protocol/agents",
+                json={"total": 0, "page": 2, "offset": 25, "agents": []},
+            )
+            payments.agents.get_user_agents(
+                pagination=PaginationOptions(
+                    page=2, offset=25, sort_by="created", sort_order="asc"
+                )
+            )
+
+        qs = parse_qs(urlparse(m.last_request.url).query)
+        assert qs["page"] == ["2"]
+        assert qs["offset"] == ["25"]
+        assert qs["sortBy"] == ["created"]
+        assert qs["sortOrder"] == ["asc"]
+
     def test_raises_on_error(self):
         payments = _payments()
         with requests_mock.Mocker() as m:


### PR DESCRIPTION
## Summary

Adds user-scoped listing to the Python SDK — the "list **my** own plans/agents" capability from #233 (follow-up to #165). These wrap backend endpoints that **already exist** (`GET /api/v1/protocol/plans` → `getUserPlans`, `/agents` → `getUserAgents`, used by the webapp's "My agents"/"My pricing plans"), but the SDK previously had only point lookups (`get_plan(id)`/`get_agent(id)`).

- `payments.plans.get_user_plans(org_id=None, pagination=...)`
- `payments.agents.get_user_agents(org_id=None, pagination=...)`

This is caller-scoped **account management, not a marketplace search** (Nevermined isn't a marketplace at this phase): it returns only the authenticated caller's own content, or an organization's with `org_id`. General/cross-user discovery stays intentionally out of scope.

## Changes
- `nvm_api.py`: `API_URL_GET_USER_PLANS` / `API_URL_GET_USER_AGENTS`
- `plans_api.py` / `agents_api.py`: the two methods (authenticated GET; `page`/`offset`/`sortBy`/`sortOrder` + optional `orgId`)
- `tests/unit/test_user_scoped_listing.py`: auth header, pagination, `orgId`, error paths (7 tests)
- `docs/api/03-payment-plans.md`, `04-agents.md`: "List Your Plans" / "List Your Agents"

## Test plan
- [x] `poetry run black --check` — clean
- [x] `poetry run pytest tests/unit/test_user_scoped_listing.py` — 7 passed
- [ ] Reviewer: confirm method names/semantics line up with the TS sibling PR

Part of #233 (follow-up to #165). Cross-SDK sibling: a matching PR in `nevermined-io/payments` (TS) adds `agents.getAgents()` + `orgId` on `getPlans()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)