### PR TITLE
feat(a2a): align A2A with x402 v2 in-band transport + canonical agent-card discovery

### DIFF
--- a/docs/api/10-a2a-integration.md
+++ b/docs/api/10-a2a-integration.md
@@ -64,7 +64,7 @@ agent_card = build_payment_agent_card(
 
 ### Agent Card Structure
 
-The agent card includes a payment extension:
+The agent card declares two extensions: the Nevermined payment extension (pricing metadata) and the official a2a-x402 extension (`https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2`), which signals support for the standards-compliant in-band x402 v2 flow (see [In-Band x402 v2 Payments](#in-band-x402-v2-payments-standards-flow)). Both ship for one release; `urn:nevermined:payment` is dropped once clients use v0.2 only.
 
 ```json
 {
@@ -82,6 +82,9 @@ The agent card includes a payment extension:
           "planIds": ["plan-basic", "plan-premium"],
           "costDescription": "1-5 credits depending on review depth"
         }
+      },
+      {
+        "uri": "https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2"
       }
     ]
   }
@@ -185,7 +188,7 @@ asyncio.run(result.server.serve())
 | `port` | `int` | No | Server port (default: 8080) |
 | `task_store` | `TaskStore` | No | Task storage implementation |
 | `base_path` | `str` | No | Base URL path (default: "/") |
-| `expose_agent_card` | `bool` | No | Expose /.well-known/agent.json |
+| `expose_agent_card` | `bool` | No | Expose /.well-known/agent-card.json (+ legacy /.well-known/agent.json alias) |
 | `hooks` | `dict` | No | Request lifecycle hooks |
 | `async_execution` | `bool` | No | Enable async task execution |
 
@@ -207,6 +210,36 @@ payment-required: eyJ4NDAy... (base64-encoded X402PaymentRequired)
 {"error": {"code": -32001, "message": "Missing bearer token."}}
 ```
 
+## In-Band x402 v2 Payments (Standards Flow)
+
+Payment is signalled **in band** following the [Coinbase x402 v2 A2A transport spec](https://github.com/coinbase/x402/blob/main/specs/transports-v2/a2a.md) and the official [a2a-x402 extension](https://github.com/google-agentic-commerce/a2a-x402). The `X402A2AUtils` helpers (see [x402 README](../../payments_py/x402/README.md)) now power this live server flow — `PaymentsA2AServer` stamps and reads the metadata automatically, so the executor is unchanged. The handshake rides on A2A task/message metadata, correlated by `taskId` — no HTTP 402 is exchanged.
+
+Lifecycle:
+
+1. **Payment required** — a payment-gated `message/send` arrives with no payment. The server returns a Task with `status.state = "input-required"` and `status.message.metadata`:
+
+   ```json
+   {
+     "x402.payment.status": "payment-required",
+     "x402.payment.required": { "...": "X402PaymentRequired (accepts[] of plans)" }
+   }
+   ```
+
+2. **Payment submitted** — the client replies with a follow-up `message/send` whose `message.metadata` carries the payload, correlated via `message.taskId`:
+
+   ```json
+   {
+     "x402.payment.status": "payment-submitted",
+     "x402.payment.payload": { "...": "PaymentPayload" }
+   }
+   ```
+
+3. **Completed / failed** — on success the final Task carries `x402.payment.status: "payment-completed"` plus `x402.payment.receipts`. On failure it is `failed` / `payment-failed` with the error under `x402.payment.error`, and paid content is suppressed.
+
+Metadata keys: `x402.payment.status`, `x402.payment.required`, `x402.payment.payload`, `x402.payment.receipts`, `x402.payment.error`.
+
+> **Note:** The legacy `payment-signature` HTTP header flow still works but is now a **deprecated fallback, kept for one release**. New integrations should use the in-band metadata flow above.
+
 ## Client Usage
 
 ### Discovering Plans from the Agent Card
@@ -217,7 +250,8 @@ Consumers can fetch the agent card to discover available plans:
 import httpx
 
 async with httpx.AsyncClient() as client:
-    resp = await client.get("http://agent-url/.well-known/agent.json")
+    # Canonical path (A2A 0.3+); /.well-known/agent.json still works as a legacy alias
+    resp = await client.get("http://agent-url/.well-known/agent-card.json")
     card = resp.json()
 
 extensions = card["capabilities"]["extensions"]

--- a/payments_py/a2a/agent_card.py
+++ b/payments_py/a2a/agent_card.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from payments_py.a2a.types import PaymentAgentCardMetadata
+from payments_py.x402.a2a import A2A_X402_EXTENSION_URI
 
 # Canonical A2A agent-card discovery path (A2A >= 0.3, per RFC 8615). Served by
 # Nevermined A2A agents and used as the default when fetching a remote card.
@@ -80,7 +81,27 @@ def build_payment_agent_card(
         "params": dict(payment_metadata),  # cast to plain dict
     }
 
+    # Also declare the official A2A x402 extension (v0.2) so generic,
+    # spec-compliant A2A clients can detect and activate the standards-based
+    # in-band payment flow. The Nevermined-specific extension is kept alongside
+    # it for one release (it still carries the agentId / plan params the server
+    # reads). ponytail: drop urn:nevermined:payment once clients use v0.2 only.
+    x402_extension = {
+        "uri": A2A_X402_EXTENSION_URI,
+        "description": (
+            "Supports payments using the x402 protocol for on-chain settlement."
+        ),
+        "required": False,
+    }
+
+    # Avoid duplicating an already-present official extension (idempotent build).
+    has_official = any(
+        (ext.get("uri") if isinstance(ext, dict) else None) == A2A_X402_EXTENSION_URI
+        for ext in extensions
+    )
     new_extensions = [*extensions, payment_extension]
+    if not has_official:
+        new_extensions.append(x402_extension)
 
     capabilities = {
         **(base_card.get("capabilities", {})),

--- a/payments_py/a2a/agent_card.py
+++ b/payments_py/a2a/agent_card.py
@@ -14,7 +14,7 @@ AGENT_CARD_WELL_KNOWN_PATH = ".well-known/agent-card.json"
 # Legacy pre-0.3 discovery path. Still served as a backward-compat alias and
 # tried as a fetch fallback, so updated clients keep working against Nevermined
 # agents that have not adopted the canonical path yet.
-# ponytail: drop the alias + fallback one release after agents are updated.
+# TODO(a2a): drop the alias + fallback one release after agents are updated.
 LEGACY_AGENT_CARD_WELL_KNOWN_PATH = ".well-known/agent.json"
 
 
@@ -85,7 +85,7 @@ def build_payment_agent_card(
     # spec-compliant A2A clients can detect and activate the standards-based
     # in-band payment flow. The Nevermined-specific extension is kept alongside
     # it for one release (it still carries the agentId / plan params the server
-    # reads). ponytail: drop urn:nevermined:payment once clients use v0.2 only.
+    # reads). TODO(a2a): drop urn:nevermined:payment once clients use v0.2 only.
     x402_extension = {
         "uri": A2A_X402_EXTENSION_URI,
         "description": (

--- a/payments_py/a2a/agent_card.py
+++ b/payments_py/a2a/agent_card.py
@@ -6,6 +6,16 @@ from typing import Any, Dict, List
 
 from payments_py.a2a.types import PaymentAgentCardMetadata
 
+# Canonical A2A agent-card discovery path (A2A >= 0.3, per RFC 8615). Served by
+# Nevermined A2A agents and used as the default when fetching a remote card.
+AGENT_CARD_WELL_KNOWN_PATH = ".well-known/agent-card.json"
+
+# Legacy pre-0.3 discovery path. Still served as a backward-compat alias and
+# tried as a fetch fallback, so updated clients keep working against Nevermined
+# agents that have not adopted the canonical path yet.
+# ponytail: drop the alias + fallback one release after agents are updated.
+LEGACY_AGENT_CARD_WELL_KNOWN_PATH = ".well-known/agent.json"
+
 
 def build_payment_agent_card(
     base_card: Dict[str, Any], payment_metadata: PaymentAgentCardMetadata

--- a/payments_py/a2a/inband.py
+++ b/payments_py/a2a/inband.py
@@ -31,7 +31,7 @@ over the base64 envelope, so the round-trip is byte-safe for the facilitator).
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 from payments_py.x402.a2a import x402Metadata
 from payments_py.x402.token import encode_access_token
@@ -67,15 +67,6 @@ def get_inband_payment_payload(message: Any) -> Optional[dict]:
     return payload if isinstance(payload, dict) else None
 
 
-def get_inband_payment_status(message: Any) -> Optional[str]:
-    """Extract the in-band ``x402.payment.status`` value from a message."""
-    meta = _message_metadata(message)
-    if not meta:
-        return None
-    status = meta.get(x402Metadata.STATUS_KEY)
-    return status if isinstance(status, str) else None
-
-
 def extract_inband_token(message: Any) -> Optional[str]:
     """Re-encode the in-band ``PaymentPayload`` into a base64 access token.
 
@@ -104,45 +95,7 @@ def extract_inband_token(message: Any) -> Optional[str]:
         return None
 
 
-def is_payment_submission(message: Any) -> bool:
-    """Whether a message carries an in-band x402 payment submission.
-
-    True when ``message.metadata`` contains the ``x402.payment.payload`` object,
-    regardless of whether the explicit ``payment-submitted`` status is set
-    (the payload presence is the load-bearing signal per the spec example).
-    """
-    return get_inband_payment_payload(message) is not None
-
-
-def resolve_token_for_message(
-    message: Any, http_ctx: Any
-) -> Tuple[Optional[str], bool]:
-    """Resolve the x402 access token for an incoming message.
-
-    Precedence (matches the MCP in-band transport): the in-band
-    ``x402.payment.payload`` wins; the deprecated ``payment-signature`` HTTP
-    header (carried on ``http_ctx``) is the fallback for one release.
-
-    Args:
-        message: The incoming A2A message.
-        http_ctx: The :class:`HttpRequestContext` for the request (may be None).
-
-    Returns:
-        A ``(token, from_inband)`` tuple. ``token`` is the base64 access token
-        (or None if neither source is available); ``from_inband`` indicates the
-        in-band path was used (so the server should emit spec receipts).
-    """
-    inband_token = extract_inband_token(message)
-    if inband_token is not None:
-        return inband_token, True
-    header_token = getattr(http_ctx, "bearer_token", None) if http_ctx else None
-    return header_token, False
-
-
 __all__ = [
     "get_inband_payment_payload",
-    "get_inband_payment_status",
     "extract_inband_token",
-    "is_payment_submission",
-    "resolve_token_for_message",
 ]

--- a/payments_py/a2a/inband.py
+++ b/payments_py/a2a/inband.py
@@ -1,0 +1,148 @@
+"""In-band x402 v2 payment helpers for the A2A transport.
+
+Implements the client/server signalling defined by the Coinbase x402 v2 A2A
+transport spec:
+https://github.com/coinbase/x402/blob/main/specs/transports-v2/a2a.md
+
+The flow these helpers support:
+
+* **Payment required** (server -> client): a ``Task`` with
+  ``status.state = "input-required"`` whose ``status.message.metadata`` carries
+  ``x402.payment.status = "payment-required"`` and the ``X402PaymentRequired``
+  object under ``x402.payment.required``.
+* **Payment payload** (client -> server): a follow-up ``message/send`` whose
+  ``message.metadata`` carries ``x402.payment.status = "payment-submitted"`` and
+  the ``PaymentPayload`` object under ``x402.payment.payload``.
+* **Settlement** (server -> client): a final ``Task`` whose
+  ``status.message.metadata`` carries ``x402.payment.status =
+  "payment-completed"`` and the ``SettleResponse`` receipt(s) under
+  ``x402.payment.receipts`` (or ``payment-failed`` + ``x402.payment.error`` on
+  failure).
+
+The Nevermined facilitator's ``verify_permissions`` / ``settle_permissions``
+consume the **base64 access token**, while the in-band payload travels as the
+decoded ``PaymentPayload`` object. :func:`extract_inband_token` reconciles the
+two by re-encoding the in-band payload back into the base64 token with
+:func:`payments_py.x402.token.encode_access_token` (the same approach the MCP
+in-band transport uses — the EIP-712 signature lives *inside* ``payload``, not
+over the base64 envelope, so the round-trip is byte-safe for the facilitator).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Tuple
+
+from payments_py.x402.a2a import x402Metadata
+from payments_py.x402.token import encode_access_token
+
+logger = logging.getLogger(__name__)
+
+
+def _message_metadata(message: Any) -> Optional[dict]:
+    """Return the metadata dict of an A2A message (dict or pydantic), or None."""
+    if message is None:
+        return None
+    if isinstance(message, dict):
+        meta = message.get("metadata")
+    else:
+        meta = getattr(message, "metadata", None)
+    return meta if isinstance(meta, dict) else None
+
+
+def get_inband_payment_payload(message: Any) -> Optional[dict]:
+    """Extract the raw in-band ``x402.payment.payload`` object from a message.
+
+    Args:
+        message: The incoming A2A message (pydantic model or plain dict).
+
+    Returns:
+        The ``PaymentPayload`` dict if present in ``message.metadata`` under the
+        spec key, otherwise ``None``.
+    """
+    meta = _message_metadata(message)
+    if not meta:
+        return None
+    payload = meta.get(x402Metadata.PAYLOAD_KEY)
+    return payload if isinstance(payload, dict) else None
+
+
+def get_inband_payment_status(message: Any) -> Optional[str]:
+    """Extract the in-band ``x402.payment.status`` value from a message."""
+    meta = _message_metadata(message)
+    if not meta:
+        return None
+    status = meta.get(x402Metadata.STATUS_KEY)
+    return status if isinstance(status, str) else None
+
+
+def extract_inband_token(message: Any) -> Optional[str]:
+    """Re-encode the in-band ``PaymentPayload`` into a base64 access token.
+
+    The facilitator's verify/settle APIs take the base64 ``x402_access_token``;
+    the in-band transport carries the decoded ``PaymentPayload`` object instead.
+    Re-encoding bridges the two without touching the EIP-712 signature (which is
+    inside ``payload``, not over the envelope), mirroring the MCP in-band path.
+
+    Args:
+        message: The incoming A2A message carrying the in-band payload.
+
+    Returns:
+        The base64url-encoded access token, or ``None`` if no in-band payload is
+        present (caller should then fall back to the deprecated header token).
+    """
+    payload = get_inband_payment_payload(message)
+    if payload is None:
+        return None
+    try:
+        return encode_access_token(payload)
+    except Exception:  # noqa: BLE001
+        logger.error(
+            "Failed to encode in-band x402 payment payload into access token",
+            exc_info=True,
+        )
+        return None
+
+
+def is_payment_submission(message: Any) -> bool:
+    """Whether a message carries an in-band x402 payment submission.
+
+    True when ``message.metadata`` contains the ``x402.payment.payload`` object,
+    regardless of whether the explicit ``payment-submitted`` status is set
+    (the payload presence is the load-bearing signal per the spec example).
+    """
+    return get_inband_payment_payload(message) is not None
+
+
+def resolve_token_for_message(
+    message: Any, http_ctx: Any
+) -> Tuple[Optional[str], bool]:
+    """Resolve the x402 access token for an incoming message.
+
+    Precedence (matches the MCP in-band transport): the in-band
+    ``x402.payment.payload`` wins; the deprecated ``payment-signature`` HTTP
+    header (carried on ``http_ctx``) is the fallback for one release.
+
+    Args:
+        message: The incoming A2A message.
+        http_ctx: The :class:`HttpRequestContext` for the request (may be None).
+
+    Returns:
+        A ``(token, from_inband)`` tuple. ``token`` is the base64 access token
+        (or None if neither source is available); ``from_inband`` indicates the
+        in-band path was used (so the server should emit spec receipts).
+    """
+    inband_token = extract_inband_token(message)
+    if inband_token is not None:
+        return inband_token, True
+    header_token = getattr(http_ctx, "bearer_token", None) if http_ctx else None
+    return header_token, False
+
+
+__all__ = [
+    "get_inband_payment_payload",
+    "get_inband_payment_status",
+    "extract_inband_token",
+    "is_payment_submission",
+    "resolve_token_for_message",
+]

--- a/payments_py/a2a/payments_request_handler.py
+++ b/payments_py/a2a/payments_request_handler.py
@@ -682,8 +682,10 @@ class PaymentsRequestHandler(DefaultRequestHandler):  # noqa: D101
         if isinstance(settle_result, dict):
             return SettleResponse.model_validate(settle_result)
         # Duck-typed object (e.g. test doubles): pull known fields off it.
+        # Default success to False — never claim a settlement landed when the
+        # result object doesn't explicitly say so (fail safe, not fail open).
         return SettleResponse(
-            success=bool(getattr(settle_result, "success", True)),
+            success=bool(getattr(settle_result, "success", False)),
             transaction=getattr(settle_result, "transaction", "") or "",
             network=getattr(settle_result, "network", "") or "",
             payer=getattr(settle_result, "payer", None),
@@ -772,8 +774,16 @@ class PaymentsRequestHandler(DefaultRequestHandler):  # noqa: D101
             _X402_UTILS.record_payment_success(task, receipt)
         else:
             task.status.state = TaskState.failed
-            # Suppress paid content everywhere it could surface: artifacts AND
-            # the message history (which carries the agent's response messages).
+            # Suppress paid content everywhere it could surface. record_payment_failure
+            # only ADDS metadata to an existing status message, so the agent's paid
+            # reply in status.message.parts would survive — replace the status message
+            # outright, and drop artifacts and history too.
+            task.status.message = Message(
+                message_id=f"{task.id}-payment-failed",
+                role="agent",
+                parts=[{"kind": "text", "text": "Payment settlement failed."}],
+                metadata={},
+            )
             task.artifacts = None
             task.history = []
             _X402_UTILS.record_payment_failure(task, "SETTLEMENT_FAILED", receipt)

--- a/payments_py/a2a/payments_request_handler.py
+++ b/payments_py/a2a/payments_request_handler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import uuid
 from typing import Any, Dict
 
 import httpx
@@ -17,18 +18,27 @@ from a2a.types import (
     MessageSendParams,
     Task,
     TaskIdParams,
+    TaskState,
+    TaskStatus,
     TaskStatusUpdateEvent,
 )
 from payments_py.common.payments_error import PaymentsError
 from payments_py.payments import Payments
+from payments_py.x402.a2a import X402A2AUtils
 from payments_py.x402.token import decode_access_token
 from payments_py.x402.helpers import (
     build_payment_required,
     build_payment_required_for_plans,
 )
+from payments_py.x402.resolve_scheme import resolve_scheme
 from payments_py.x402.schemes import is_valid_scheme
+from payments_py.x402.types import SettleResponse
 
+from .inband import get_inband_payment_payload
 from .types import HttpRequestContext
+
+# Shared in-band x402 metadata helper (stateless; one instance is fine).
+_X402_UTILS = X402A2AUtils()
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +82,9 @@ class PaymentsRequestHandler(DefaultRequestHandler):  # noqa: D101
         self._async_execution = async_execution
         self._http_ctx_by_task: Dict[str, HttpRequestContext] = {}
         self._http_ctx_by_message: Dict[str, HttpRequestContext] = {}
+        # Settlement receipt captured per task during finalization, so the
+        # in-band x402 v2 path can emit it into the resulting task metadata.
+        self._settle_receipt_by_task: Dict[str, SettleResponse] = {}
         self.latest_agent_request: Any = None
         self.latest_agent_request_id: str | None = None
 
@@ -192,9 +205,16 @@ class PaymentsRequestHandler(DefaultRequestHandler):  # noqa: D101
         if not decoded:
             raise PaymentsError.unauthorized("Invalid access token")
 
-        # If no plan_ids found in agent card, try token
+        # If no plan_ids found in agent card, try token. The in-band v2
+        # PaymentPayload nests the plan under ``accepted.planId``; the legacy
+        # token shape may carry it at the top level.
         if not resolved_plan_ids:
-            decoded_plan_id = decoded.get("planId") or decoded.get("plan_id")
+            accepted = decoded.get("accepted") or {}
+            decoded_plan_id = (
+                decoded.get("planId")
+                or decoded.get("plan_id")
+                or (accepted.get("planId") if isinstance(accepted, dict) else None)
+            )
             if decoded_plan_id:
                 resolved_plan_ids = [decoded_plan_id]
 
@@ -302,6 +322,37 @@ class PaymentsRequestHandler(DefaultRequestHandler):  # noqa: D101
         if not agent_id:
             raise PaymentsError.internal("Agent ID not found in payment extension.")
 
+        # ---------------- in-band x402 v2 A2A flow ----------------
+        # The standards path signals payment in band (not via HTTP 402): a first
+        # ``message/send`` with no payment yields an ``input-required`` task; a
+        # follow-up carrying ``x402.payment.payload`` is verified, executed and
+        # settled with the receipt emitted into the resulting task metadata.
+        inband_payload = get_inband_payment_payload(params.message)
+        if http_ctx.inband:
+            # First contact (no token, no payload) -> ask for payment in band.
+            # Nothing executes, so release the stored context immediately.
+            if not http_ctx.bearer_token and inband_payload is None:
+                self.delete_http_ctx_for_task(prev_task_id or "")
+                self.delete_http_ctx_for_message(params.message.message_id)
+                return self._build_payment_required_task(
+                    task_id=prev_task_id or params.message.task_id,
+                    context_id=params.message.context_id,
+                    agent_id=agent_id,
+                    ext_params=ext_params,
+                    endpoint=http_ctx.url_requested,
+                )
+            # Verification already failed in the middleware -> payment-failed.
+            verify_error = http_ctx.validation.get("verify_error")
+            if verify_error:
+                self.delete_http_ctx_for_task(prev_task_id or "")
+                self.delete_http_ctx_for_message(params.message.message_id)
+                return self._build_payment_failed_task(
+                    task_id=prev_task_id or params.message.task_id,
+                    context_id=params.message.context_id,
+                    code="PAYMENT_VERIFICATION_FAILED",
+                    reason=verify_error,
+                )
+
         # Setup message execution (equivalent to TS setup)
         (
             task_manager,
@@ -331,6 +382,14 @@ class PaymentsRequestHandler(DefaultRequestHandler):  # noqa: D101
         ):
             blocking = False
 
+        # The in-band x402 v2 settlement receipt is captured synchronously during
+        # finalization and must be stamped onto the returned task; in non-blocking
+        # mode the task returns before settlement lands, which would risk
+        # delivering paid content without settlement. Force blocking for the
+        # in-band path so the spec's "never deliver unpaid content" rule holds.
+        if http_ctx.inband and http_ctx.bearer_token:
+            blocking = True
+
         interrupted_or_non_blocking = False
         try:
             # Both blocking and non-blocking use the same method, but with different
@@ -346,6 +405,10 @@ class PaymentsRequestHandler(DefaultRequestHandler):  # noqa: D101
 
             if isinstance(result, Task):
                 self._validate_task_id_match(task_id, result.id)
+                # In-band x402 v2: stamp the settlement outcome onto the task so
+                # spec-compliant clients read the receipt/status from metadata.
+                if http_ctx.inband:
+                    self._apply_inband_settlement(result, task_id)
 
             await self._send_push_notification_if_needed(task_id, result_aggregator)
 
@@ -571,7 +634,7 @@ class PaymentsRequestHandler(DefaultRequestHandler):  # noqa: D101
 
         try:
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(
+            settle_result = await loop.run_in_executor(
                 None,
                 lambda: self._payments.facilitator.settle_permissions(
                     payment_required=payment_required,
@@ -580,12 +643,140 @@ class PaymentsRequestHandler(DefaultRequestHandler):  # noqa: D101
                     agent_request_id=agent_request_id,
                 ),
             )
+            # Capture the receipt so the in-band x402 v2 path can stamp it onto
+            # the task. Only kept for in-band requests to avoid unbounded growth
+            # on the legacy header path (which never consumes these entries).
+            task_id = getattr(event, "task_id", None)
+            if task_id is not None and http_ctx.inband:
+                self._settle_receipt_by_task[task_id] = self._coerce_settle_response(
+                    settle_result
+                )
         except Exception:  # noqa: BLE001
             logger.warning(
                 "Failed to settle %s credits during task finalization",
                 credits_used,
                 exc_info=True,
             )
+            task_id = getattr(event, "task_id", None)
+            if task_id is not None and http_ctx.inband:
+                # Record a failed receipt so the in-band path emits payment-failed
+                # and never delivers paid content without settlement landing.
+                self._settle_receipt_by_task[task_id] = SettleResponse(
+                    success=False,
+                    error_reason="Settlement failed during task finalization",
+                )
+
+    # ------------------------------------------------------------------
+    # In-band x402 v2 helpers ------------------------------------------
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _coerce_settle_response(settle_result: Any) -> SettleResponse:
+        """Normalize a facilitator settle result into a ``SettleResponse``.
+
+        ``settle_permissions`` may return a ``SettleResponse``, a compatible
+        object (duck-typed in tests), or a plain dict. Always return a
+        ``SettleResponse`` so the receipt serializes with the x402 aliases.
+        """
+        if isinstance(settle_result, SettleResponse):
+            return settle_result
+        if isinstance(settle_result, dict):
+            return SettleResponse.model_validate(settle_result)
+        # Duck-typed object (e.g. test doubles): pull known fields off it.
+        return SettleResponse(
+            success=bool(getattr(settle_result, "success", True)),
+            transaction=getattr(settle_result, "transaction", "") or "",
+            network=getattr(settle_result, "network", "") or "",
+            payer=getattr(settle_result, "payer", None),
+            credits_redeemed=getattr(settle_result, "credits_redeemed", None),
+            error_reason=getattr(settle_result, "error_reason", None),
+        )
+
+    def _build_payment_required_task(
+        self,
+        *,
+        task_id: str | None,
+        context_id: str | None,
+        agent_id: str,
+        ext_params: dict,
+        endpoint: str | None = None,
+    ) -> Task:
+        """Build an ``input-required`` task carrying the x402 PaymentRequired.
+
+        This is the spec-compliant "payment required" signal for the in-band
+        A2A transport: the client reads ``x402.payment.required`` and replies
+        with a follow-up ``message/send`` carrying ``x402.payment.payload``.
+        """
+        plan_id = ext_params.get("planId") or ext_params.get("plan_id")
+        plan_ids = ext_params.get("planIds") or ext_params.get("plan_ids")
+        resolved_plan_ids = (
+            plan_ids
+            if isinstance(plan_ids, list) and plan_ids
+            else ([plan_id] if plan_id else [])
+        )
+        scheme = "nvm:erc4337"
+        if resolved_plan_ids:
+            try:
+                scheme = resolve_scheme(self._payments, resolved_plan_ids[0])
+            except Exception:  # noqa: BLE001
+                scheme = "nvm:erc4337"
+
+        payment_required = build_payment_required_for_plans(
+            plan_ids=resolved_plan_ids or [""],
+            agent_id=agent_id,
+            endpoint=endpoint,
+            http_verb="POST",
+            scheme=scheme,
+            environment=getattr(self._payments, "environment_name", None),
+        )
+
+        task = Task(
+            id=task_id or str(uuid.uuid4()),
+            context_id=context_id or str(uuid.uuid4()),
+            status=TaskStatus(state=TaskState.input_required),
+            history=[],
+        )
+        return _X402_UTILS.create_payment_required_task(task, payment_required)
+
+    def _build_payment_failed_task(
+        self,
+        *,
+        task_id: str | None,
+        context_id: str | None,
+        code: str,
+        reason: str,
+    ) -> Task:
+        """Build a ``failed`` task carrying the x402 payment-failed metadata."""
+        task = Task(
+            id=task_id or str(uuid.uuid4()),
+            context_id=context_id or str(uuid.uuid4()),
+            status=TaskStatus(state=TaskState.failed),
+            history=[],
+        )
+        return _X402_UTILS.record_payment_failure(
+            task, code, SettleResponse(success=False, error_reason=reason)
+        )
+
+    def _apply_inband_settlement(self, task: Task, task_id: str) -> None:
+        """Stamp the captured settlement outcome onto an executed task.
+
+        On success the task carries ``payment-completed`` + the receipt; on a
+        settlement failure it is forced to ``failed`` / ``payment-failed`` and
+        its agent content is dropped so a paid result is never delivered without
+        settlement landing (spec requirement).
+        """
+        receipt = self._settle_receipt_by_task.pop(task_id, None)
+        if receipt is None:
+            # Free / no-credit call: nothing settled, nothing to stamp.
+            return
+        if receipt.success:
+            _X402_UTILS.record_payment_success(task, receipt)
+        else:
+            task.status.state = TaskState.failed
+            # Suppress paid content everywhere it could surface: artifacts AND
+            # the message history (which carries the agent's response messages).
+            task.artifacts = None
+            task.history = []
+            _X402_UTILS.record_payment_failure(task, "SETTLEMENT_FAILED", receipt)
 
     # ------------------------------------------------------------------
     # Streaming override ------------------------------------------------

--- a/payments_py/a2a/server.py
+++ b/payments_py/a2a/server.py
@@ -18,6 +18,7 @@ from payments_py.a2a.agent_card import (
     AGENT_CARD_WELL_KNOWN_PATH,
     LEGACY_AGENT_CARD_WELL_KNOWN_PATH,
 )
+from payments_py.a2a.inband import extract_inband_token
 from payments_py.a2a.types import AgentCard, HttpRequestContext
 from payments_py.payments import Payments
 from payments_py.x402.helpers import build_payment_required_for_plans
@@ -245,26 +246,8 @@ class PaymentsA2AServer:  # noqa: D101
                 environment=getattr(payments_service, "environment_name", None),
             )
 
-            bearer_token = request.headers.get("payment-signature")
-            if not bearer_token:
-                return _send_payment_required(
-                    payment_required, "Missing payment-signature header."
-                )
-
-            validation: Any
-            try:
-                validation = await handler.validate_request(
-                    agent_id=agent_id,
-                    bearer_token=bearer_token,
-                    url_requested=absolute_url,
-                    http_method_requested=request.method,
-                )
-            except Exception as exc:  # noqa: BLE001
-                return _send_payment_required(
-                    payment_required, f"Validation error: {exc}"
-                )
-
-            # Parse JSON body early to capture method / messageId / taskId
+            # Parse JSON body early to capture method / messageId / taskId and the
+            # in-band x402 payment payload (x402 v2 A2A transport).
             try:
                 body = await request.body()
             except Exception:  # noqa: BLE001
@@ -281,16 +264,95 @@ class PaymentsA2AServer:  # noqa: D101
                 body_json = {}
 
             method_name = body_json.get("method")
-            task_id = body_json.get("params", {}).get("message", {}).get(
-                "taskId"
-            ) or body_json.get("params", {}).get("taskId")
-            message_id = body_json.get("params", {}).get("message", {}).get("messageId")
+            params = body_json.get("params", {}) or {}
+            message_obj = params.get("message", {}) or {}
+            task_id = message_obj.get("taskId") or params.get("taskId")
+            message_id = message_obj.get("messageId")
+
+            # In-band token (x402 v2 A2A): re-encode the x402.payment.payload
+            # object into the base64 access token the facilitator consumes. The
+            # deprecated ``payment-signature`` header is the one-release fallback.
+            inband_token = extract_inband_token(message_obj)
+            header_token = request.headers.get("payment-signature")
+            # The in-band task lifecycle (input-required / payment-failed task)
+            # is the non-streaming ``message/send`` shape per the spec. Streaming
+            # keeps its prior behaviour (it can still settle an in-band token, but
+            # falls back to the HTTP-402 challenge when no token is present).
+            is_send = method_name == "message/send"
+
+            bearer_token = inband_token or header_token
+            from_inband = inband_token is not None
+
+            if not bearer_token:
+                # No token at all. For a standards-compliant in-band message/send
+                # this is the FIRST contact: let it reach the handler so the
+                # handler can answer with an ``input-required`` payment-required
+                # task (NOT an HTTP 402). Anything else keeps the deprecated
+                # HTTP-402 header challenge for one release.
+                if is_send:
+                    ctx = HttpRequestContext(
+                        bearer_token="",
+                        url_requested=absolute_url,
+                        http_method_requested=request.method,
+                        validation={},
+                        inband=True,
+                    )
+                    if task_id:
+                        handler.set_http_ctx_for_task(task_id, ctx)
+                    elif message_id:
+                        handler.set_http_ctx_for_message(message_id, ctx)
+
+                    if hooks and callable(hooks.get("beforeRequest")):
+                        await hooks["beforeRequest"](method_name, params, request)
+                    request._body = body  # restore consumed body for downstream
+                    try:
+                        response = await call_next(request)
+                        if hooks and callable(hooks.get("afterRequest")):
+                            await hooks["afterRequest"](method_name, response, request)
+                        return response
+                    except Exception as exc:  # noqa: BLE001
+                        if hooks and callable(hooks.get("onError")):
+                            await hooks["onError"](method_name, exc, request)
+                        raise
+                return _send_payment_required(
+                    payment_required, "Missing payment-signature header."
+                )
+
+            validation: Any
+            try:
+                validation = await handler.validate_request(
+                    agent_id=agent_id,
+                    bearer_token=bearer_token,
+                    url_requested=absolute_url,
+                    http_method_requested=request.method,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # In-band clients expect the failure as a ``payment-failed`` task,
+                # not an HTTP 402. Reach the handler so it can emit one.
+                if from_inband and is_send:
+                    ctx = HttpRequestContext(
+                        bearer_token=bearer_token,
+                        url_requested=absolute_url,
+                        http_method_requested=request.method,
+                        validation={"verify_error": str(exc)},
+                        inband=True,
+                    )
+                    if task_id:
+                        handler.set_http_ctx_for_task(task_id, ctx)
+                    elif message_id:
+                        handler.set_http_ctx_for_message(message_id, ctx)
+                    request._body = body
+                    return await call_next(request)
+                return _send_payment_required(
+                    payment_required, f"Validation error: {exc}"
+                )
 
             ctx = HttpRequestContext(
                 bearer_token=bearer_token,
                 url_requested=absolute_url,
                 http_method_requested=request.method,
                 validation=validation,
+                inband=from_inband,
             )
 
             if task_id:
@@ -304,6 +366,7 @@ class PaymentsA2AServer:  # noqa: D101
                     method_name, body_json.get("params"), request
                 )
 
+            request._body = body  # restore consumed body for downstream handler
             try:
                 response = await call_next(request)
                 if hooks and callable(hooks.get("afterRequest")):

--- a/payments_py/a2a/server.py
+++ b/payments_py/a2a/server.py
@@ -14,6 +14,10 @@ from a2a.server.apps.jsonrpc.fastapi_app import A2AFastAPIApplication
 from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 
 from payments_py.a2a.payments_request_handler import PaymentsRequestHandler
+from payments_py.a2a.agent_card import (
+    AGENT_CARD_WELL_KNOWN_PATH,
+    LEGACY_AGENT_CARD_WELL_KNOWN_PATH,
+)
 from payments_py.a2a.types import AgentCard, HttpRequestContext
 from payments_py.payments import Payments
 from payments_py.x402.helpers import build_payment_required_for_plans
@@ -310,15 +314,15 @@ class PaymentsA2AServer:  # noqa: D101
                     await hooks["onError"](method_name, exc, request)
                 raise
 
-        # Basic .well-known/agent.json endpoint
+        # Agent card discovery: canonical path (A2A >= 0.3) + legacy alias, so
+        # both pre-spec and current A2A clients can discover the card.
         if expose_agent_card:
-            route_path = (
-                f"{base_path.rstrip('/')}/.well-known/agent.json"
-                if base_path != "/"
-                else "/.well-known/agent.json"
-            )
+            prefix = base_path.rstrip("/") if base_path != "/" else ""
 
-            @app.get(route_path, include_in_schema=False)
+            @app.get(f"{prefix}/{AGENT_CARD_WELL_KNOWN_PATH}", include_in_schema=False)
+            @app.get(
+                f"{prefix}/{LEGACY_AGENT_CARD_WELL_KNOWN_PATH}", include_in_schema=False
+            )
             async def get_agent_card() -> Any:  # noqa: D401, ANN201
                 return agent_card
 

--- a/payments_py/a2a/types.py
+++ b/payments_py/a2a/types.py
@@ -44,3 +44,8 @@ class HttpRequestContext:  # noqa: D101
     url_requested: str
     http_method_requested: str
     validation: Dict[str, Any]
+    # True when the access token was carried in-band via the x402 v2 A2A payload
+    # metadata (x402.payment.payload) rather than the deprecated
+    # ``payment-signature`` HTTP header. Tells the handler to emit spec-shaped
+    # receipts/status into the resulting task metadata.
+    inband: bool = False

--- a/payments_py/x402/README.md
+++ b/payments_py/x402/README.md
@@ -894,7 +894,13 @@ else:
 
 ### A2A Integration Utilities
 
-Utilities for managing x402 payment state in A2A/AP2 tasks.
+Utilities for managing x402 payment state in A2A/AP2 tasks. These helpers now power the **live in-band server flow** in `PaymentsA2AServer` (the [a2a-x402 extension](https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2) is declared on the agent card), so a payment-gated request with no payment yields an `input-required` task instead of an HTTP 402. Payment is signalled **in band** via task/message metadata, correlated by `taskId`:
+
+- **payment-required** → server sets task `status.state = "input-required"`, metadata `x402.payment.status = "payment-required"` + `x402.payment.required` (the `X402PaymentRequired`).
+- **payment-submitted** → client's follow-up `message/send` carries `x402.payment.status = "payment-submitted"` + `x402.payment.payload`.
+- **payment-completed / payment-failed** → final task carries `x402.payment.status` + `x402.payment.receipts` (or `x402.payment.error` on failure).
+
+The legacy `payment-signature` HTTP header is a **deprecated fallback (one release)**. See the [A2A Integration guide](../../docs/api/10-a2a-integration.md#in-band-x402-v2-payments-standards-flow) for the full lifecycle.
 
 ```python
 from payments_py.x402 import X402A2AUtils

--- a/payments_py/x402/a2a.py
+++ b/payments_py/x402/a2a.py
@@ -18,7 +18,7 @@ from typing import Optional, Union
 from a2a.types import Message, Task, TaskState, TaskStatus, TextPart
 
 # NOTE: PaymentStatus and x402Metadata are defined by the A2A x402 specification:
-# https://github.com/google-a2a/a2a-x402/blob/main/spec/v0.1/spec.md
+# https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2/spec.md
 #
 # These constants are also defined in x402_a2a.types.state, but we cannot import
 # from x402_a2a here as it would create a circular dependency (x402_a2a depends
@@ -28,12 +28,20 @@ from a2a.types import Message, Task, TaskState, TaskStatus, TextPart
 
 from enum import Enum
 
+# Official A2A x402 extension URI (v0.2). Declared in the agent card's
+# ``capabilities.extensions`` so generic, spec-compliant A2A clients can detect
+# and activate the in-band x402 payment flow. Matches the Coinbase x402 v2 A2A
+# transport spec: https://github.com/coinbase/x402/blob/main/specs/transports-v2/a2a.md
+A2A_X402_EXTENSION_URI = (
+    "https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2"
+)
+
 
 class PaymentStatus(str, Enum):
     """
     Protocol-defined payment states for A2A x402 flow.
 
-    As defined in: https://github.com/google-a2a/a2a-x402/blob/main/spec/v0.1/spec.md
+    As defined in: https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2/spec.md
     Section 6: State Management
 
     These values are part of the A2A x402 specification and must not be changed.
@@ -51,7 +59,7 @@ class x402Metadata:
     """
     Spec-defined metadata key constants for A2A x402 protocol.
 
-    As defined in: https://github.com/google-a2a/a2a-x402/blob/main/spec/v0.1/spec.md
+    As defined in: https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2/spec.md
     Section 6: State Management
 
     These keys are part of the A2A x402 specification and must not be changed.
@@ -462,4 +470,5 @@ __all__ = [
     "X402Metadata",  # Alias for x402Metadata
     "x402Metadata",  # Original protocol-defined name
     "PaymentStatus",  # Protocol-defined enum
+    "A2A_X402_EXTENSION_URI",  # Official v0.2 extension URI
 ]

--- a/tests/integration/a2a/test_complete_message_send_flow.py
+++ b/tests/integration/a2a/test_complete_message_send_flow.py
@@ -353,7 +353,12 @@ async def test_message_send_with_validation_failure():
 
 @pytest.mark.asyncio
 async def test_message_send_with_missing_bearer_token():
-    """Test message/send without bearer token."""
+    """message/send without a token yields an in-band payment-required task.
+
+    Standards path (x402 v2 A2A): no header token and no in-band payload on a
+    ``message/send`` returns an ``input-required`` task with the
+    ``X402PaymentRequired`` object in metadata — not an HTTP 402.
+    """
     mock_payments = MockPaymentsService()
 
     agent_card = {
@@ -402,14 +407,13 @@ async def test_message_send_with_missing_bearer_token():
     # No Authorization header
     response = client.post("/rpc", json=payload)
 
-    # Should return 402 (payment required) with payment-required header
-    assert response.status_code == 402
-    response_data = response.json()
-    assert "error" in response_data
-    assert "Missing payment-signature header" in response_data["error"]["message"]
-    assert "payment-required" in response.headers
-    # Verify the payment-required header contains planId and agentId
-    pr_data = json.loads(base64.b64decode(response.headers["payment-required"]))
+    # Should return an in-band payment-required task (not HTTP 402).
+    assert response.status_code == 200
+    task = response.json()["result"]
+    assert task["status"]["state"] == "input-required"
+    meta = task["status"]["message"]["metadata"]
+    assert meta["x402.payment.status"] == "payment-required"
+    pr_data = meta["x402.payment.required"]
     assert pr_data["accepts"][0]["planId"] == "test-plan"
     assert pr_data["accepts"][0]["extra"]["agentId"] == "test-agent-789"
 

--- a/tests/integration/a2a/test_decorator_integration.py
+++ b/tests/integration/a2a/test_decorator_integration.py
@@ -194,8 +194,15 @@ async def test_decorator_default_credits():
 
 
 @pytest.mark.asyncio
-async def test_decorator_missing_payment_signature_returns_402():
-    """Request without payment-signature header should get 402 with payment-required."""
+async def test_decorator_missing_token_returns_inband_payment_required():
+    """First message/send with no payment yields an in-band payment-required task.
+
+    Per the x402 v2 A2A transport, a payment-gated message with neither the
+    deprecated ``payment-signature`` header nor an in-band ``x402.payment.payload``
+    must NOT return HTTP 402 — it returns an ``input-required`` task carrying the
+    ``X402PaymentRequired`` object in ``x402.payment.required`` so standards
+    clients can pay on the follow-up message.
+    """
     mock_payments = MockPaymentsService()
 
     @a2a_requires_payment(
@@ -210,13 +217,15 @@ async def test_decorator_missing_payment_signature_returns_402():
 
     response = client.post("/rpc", json=_make_payload())
 
-    assert response.status_code == 402
-    assert "Missing payment-signature header" in response.json()["error"]["message"]
-    assert "payment-required" in response.headers
-    # Verify the payment-required header contains planId and agentId
-    pr_data = json.loads(base64.b64decode(response.headers["payment-required"]))
+    assert response.status_code == 200
+    task = response.json()["result"]
+    assert task["status"]["state"] == "input-required"
+    meta = task["status"]["message"]["metadata"]
+    assert meta["x402.payment.status"] == "payment-required"
+    pr_data = meta["x402.payment.required"]
     assert pr_data["accepts"][0]["planId"] == "test-plan"
     assert pr_data["accepts"][0]["extra"]["agentId"] == "decorator-test-agent"
+    # The agent must NOT run and nothing settles before payment.
     assert mock_payments.facilitator.validation_call_count == 0
     assert mock_payments.facilitator.settle_call_count == 0
 
@@ -317,8 +326,8 @@ async def test_decorator_agent_card_endpoint():
 
 
 @pytest.mark.asyncio
-async def test_decorator_multi_plan_missing_token_returns_402():
-    """Multi-plan agent card returns 402 with correct accepts[] entries."""
+async def test_decorator_multi_plan_missing_token_returns_inband_payment_required():
+    """Multi-plan card yields an in-band payment-required task with both plans."""
     mock_payments = MockPaymentsService()
 
     multi_plan_card = build_payment_agent_card(
@@ -348,9 +357,12 @@ async def test_decorator_multi_plan_missing_token_returns_402():
 
     response = client.post("/rpc", json=_make_payload())
 
-    assert response.status_code == 402
-    assert "payment-required" in response.headers
-    pr_data = json.loads(base64.b64decode(response.headers["payment-required"]))
+    assert response.status_code == 200
+    task = response.json()["result"]
+    assert task["status"]["state"] == "input-required"
+    meta = task["status"]["message"]["metadata"]
+    assert meta["x402.payment.status"] == "payment-required"
+    pr_data = meta["x402.payment.required"]
     assert len(pr_data["accepts"]) == 2
     assert pr_data["accepts"][0]["planId"] == "plan-a"
     assert pr_data["accepts"][1]["planId"] == "plan-b"

--- a/tests/integration/a2a/test_inband_x402.py
+++ b/tests/integration/a2a/test_inband_x402.py
@@ -282,9 +282,11 @@ async def test_inband_settlement_failure_suppresses_content():
     meta = task["status"]["message"]["metadata"]
     assert meta["x402.payment.status"] == "payment-failed"
     assert "x402.payment.error" in meta
-    # Paid content suppressed in artifacts AND anywhere else in the task.
+    # Paid content suppressed in artifacts, the status message, AND anywhere else.
     assert task.get("artifacts") in (None, [])
-    assert "PAID_SECRET_RESULT" not in response.text
+    assert "PAID_SECRET_RESULT" not in response.text  # artifact
+    assert "Request completed successfully!" not in response.text  # status message
+    assert task["status"]["message"]["parts"][0]["text"] == "Payment settlement failed."
     # Verify ran (token was valid) and settle was attempted once.
     assert mock_payments.facilitator.validation_call_count == 1
     assert mock_payments.facilitator.settle_call_count == 1

--- a/tests/integration/a2a/test_inband_x402.py
+++ b/tests/integration/a2a/test_inband_x402.py
@@ -1,0 +1,339 @@
+"""Integration tests for the in-band x402 v2 A2A payment transport.
+
+Exercises the full HTTP -> middleware -> handler -> settle path of the
+standards-compliant in-band flow defined by the Coinbase x402 v2 A2A transport
+spec (https://github.com/coinbase/x402/blob/main/specs/transports-v2/a2a.md):
+
+1. A payment-gated ``message/send`` with no header and no payload returns an
+   ``input-required`` task carrying ``x402.payment.required``.
+2. A ``message/send`` carrying ``x402.payment.payload`` verifies, executes,
+   settles, and the resulting task carries ``x402.payment.status =
+   payment-completed`` + ``x402.payment.receipts``. (Real clients correlate the
+   payload to the prior payment-required task via ``message.taskId``; the
+   server-side verify/execute/settle behaviour under test is identical.)
+3. A settlement failure yields ``payment-failed`` + ``x402.payment.error`` and
+   does NOT deliver the agent's content.
+
+The deprecated ``payment-signature`` header path is covered separately in
+``test_complete_message_send_flow.py`` (regression).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from a2a.types import Artifact, TaskArtifactUpdateEvent
+
+from payments_py.a2a.server import PaymentsA2AServer
+
+# Reuse the battle-tested mocks/executor from the existing flow test.
+from tests.integration.a2a.test_complete_message_send_flow import (
+    DummyExecutor,
+    MockPaymentsService,
+    mock_decode_token,
+)
+
+
+class _ArtifactDummyExecutor(DummyExecutor):
+    """DummyExecutor that ALSO emits the paid result as an artifact.
+
+    The x402 A2A spec's own example delivers paid content as an artifact, so this
+    lets the settlement-failure test prove suppression covers artifacts and not
+    only the status message.
+    """
+
+    async def execute(self, context, event_queue):  # noqa: ANN001, D401
+        task_id = getattr(context, "task_id", None)
+        context_id = getattr(context, "context_id", None) or "test-ctx"
+        await event_queue.enqueue_event(
+            TaskArtifactUpdateEvent(
+                task_id=task_id or "t",
+                context_id=context_id,
+                artifact=Artifact(
+                    artifact_id="paid-artifact",
+                    parts=[{"kind": "text", "text": "PAID_SECRET_RESULT"}],
+                ),
+            )
+        )
+        await super().execute(context, event_queue)
+
+
+AGENT_CARD = {
+    "capabilities": {
+        "extensions": [
+            {
+                "uri": "urn:nevermined:payment",
+                "params": {
+                    "agentId": "test-agent-inband",
+                    "credits": 10,
+                    "planId": "test-plan",
+                    "paymentType": "credits",
+                },
+            }
+        ]
+    },
+}
+
+
+def _payment_payload() -> dict:
+    """A v2 PaymentPayload object as it travels in x402.payment.payload."""
+    return {
+        "x402Version": 2,
+        "accepted": {
+            "scheme": "nvm:erc4337",
+            "network": "eip155:84532",
+            "planId": "test-plan",
+            "extra": {"version": "1"},
+        },
+        "payload": {
+            "signature": "0x123",
+            "authorization": {"from": "0xTestSubscriber"},
+        },
+    }
+
+
+def _make_client(payments, executor) -> TestClient:
+    result = PaymentsA2AServer.start(
+        payments_service=payments,  # type: ignore[arg-type]
+        agent_card=AGENT_CARD,
+        executor=executor,
+        port=0,
+        base_path="/rpc",
+        expose_default_routes=True,
+    )
+    return TestClient(result.app)
+
+
+# ---------------------------------------------------------------------------
+# 1. First contact -> input-required payment-required task
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_inband_first_contact_returns_payment_required_task():
+    mock_payments = MockPaymentsService()
+    client = _make_client(mock_payments, DummyExecutor())
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": "msg-first",
+                "contextId": "ctx-first",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "do the thing"}],
+            }
+        },
+    }
+    response = client.post("/rpc", json=payload)
+
+    assert response.status_code == 200
+    task = response.json()["result"]
+    assert task["kind"] == "task"
+    assert task["status"]["state"] == "input-required"
+    meta = task["status"]["message"]["metadata"]
+    assert meta["x402.payment.status"] == "payment-required"
+    pr = meta["x402.payment.required"]
+    assert pr["x402Version"] == 2
+    assert pr["accepts"][0]["planId"] == "test-plan"
+    assert pr["accepts"][0]["extra"]["agentId"] == "test-agent-inband"
+    # Agent must not run and nothing settles before payment.
+    assert mock_payments.facilitator.validation_call_count == 0
+    assert mock_payments.facilitator.settle_call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Follow-up payload -> verify + execute + settle + receipts
+# ---------------------------------------------------------------------------
+@patch(
+    "payments_py.a2a.payments_request_handler.decode_access_token", mock_decode_token
+)
+@pytest.mark.asyncio
+async def test_inband_payload_verifies_executes_and_settles():
+    mock_payments = MockPaymentsService()
+    client = _make_client(mock_payments, DummyExecutor(credits_to_use=3))
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": "msg-pay",
+                "contextId": "ctx-pay",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "here is my payment"}],
+                "metadata": {
+                    "x402.payment.status": "payment-submitted",
+                    "x402.payment.payload": _payment_payload(),
+                },
+            }
+        },
+    }
+    response = client.post("/rpc", json=payload)
+
+    assert response.status_code == 200, response.text
+    task = response.json()["result"]
+    assert task["status"]["state"] == "completed"
+    meta = task["status"]["message"]["metadata"]
+    # Spec settlement signalling.
+    assert meta["x402.payment.status"] == "payment-completed"
+    receipts = meta["x402.payment.receipts"]
+    assert receipts["success"] is True
+    assert receipts["transaction"].startswith("0xtest")
+    # The token was carried in-band: verify + settle both ran.
+    assert mock_payments.facilitator.validation_call_count == 1
+    assert mock_payments.facilitator.settle_call_count == 1
+    assert mock_payments.facilitator.last_settle_credits == 3
+    # Agent content is still delivered on success.
+    assert (
+        task["status"]["message"]["parts"][0]["text"]
+        == "Request completed successfully!"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3a. Verification failure -> payment-failed, agent never runs
+# ---------------------------------------------------------------------------
+@patch(
+    "payments_py.a2a.payments_request_handler.decode_access_token", mock_decode_token
+)
+@pytest.mark.asyncio
+async def test_inband_verification_failure_returns_payment_failed():
+    mock_payments = MockPaymentsService()
+    mock_payments.facilitator.should_fail_validation = True
+    client = _make_client(mock_payments, DummyExecutor())
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": "msg-badpay",
+                "contextId": "ctx-badpay",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "bad payment"}],
+                "metadata": {
+                    "x402.payment.status": "payment-submitted",
+                    "x402.payment.payload": _payment_payload(),
+                },
+            }
+        },
+    }
+    response = client.post("/rpc", json=payload)
+
+    assert response.status_code == 200, response.text
+    task = response.json()["result"]
+    assert task["status"]["state"] == "failed"
+    meta = task["status"]["message"]["metadata"]
+    assert meta["x402.payment.status"] == "payment-failed"
+    assert "x402.payment.error" in meta
+    # Verification was attempted, but the agent never ran and nothing settled.
+    assert mock_payments.facilitator.validation_call_count == 1
+    assert mock_payments.facilitator.settle_call_count == 0
+    assert (
+        task["status"]["message"]["parts"][0]["text"]
+        != "Request completed successfully!"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3b. Settlement failure -> payment-failed, agent content suppressed
+# ---------------------------------------------------------------------------
+@patch(
+    "payments_py.a2a.payments_request_handler.decode_access_token", mock_decode_token
+)
+@pytest.mark.asyncio
+async def test_inband_settlement_failure_suppresses_content():
+    mock_payments = MockPaymentsService()
+    mock_payments.facilitator.should_fail_settle = True
+    # Executor emits the paid result as an artifact too, so suppression is proven
+    # against artifacts, not only the status message.
+    client = _make_client(mock_payments, _ArtifactDummyExecutor(credits_to_use=4))
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": "msg-settlefail",
+                "contextId": "ctx-settlefail",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "pay then fail settle"}],
+                "metadata": {
+                    "x402.payment.status": "payment-submitted",
+                    "x402.payment.payload": _payment_payload(),
+                },
+            }
+        },
+    }
+    response = client.post("/rpc", json=payload)
+
+    assert response.status_code == 200, response.text
+    task = response.json()["result"]
+    # Settlement failed after execution: task is forced failed and the paid
+    # content is dropped (never deliver paid content without settlement).
+    assert task["status"]["state"] == "failed"
+    meta = task["status"]["message"]["metadata"]
+    assert meta["x402.payment.status"] == "payment-failed"
+    assert "x402.payment.error" in meta
+    # Paid content suppressed in artifacts AND anywhere else in the task.
+    assert task.get("artifacts") in (None, [])
+    assert "PAID_SECRET_RESULT" not in response.text
+    # Verify ran (token was valid) and settle was attempted once.
+    assert mock_payments.facilitator.validation_call_count == 1
+    assert mock_payments.facilitator.settle_call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Deprecated payment-signature header path still works (regression).
+# ---------------------------------------------------------------------------
+@patch(
+    "payments_py.a2a.payments_request_handler.decode_access_token", mock_decode_token
+)
+@pytest.mark.asyncio
+async def test_legacy_header_path_still_settles_without_inband_metadata():
+    """The deprecated ``payment-signature`` header path remains functional.
+
+    It settles credits and returns a ``completed`` task, but does NOT stamp the
+    in-band x402 metadata (that is reserved for the standards in-band flow).
+    """
+    mock_payments = MockPaymentsService()
+    client = _make_client(mock_payments, DummyExecutor(credits_to_use=2))
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": "msg-legacy",
+                "contextId": "ctx-legacy",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "legacy header pay"}],
+            }
+        },
+    }
+    response = client.post(
+        "/rpc", json=payload, headers={"payment-signature": "LEGACY_TOKEN"}
+    )
+
+    assert response.status_code == 200, response.text
+    task = response.json()["result"]
+    assert task["status"]["state"] == "completed"
+    # Legacy path: credits settled, agent content delivered, no in-band metadata.
+    assert mock_payments.facilitator.validation_call_count == 1
+    assert mock_payments.facilitator.settle_call_count == 1
+    assert mock_payments.facilitator.last_settle_credits == 2
+    assert (
+        task["status"]["message"]["parts"][0]["text"]
+        == "Request completed successfully!"
+    )
+    meta = task["status"]["message"].get("metadata") or {}
+    assert "x402.payment.status" not in meta
+    assert "x402.payment.receipts" not in meta

--- a/tests/integration/a2a/test_payments_server.py
+++ b/tests/integration/a2a/test_payments_server.py
@@ -105,14 +105,12 @@ def test_agent_card_endpoint(agent_card, dummy_payments, base_path):  # noqa: D4
     )
 
     client = TestClient(srv.app)
-    url = (
-        f"{base_path.rstrip('/')}/.well-known/agent.json"
-        if base_path != "/"
-        else "/.well-known/agent.json"
-    )
-    resp = client.get(url)
-    assert resp.status_code == 200
-    assert resp.json()["name"] == "PyAgent"
+    prefix = base_path.rstrip("/") if base_path != "/" else ""
+    # Canonical path (A2A >= 0.3) and legacy alias must both serve the card.
+    for well_known in (".well-known/agent-card.json", ".well-known/agent.json"):
+        resp = client.get(f"{prefix}/{well_known}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "PyAgent"
 
 
 flag = {"before": False, "after": False, "error": False}

--- a/tests/unit/a2a/test_agent_card.py
+++ b/tests/unit/a2a/test_agent_card.py
@@ -3,6 +3,11 @@
 import pytest
 
 from payments_py.a2a.agent_card import build_payment_agent_card
+from payments_py.x402.a2a import A2A_X402_EXTENSION_URI
+
+
+def _ext_by_uri(card, uri):
+    return next(e for e in card["capabilities"]["extensions"] if e["uri"] == uri)
 
 
 def test_build_payment_agent_card_success():  # noqa: D401
@@ -15,9 +20,11 @@ def test_build_payment_agent_card_success():  # noqa: D401
         "costDescription": "5 credits per call",
     }
     card = build_payment_agent_card(base_card, metadata)  # type: ignore[arg-type]
-    ext = card["capabilities"]["extensions"][-1]
-    assert ext["uri"] == "urn:nevermined:payment"
+    ext = _ext_by_uri(card, "urn:nevermined:payment")
     assert ext["params"]["agentId"] == "agent-1"
+    # The official A2A x402 v0.2 extension is also declared for standards clients.
+    official = _ext_by_uri(card, A2A_X402_EXTENSION_URI)
+    assert official["required"] is False
 
 
 def test_build_payment_agent_card_with_plan_ids():  # noqa: D401
@@ -30,10 +37,11 @@ def test_build_payment_agent_card_with_plan_ids():  # noqa: D401
         "planIds": ["plan-1", "plan-2"],
     }
     card = build_payment_agent_card(base_card, metadata)  # type: ignore[arg-type]
-    ext = card["capabilities"]["extensions"][-1]
-    assert ext["uri"] == "urn:nevermined:payment"
+    ext = _ext_by_uri(card, "urn:nevermined:payment")
     assert ext["params"]["planIds"] == ["plan-1", "plan-2"]
     assert "planId" not in ext["params"]
+    # Official extension present alongside the Nevermined one.
+    assert _ext_by_uri(card, A2A_X402_EXTENSION_URI)["uri"] == A2A_X402_EXTENSION_URI
 
 
 # noqa: WPS437

--- a/tests/unit/a2a/test_inband.py
+++ b/tests/unit/a2a/test_inband.py
@@ -1,0 +1,281 @@
+"""Unit tests for the in-band x402 v2 A2A helpers and handler integration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
+from a2a.types import Task, TaskState, TaskStatus, TaskStatusUpdateEvent
+
+from payments_py.a2a.inband import (
+    extract_inband_token,
+    get_inband_payment_payload,
+    get_inband_payment_status,
+    is_payment_submission,
+    resolve_token_for_message,
+)
+from payments_py.a2a.payments_request_handler import PaymentsRequestHandler
+from payments_py.a2a.types import HttpRequestContext
+from payments_py.x402.a2a import x402Metadata
+from payments_py.x402.token import decode_access_token
+from payments_py.x402.types import SettleResponse
+
+
+class DummyExecutor:  # noqa: D101
+    async def execute(self, *args, **kwargs):  # noqa: D401
+        pass
+
+
+def _payload() -> dict:
+    return {
+        "x402Version": 2,
+        "accepted": {"scheme": "nvm:erc4337", "planId": "plan-1"},
+        "payload": {"authorization": {"from": "0xSubscriber"}},
+    }
+
+
+def _message_with_payload() -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata={
+            x402Metadata.STATUS_KEY: "payment-submitted",
+            x402Metadata.PAYLOAD_KEY: _payload(),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper extraction
+# ---------------------------------------------------------------------------
+def test_get_inband_payment_payload_and_status_from_dict_message():
+    msg = {
+        "metadata": {
+            x402Metadata.STATUS_KEY: "payment-submitted",
+            x402Metadata.PAYLOAD_KEY: _payload(),
+        }
+    }
+    assert get_inband_payment_payload(msg) == _payload()
+    assert get_inband_payment_status(msg) == "payment-submitted"
+    assert is_payment_submission(msg) is True
+
+
+def test_get_inband_payment_payload_absent_returns_none():
+    assert get_inband_payment_payload(SimpleNamespace(metadata={})) is None
+    assert get_inband_payment_payload(SimpleNamespace(metadata=None)) is None
+    assert get_inband_payment_payload(None) is None
+    assert is_payment_submission(SimpleNamespace(metadata={})) is False
+
+
+# ---------------------------------------------------------------------------
+# Token plumbing: in-band payload <-> base64 access token round-trip
+# ---------------------------------------------------------------------------
+def test_extract_inband_token_roundtrips_through_decode():
+    """The re-encoded token must decode back to the original payload object.
+
+    This is the core reconciliation: the facilitator consumes the base64
+    token, while the in-band transport carries the decoded payload object.
+    """
+    msg = _message_with_payload()
+    token = extract_inband_token(msg)
+    assert isinstance(token, str) and token
+
+    decoded = decode_access_token(token)
+    assert decoded == _payload()
+    # The subscriber address the handler reads survives the round-trip.
+    assert decoded["payload"]["authorization"]["from"] == "0xSubscriber"
+
+
+def test_extract_inband_token_none_when_no_payload():
+    assert extract_inband_token(SimpleNamespace(metadata={})) is None
+
+
+def test_resolve_token_prefers_inband_over_header():
+    msg = _message_with_payload()
+    http_ctx = SimpleNamespace(bearer_token="HEADER_TOKEN")
+    token, from_inband = resolve_token_for_message(msg, http_ctx)
+    assert from_inband is True
+    assert decode_access_token(token) == _payload()
+
+
+def test_resolve_token_falls_back_to_header():
+    msg = SimpleNamespace(metadata={})
+    http_ctx = SimpleNamespace(bearer_token="HEADER_TOKEN")
+    token, from_inband = resolve_token_for_message(msg, http_ctx)
+    assert from_inband is False
+    assert token == "HEADER_TOKEN"
+
+
+def test_resolve_token_none_when_neither_present():
+    token, from_inband = resolve_token_for_message(SimpleNamespace(metadata={}), None)
+    assert token is None
+    assert from_inband is False
+
+
+# ---------------------------------------------------------------------------
+# Handler helpers
+# ---------------------------------------------------------------------------
+def _handler() -> PaymentsRequestHandler:
+    return PaymentsRequestHandler(
+        agent_card={
+            "capabilities": {
+                "extensions": [
+                    {
+                        "uri": "urn:nevermined:payment",
+                        "params": {"agentId": "agent-1", "planId": "plan-1"},
+                    }
+                ]
+            }
+        },
+        task_store=InMemoryTaskStore(),
+        agent_executor=DummyExecutor(),
+        payments_service=SimpleNamespace(environment_name="staging_sandbox"),
+    )
+
+
+def test_build_payment_required_task_shape():
+    handler = _handler()
+    task = handler._build_payment_required_task(
+        task_id=None,
+        context_id="ctx-1",
+        agent_id="agent-1",
+        ext_params={"planId": "plan-1"},
+    )
+    assert task.status.state == TaskState.input_required
+    meta = task.status.message.metadata
+    assert meta[x402Metadata.STATUS_KEY] == "payment-required"
+    pr = meta[x402Metadata.REQUIRED_KEY]
+    assert pr["x402Version"] == 2
+    assert pr["accepts"][0]["planId"] == "plan-1"
+    assert pr["accepts"][0]["extra"]["agentId"] == "agent-1"
+
+
+def test_build_payment_failed_task_shape():
+    handler = _handler()
+    task = handler._build_payment_failed_task(
+        task_id="tid",
+        context_id="ctx",
+        code="PAYMENT_VERIFICATION_FAILED",
+        reason="bad signature",
+    )
+    assert task.status.state == TaskState.failed
+    meta = task.status.message.metadata
+    assert meta[x402Metadata.STATUS_KEY] == "payment-failed"
+    assert meta[x402Metadata.ERROR_KEY]["code"] == "PAYMENT_VERIFICATION_FAILED"
+
+
+def test_apply_inband_settlement_success_stamps_receipt():
+    handler = _handler()
+    task = Task(
+        id="tid",
+        context_id="ctx",
+        status=TaskStatus(state=TaskState.completed),
+        history=[],
+    )
+    handler._settle_receipt_by_task["tid"] = SettleResponse(
+        success=True, transaction="0xfeed", network="eip155:84532"
+    )
+    handler._apply_inband_settlement(task, "tid")
+
+    meta = task.status.message.metadata
+    assert meta[x402Metadata.STATUS_KEY] == "payment-completed"
+    assert meta[x402Metadata.RECEIPTS_KEY]["transaction"] == "0xfeed"
+    # Receipt consumed (popped) so a later call is a no-op.
+    assert "tid" not in handler._settle_receipt_by_task
+
+
+def test_apply_inband_settlement_failure_forces_failed_and_drops_content():
+    handler = _handler()
+    task = Task(
+        id="tid",
+        context_id="ctx",
+        status=TaskStatus(state=TaskState.completed),
+        history=[],
+        artifacts=[{"artifactId": "a1", "name": "secret", "parts": []}],
+    )
+    handler._settle_receipt_by_task["tid"] = SettleResponse(
+        success=False, error_reason="insufficient funds"
+    )
+    handler._apply_inband_settlement(task, "tid")
+
+    assert task.status.state == TaskState.failed
+    assert task.artifacts is None  # paid content suppressed
+    meta = task.status.message.metadata
+    assert meta[x402Metadata.STATUS_KEY] == "payment-failed"
+
+
+def test_apply_inband_settlement_noop_without_receipt():
+    handler = _handler()
+    task = Task(
+        id="tid",
+        context_id="ctx",
+        status=TaskStatus(state=TaskState.completed),
+        history=[],
+    )
+    # No receipt recorded (free / no-credit call): nothing is stamped.
+    handler._apply_inband_settlement(task, "tid")
+    assert task.status.state == TaskState.completed
+    assert task.status.message is None
+
+
+@pytest.mark.asyncio
+async def test_finalization_does_not_store_receipt_on_legacy_header_path():
+    """The legacy header path (inband=False) must not retain settle receipts.
+
+    Locks in the fix that prevents ``_settle_receipt_by_task`` from growing
+    unbounded for header-path callers that never consume the receipt.
+    """
+    settle_mock = Mock(return_value=SettleResponse(success=True, transaction="0xabc"))
+    handler = PaymentsRequestHandler(
+        agent_card={
+            "capabilities": {
+                "extensions": [
+                    {
+                        "uri": "urn:nevermined:payment",
+                        "params": {"agentId": "agent-1", "planId": "plan-1"},
+                    }
+                ]
+            }
+        },
+        task_store=InMemoryTaskStore(),
+        agent_executor=DummyExecutor(),
+        payments_service=SimpleNamespace(
+            facilitator=SimpleNamespace(settle_permissions=settle_mock)
+        ),
+    )
+    event = TaskStatusUpdateEvent(
+        task_id="tid-legacy",
+        context_id="ctx",
+        status=TaskStatus(state=TaskState.completed),
+        final=True,
+        metadata={"creditsUsed": 2},
+    )
+    ctx = HttpRequestContext(
+        bearer_token="HEADER",
+        url_requested="https://x",
+        http_method_requested="POST",
+        validation={"plan_id": "plan-1"},
+        inband=False,
+    )
+    await handler._handle_task_finalization_from_event(event, ctx)
+
+    settle_mock.assert_called_once()
+    # Header path settles but stores no receipt (nothing would ever pop it).
+    assert "tid-legacy" not in handler._settle_receipt_by_task
+
+
+def test_coerce_settle_response_from_duck_typed_object():
+    obj = SimpleNamespace(
+        success=True, transaction="0xabc", network="eip155:84532", payer="0xp"
+    )
+    coerced = PaymentsRequestHandler._coerce_settle_response(obj)
+    assert isinstance(coerced, SettleResponse)
+    assert coerced.transaction == "0xabc"
+    # by_alias serialization carries the x402 receipt fields.
+    dumped = coerced.model_dump(by_alias=True)
+    assert dumped["success"] is True
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/unit/a2a/test_inband.py
+++ b/tests/unit/a2a/test_inband.py
@@ -13,9 +13,6 @@ from a2a.types import Task, TaskState, TaskStatus, TaskStatusUpdateEvent
 from payments_py.a2a.inband import (
     extract_inband_token,
     get_inband_payment_payload,
-    get_inband_payment_status,
-    is_payment_submission,
-    resolve_token_for_message,
 )
 from payments_py.a2a.payments_request_handler import PaymentsRequestHandler
 from payments_py.a2a.types import HttpRequestContext
@@ -49,7 +46,7 @@ def _message_with_payload() -> SimpleNamespace:
 # ---------------------------------------------------------------------------
 # Helper extraction
 # ---------------------------------------------------------------------------
-def test_get_inband_payment_payload_and_status_from_dict_message():
+def test_get_inband_payment_payload_from_dict_message():
     msg = {
         "metadata": {
             x402Metadata.STATUS_KEY: "payment-submitted",
@@ -57,15 +54,12 @@ def test_get_inband_payment_payload_and_status_from_dict_message():
         }
     }
     assert get_inband_payment_payload(msg) == _payload()
-    assert get_inband_payment_status(msg) == "payment-submitted"
-    assert is_payment_submission(msg) is True
 
 
 def test_get_inband_payment_payload_absent_returns_none():
     assert get_inband_payment_payload(SimpleNamespace(metadata={})) is None
     assert get_inband_payment_payload(SimpleNamespace(metadata=None)) is None
     assert get_inband_payment_payload(None) is None
-    assert is_payment_submission(SimpleNamespace(metadata={})) is False
 
 
 # ---------------------------------------------------------------------------
@@ -89,28 +83,6 @@ def test_extract_inband_token_roundtrips_through_decode():
 
 def test_extract_inband_token_none_when_no_payload():
     assert extract_inband_token(SimpleNamespace(metadata={})) is None
-
-
-def test_resolve_token_prefers_inband_over_header():
-    msg = _message_with_payload()
-    http_ctx = SimpleNamespace(bearer_token="HEADER_TOKEN")
-    token, from_inband = resolve_token_for_message(msg, http_ctx)
-    assert from_inband is True
-    assert decode_access_token(token) == _payload()
-
-
-def test_resolve_token_falls_back_to_header():
-    msg = SimpleNamespace(metadata={})
-    http_ctx = SimpleNamespace(bearer_token="HEADER_TOKEN")
-    token, from_inband = resolve_token_for_message(msg, http_ctx)
-    assert from_inband is False
-    assert token == "HEADER_TOKEN"
-
-
-def test_resolve_token_none_when_neither_present():
-    token, from_inband = resolve_token_for_message(SimpleNamespace(metadata={}), None)
-    assert token is None
-    assert from_inband is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The A2A integration only interoperated with Nevermined's **own** SDK. The agent card was served at the pre-spec `/.well-known/agent.json`, but stock A2A clients (and `a2a-sdk` 0.3+) discover it at `/.well-known/agent-card.json`, so third-party A2A clients 404'd on Nevermined Python agents. And payment used a home-grown HTTP-header paywall rather than the standard, so a generic A2A agent couldn't pay a Nevermined agent. A2A's whole value is cross-vendor interoperability, so this defeated the purpose.

This is the A2A analog of the MCP in-band migration the team already shipped (#228), applying the same approach to the A2A transport. Notably, the in-band utilities (`X402A2AUtils`) already existed in `payments_py/x402/a2a.py` but were **latent** — this PR wires them into the live server/handler.

## What

### 1. Canonical agent-card discovery (interop fix)
- Serve the card at the canonical `/.well-known/agent-card.json`, keeping `/.well-known/agent.json` as a backward-compat **alias**. (The client synthesizes a minimal card from the base URL, so no client change is needed.)

### 2. In-band x402 v2 A2A transport (standards payment flow)
Per the [Coinbase x402 v2 A2A transport spec](https://github.com/coinbase/x402/blob/main/specs/transports-v2/a2a.md) + the official [a2a-x402 extension](https://github.com/google-agentic-commerce/a2a-x402):
- The agent card now declares the official extension URI (`.../a2a-x402/blob/main/spec/v0.2`) alongside `urn:nevermined:payment` (kept one release). `x402/a2a.py` spec references bumped v0.1 → v0.2.
- **Payment required** → server returns an `input-required` Task with `x402.payment.status: payment-required` + `x402.payment.required` metadata (no HTTP 402).
- **Payment submitted** → the payload is read from the message's `x402.payment.payload` metadata, re-encoded to the base64 token the facilitator verify/settle path already expects.
- **Settlement** is stamped in band (`payment-completed` + `x402.payment.receipts`). **A settlement failure forces `failed`/`payment-failed` and drops paid content — status message, artifacts AND history — so a paid result is never delivered without settlement landing.**
- The legacy `payment-signature` header flow is kept as a **deprecated fallback (one release)**.

New module `payments_py/a2a/inband.py` (in-band payload extraction + token re-encode) wires the latent `X402A2AUtils` into the server.

## Backward compatibility
- Legacy `/.well-known/agent.json` still served (alias); legacy `payment-signature` header flow still works (deprecated).
- The shared `x402/a2a.py` change is covered by the existing MCP suite (no regression).

## Tests
- New coverage: first-contact → `input-required`; in-band payload → verify/execute/settle/receipts; verify/settle failure with **content + artifact** suppression; legacy-header regression.
- `black` clean; **85 a2a / 691 full suite** (`-m "not slow"`) green.

## Deferred (out of scope)
- **A2A 1.0** — `a2a-sdk` 1.x is GA but `@a2a-js/sdk` 1.0 is still alpha; defer to keep TS/Python parity.
- **AP2 embedded flow** — the in-band structures are AP2-nestable; build when a counterparty exists.
- **Agent-card JWS signing** — production hardening, later.

## Pre-release note
The in-band token round-trip is verified at the codec level + against the mocked facilitator. A live-facilitator E2E pass on staging is worth running before release, same caveat as the MCP PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
