### PR TITLE
chore(deps): add uvicorn to the [fastapi] extra for MCP server

### DIFF
--- a/docs/api/01-installation.md
+++ b/docs/api/01-installation.md
@@ -36,7 +36,8 @@ poetry add payments-py
 
 ### With Optional Dependencies
 
-For FastAPI/x402 middleware support:
+For FastAPI/x402 middleware and MCP server support (installs `fastapi`,
+`starlette`, and `uvicorn`):
 
 ```bash
 # Using pip

--- a/poetry.lock
+++ b/poetry.lock
@@ -4462,7 +4462,7 @@ markers = {main = "extra == \"langchain\" or extra == \"langsmith\""}
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
 [extras]
-fastapi = ["fastapi", "starlette"]
+fastapi = ["fastapi", "starlette", "uvicorn"]
 langchain = ["langchain-core"]
 langsmith = ["fastapi", "langsmith", "starlette"]
 strands = ["strands-agents"]
@@ -4470,4 +4470,4 @@ strands = ["strands-agents"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "46e0eaa0ff5f06bafcbccc29e3ca3caf24dff099d50454d01c1b34055231c392"
+content-hash = "3cea49787ab8fc8656a783277dc7be42e7f56b911565c7a51d7dbb562a454683"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,13 @@ mcp = "^1.25.0"
 # Optional dependencies
 fastapi = {version = "^0.120.0", optional = true}
 starlette = {version = "^0.49.1", optional = true}
+uvicorn = {version = "^0.31.1", optional = true}
 strands-agents = {version = ">=1.0.0", optional = true}
 langchain-core = {version = ">=0.3.0", optional = true}
 langsmith = {version = ">=0.1.40,<1.0.0", optional = true}
 
 [tool.poetry.extras]
-fastapi = ["fastapi", "starlette"]
+fastapi = ["fastapi", "starlette", "uvicorn"]
 strands = ["strands-agents"]
 langchain = ["langchain-core"]
 langsmith = ["langsmith", "fastapi", "starlette"]


### PR DESCRIPTION
## Description

The MCP server (`payments_py/mcp/core/server_manager.py`) does `import uvicorn`
and serves via `uvicorn.Config` / `uvicorn.Server` at runtime, but `uvicorn` was
declared **only** under `[tool.poetry.group.test.dependencies]` — it never
shipped to consumers. So `pip install payments-py[fastapi]` installed
`fastapi` + `starlette` but **not** `uvicorn`, and starting an MCP server
crashed with `ModuleNotFoundError: No module named 'uvicorn'`.

Changes:
- Declare `uvicorn = {version = "^0.31.1", optional = true}` under
  `[tool.poetry.dependencies]`.
- Add `"uvicorn"` to the `fastapi` extra so the extra is self-sufficient to run
  the MCP server.
- Regenerate `poetry.lock` (`[extras]` map + content-hash only).
- Broaden `docs/api/01-installation.md` to note MCP server support and enumerate
  the now-three included deps.

The pin (`^0.31.1`) matches the existing test-group pin — not invented. No
version bump (release pipeline owns versioning).

Verified: `poetry install --extras fastapi --dry-run` pulls `uvicorn (0.31.1)`;
`poetry check --lock` clean; `poetry run black --check .` clean;
`poetry run mkdocs build` OK.

## Is this PR related with an open issue?

Closes #240
Part of nevermined-io/nvm-monorepo#2004

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes (packaging-only change; no code paths to unit-test — verified via `poetry install --extras fastapi --dry-run`)
- [x] Documentation

#### Funny gif

![dependency resolved](https://media.giphy.com/media/3o7aTskHEUdgCQAXde/giphy.gif)