### PR TITLE
docs(mcp): plan-centric MCP server config + fix a2a link-rot

### DIFF
--- a/docs/api/09-mcp-integration.md
+++ b/docs/api/09-mcp-integration.md
@@ -322,15 +322,15 @@ asyncio.run(main())
 | Option | Type | Description |
 |--------|------|-------------|
 | `credits` | `int` or `callable` | Credits to consume per call |
-| `planId` | `str` | Optional override for the plan ID (otherwise inferred from token) |
+| `planId` | `str` | Per-handler plan ID override. A server-level `planId` (set via `configure`/`start`) is required; set this only to charge a different plan for this handler. |
 | `maxAmount` | `int` | Max credits to verify during authentication (default: `1`) |
-| `onRedeemError` | `str` | `"ignore"` (default) or `"propagate"` to raise on redemption failure |
+| `onRedeemError` | `str` | On post-execution settlement failure: `"ignore"` (default) returns the in-band payment error; `"propagate"` raises a JSON-RPC error. Tool content is always suppressed either way (a paid result is never delivered without settlement). |
 
 ## In-band x402 signaling (`_meta`)
 
 The MCP transport follows the [x402 v2 MCP transport specification](https://github.com/coinbase/x402/blob/main/specs/transports-v2/mcp.md): payments are signalled **in band** through the MCP tool-call machinery, not via HTTP status codes or headers.
 
-**Request — payment payload.** The client sends the x402 `PaymentPayload` as plain JSON in the tool-call request params under `_meta["x402/payment"]`:
+**Request — payment payload.** The client sends the x402 `PaymentPayload` as plain JSON in the tool-call request params under `_meta["x402/payment"]`. This is the **payment** channel — separate from session auth: the MCP session is an OAuth-protected resource, so the client must also send an `Authorization: Bearer <access_token>` header when opening the transport to establish the session (`initialize` returns `401` without it).
 
 ```json
 {

--- a/docs/api/10-a2a-integration.md
+++ b/docs/api/10-a2a-integration.md
@@ -212,7 +212,7 @@ payment-required: eyJ4NDAy... (base64-encoded X402PaymentRequired)
 
 ## In-Band x402 v2 Payments (Standards Flow)
 
-Payment is signalled **in band** following the [Coinbase x402 v2 A2A transport spec](https://github.com/coinbase/x402/blob/main/specs/transports-v2/a2a.md) and the official [a2a-x402 extension](https://github.com/google-agentic-commerce/a2a-x402). The `X402A2AUtils` helpers (see [x402 README](../../payments_py/x402/README.md)) now power this live server flow — `PaymentsA2AServer` stamps and reads the metadata automatically, so the executor is unchanged. The handshake rides on A2A task/message metadata, correlated by `taskId` — no HTTP 402 is exchanged.
+Payment is signalled **in band** following the [Coinbase x402 v2 A2A transport spec](https://github.com/coinbase/x402/blob/main/specs/transports-v2/a2a.md) and the official [a2a-x402 extension](https://github.com/google-agentic-commerce/a2a-x402). The `X402A2AUtils` helpers (see [x402 README](https://github.com/nevermined-io/payments-py/blob/main/payments_py/x402/README.md)) now power this live server flow — `PaymentsA2AServer` stamps and reads the metadata automatically, so the executor is unchanged. The handshake rides on A2A task/message metadata, correlated by `taskId` — no HTTP 402 is exchanged.
 
 Lifecycle:
 


### PR DESCRIPTION
## Summary
Source-doc fixes in `docs/api/` so the next release's auto-synced docs PR is correct and passes link validation. The docs site's `api-reference/python/**` is **generated from this repo**, so these belong here, not hand-edited in the docs repo.

## Changes
- **`docs/api/09-mcp-integration.md`** — plan-centric refinements (the agentId-optional examples + options table were already current on `main`; this fills the remaining gaps):
  - Handler Options table: `planId` reworded as a per-handler override on top of a required server-level `planId`; `onRedeemError` clarified (on post-execution settlement failure, tool content is always suppressed — a paid result is never delivered without settlement).
  - In-band request section: added a session-auth note — the MCP session is an OAuth-protected resource, so the client must send an `Authorization: Bearer <access_token>` header to establish the session (`initialize` returns `401` without it); the payment is the separate in-band `_meta["x402/payment"]` channel.
- **`docs/api/10-a2a-integration.md`** — fixed link-rot: the relative `../../payments_py/x402/README.md` link resolves in the repo but 404s once synced to the docs site. This is exactly why the v1.15.0 release docs PR (nevermined-io/docs#234) fails the Mintlify **link-rot** check. Replaced with an absolute GitHub URL (valid in both mkdocs and the site).

## Why now
After this merges + a patch release, the release bot's docs sync PR will carry the corrected MCP api-reference **and** pass link-rot — no hand-editing of the generated `api-reference/**` in the docs repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)