### PR TITLE
ci(docs): catch docs link-rot before release (staged link-check gate)

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -39,16 +39,16 @@ jobs:
       - name: Lint synced-doc links (escaping / unmapped relative links)
         run: python3 scripts/lint_doc_links.py
 
-  # BACKSTOP: replicate the docs-site sync, then run the REAL Mintlify checker
-  # against the staged whole site. Internal links only (no --check-external —
-  # external liveness is flaky and must not block). Depends on cloning the
-  # public docs repo + npx mintlify, so it is non-blocking on PRs
-  # (continue-on-error) and a hard gate is the deterministic lint above; the
-  # release pipeline runs the same check as its own backstop.
+  # FULL CHECK: replicate the docs-site sync, then run the REAL Mintlify checker
+  # against the whole staged site. Internal links only (no --check-external —
+  # external liveness is flaky and must not block). Fails ONLY on broken links
+  # sourced from the staged python pages (docs/api-reference/python/), so
+  # pre-existing breakage elsewhere on the site never fails this PR. Clones the
+  # public docs repo unauthenticated (no token). The deterministic lint above is
+  # the first, always-on gate; the release pipeline runs the same check too.
   staged-mintlify-check:
     runs-on: ubuntu-latest
     needs: lint-links
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,61 @@
+name: Docs link check
+
+# Catch docs link-rot BEFORE release. The release pipeline
+# (publish-mintlify-docs.yml) converts docs/api/**.md into the docs site's
+# docs/api-reference/python/**.mdx and opens a PR against nevermined-io/docs.
+# A link that resolves in this repo but is dead on the site (e.g.
+# `](../../payments_py/x402/README.md)`) only fails AFTER release, when the
+# bot's PR trips Mintlify link-rot — it bit nevermined-io/docs#234 (v1.15.0).
+# These jobs fail fast at PR time instead.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/api/**'
+      - 'scripts/convert_to_mintlify.py'
+      - 'scripts/lint_doc_links.py'
+      - 'scripts/check_synced_doc_links.sh'
+      - '.github/workflows/docs-link-check.yml'
+  pull_request:
+    paths:
+      - 'docs/api/**'
+      - 'scripts/convert_to_mintlify.py'
+      - 'scripts/lint_doc_links.py'
+      - 'scripts/check_synced_doc_links.sh'
+      - '.github/workflows/docs-link-check.yml'
+
+jobs:
+  # HARD GATE: deterministic, network-free escaping-link lint. Rejects the exact
+  # class that broke the docs site (relative links escaping the synced tree /
+  # pointing at repo source). Runs in milliseconds, never flakes.
+  lint-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.x'
+      - name: Lint synced-doc links (escaping / unmapped relative links)
+        run: python3 scripts/lint_doc_links.py
+
+  # BACKSTOP: replicate the docs-site sync, then run the REAL Mintlify checker
+  # against the staged whole site. Internal links only (no --check-external —
+  # external liveness is flaky and must not block). Depends on cloning the
+  # public docs repo + npx mintlify, so it is non-blocking on PRs
+  # (continue-on-error) and a hard gate is the deterministic lint above; the
+  # release pipeline runs the same check as its own backstop.
+  staged-mintlify-check:
+    runs-on: ubuntu-latest
+    needs: lint-links
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run staged Mintlify broken-links against the docs site
+        run: bash scripts/check_synced_doc_links.sh

--- a/.github/workflows/publish-mintlify-docs.yml
+++ b/.github/workflows/publish-mintlify-docs.yml
@@ -112,6 +112,21 @@ jobs:
           COPIED_COUNT=$(find "$TARGET_DIR" -name "*.mdx" | wc -l)
           echo "✓ Copied $COPIED_COUNT documentation files"
 
+      # Backstop: run the real Mintlify link checker against the staged site
+      # BEFORE opening the docs PR, so a dead internal link (the class that
+      # broke nevermined-io/docs#234) fails the release here instead of leaving
+      # the auto-merged docs PR stuck. Internal links only — no --check-external
+      # (external liveness is network-flaky and must not block a release). The
+      # same check runs at PR time in docs-link-check.yml.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check staged docs for broken internal links
+        working-directory: docs_mintlify
+        run: npx --yes mintlify@4.2.629 broken-links
+
       - name: Get version and target info
         id: version
         run: |

--- a/.github/workflows/publish-mintlify-docs.yml
+++ b/.github/workflows/publish-mintlify-docs.yml
@@ -46,8 +46,8 @@ jobs:
           FILE_COUNT=$(find payments-py/docs/api -name "*.md" | wc -l)
           echo "Found $FILE_COUNT documentation files"
 
-          if [ "$FILE_COUNT" -lt 12 ]; then
-            echo "Error: Expected at least 12 documentation files, found $FILE_COUNT"
+          if [ "$FILE_COUNT" -lt 13 ]; then
+            echo "Error: Expected at least 13 documentation files, found $FILE_COUNT"
             exit 1
           fi
 
@@ -169,7 +169,7 @@ jobs:
             This PR updates the Python SDK documentation for version `${{ steps.version.outputs.version }}`.
 
             ### Changes
-            - ✅ Updated all 12 documentation files
+            - ✅ Updated all 13 documentation files
             - 📦 Source: [nevermined-io/payments-py@${{ github.sha }}](https://github.com/nevermined-io/payments-py/commit/${{ github.sha }})
             - 🏷️ Version: `${{ steps.version.outputs.version }}`
             - 🎯 Target Branch: `${{ steps.version.outputs.target_branch }}`
@@ -187,6 +187,7 @@ jobs:
             - `a2a-module.mdx`
             - `x402-module.mdx`
             - `langchain-module.mdx`
+            - `langsmith-deployment-module.mdx`
 
             ### Conversion Details
             - Converted from Markdown to Mintlify MDX format

--- a/.github/workflows/publish-mintlify-docs.yml
+++ b/.github/workflows/publish-mintlify-docs.yml
@@ -112,20 +112,23 @@ jobs:
           COPIED_COUNT=$(find "$TARGET_DIR" -name "*.mdx" | wc -l)
           echo "✓ Copied $COPIED_COUNT documentation files"
 
-      # Backstop: run the real Mintlify link checker against the staged site
-      # BEFORE opening the docs PR, so a dead internal link (the class that
-      # broke nevermined-io/docs#234) fails the release here instead of leaving
-      # the auto-merged docs PR stuck. Internal links only — no --check-external
-      # (external liveness is network-flaky and must not block a release). The
-      # same check runs at PR time in docs-link-check.yml.
+      # Backstop: run the same scoped link check the PR gate uses against the
+      # staged site BEFORE opening the docs PR, so a dead internal link (the
+      # class that broke nevermined-io/docs#234) fails the release here instead
+      # of leaving the auto-merged docs PR stuck. The script reuses the docs site
+      # we already checked out (DOCS_CHECKOUT), re-converts docs/api/** with the
+      # same transform, and fails ONLY on broken links sourced from the staged
+      # python pages — internal links only, pre-existing site breakage ignored.
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Check staged docs for broken internal links
-        working-directory: docs_mintlify
-        run: npx --yes mintlify@4.2.629 broken-links
+        working-directory: payments-py
+        env:
+          DOCS_CHECKOUT: ${{ github.workspace }}/docs_mintlify
+        run: bash scripts/check_synced_doc_links.sh
 
       - name: Get version and target info
         id: version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ python3 scripts/lint_doc_links.py
 
 # Full check — converts the docs, drops them into a clone of the docs site, and
 # runs the same `mintlify broken-links` the docs repo uses (internal links only).
-# Needs network (clones nevermined-io/docs) + Node/npx.
+# Needs network (clones nevermined-io/docs_mintlify) + Node/npx.
 bash scripts/check_synced_doc_links.sh
 ```
 
@@ -71,4 +71,9 @@ flakes). The staged Mintlify check runs the real checker against the whole site
 but fails **only on broken links sourced from the staged python pages**, so
 pre-existing breakage elsewhere on the docs site never fails your PR. Only
 **internal** links are gated; external-URL liveness is not (it is network-flaky).
+
+> **Repo admin note:** the `lint-links` (and `staged-mintlify-check`) jobs only
+> enforce once added to the branch-protection **required status checks** for
+> `main`. Until then the gate runs but is advisory — a red check won't block
+> merge. Add both to the required checks to make the gate binding.
 The same staged check is a hard gate in the release pipeline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,9 @@ python3 scripts/lint_doc_links.py
 bash scripts/check_synced_doc_links.sh
 ```
 
-The lint is the blocking gate (deterministic, never flakes). The staged Mintlify
-check is a non-blocking PR backstop and a hard gate in the release pipeline. Only
+Both gates block. The lint is the first, always-on gate (deterministic, never
+flakes). The staged Mintlify check runs the real checker against the whole site
+but fails **only on broken links sourced from the staged python pages**, so
+pre-existing breakage elsewhere on the docs site never fails your PR. Only
 **internal** links are gated; external-URL liveness is not (it is network-flaky).
+The same staged check is a hard gate in the release pipeline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to payments-py
+
+Thanks for contributing to the Nevermined Payments Python SDK. This guide covers
+conventions that CI enforces; see [`CLAUDE.md`](./CLAUDE.md) for the full
+development workflow (Poetry, Black, tests, releases).
+
+## Quick start
+
+```bash
+poetry install
+poetry run pre-commit install   # runs Black on every commit
+poetry run pytest -m "not slow" -v
+poetry run black .              # CI fails on unformatted code
+```
+
+## Documentation
+
+User-facing SDK docs are hand-written under [`docs/api/`](./docs/api/) as
+numbered chapters (`NN-<slug>.md`). On release, `publish-mintlify-docs.yml`
+converts them to Mintlify MDX via
+[`scripts/convert_to_mintlify.py`](./scripts/convert_to_mintlify.py) and opens a
+PR against the docs site (`nevermined-io/docs`), publishing them at
+`docs/api-reference/python/<slug>`.
+
+When you change a public API, update the matching chapter in `docs/api/` (see
+[`CLAUDE.md`](./CLAUDE.md) for which files map to which APIs) and rebuild with
+`poetry run mkdocs build`.
+
+### Link conventions for `docs/api/**`
+
+Because these files are **transformed and republished on the docs site**, a
+relative link that resolves fine inside this repo can be **dead on the site** —
+the site has no parent directories and no repo source tree. This exact class of
+link once broke a docs-site sync PR (`nevermined-io/docs#234`, the v1.15.0
+sync of `a2a-module.mdx` → `../../payments_py/x402/README.md`).
+
+In `docs/api/**`, use only:
+
+- ✅ **Chapter links** to other `docs/api/` pages, by filename — `[x402](11-x402.md)`
+  or `[x402](./11-x402.md#section)`. The converter rewrites these to the site URL
+  (`/docs/api-reference/python/x402-module`). The set of rewritable chapters is
+  `LINK_MAPPING` in [`scripts/convert_to_mintlify.py`](./scripts/convert_to_mintlify.py);
+  add a chapter there when you add a page.
+- ✅ **Site-relative links** to other docs-site pages — `[LangChain](/docs/integrate/add-to-your-agent/langchain)`.
+- ✅ **In-page anchors** — `[Credits](#credits-semantics)`.
+- ✅ **Absolute GitHub URLs** for anything in the repo (source, tests, READMEs,
+  other directories) — `[x402 README](https://github.com/nevermined-io/payments-py/blob/main/payments_py/x402/README.md)`.
+- ❌ **Escaping relative links** (`](../…)`) and **links to repo source**
+  (`payments_py/…`, paths with a `/` that the converter does not rewrite) — these
+  resolve in-repo but 404 on the site. CI rejects them.
+
+### Link checks
+
+Two gates run in CI ([`.github/workflows/docs-link-check.yml`](./.github/workflows/docs-link-check.yml))
+on changes to `docs/api/**`, plus a release-time backstop in
+`publish-mintlify-docs.yml`. Reproduce them locally:
+
+```bash
+# Fast, network-free lint — rejects escaping (../) / unmapped relative links.
+# Hard gate. Driven off the converter's LINK_MAPPING, so it never drifts.
+python3 scripts/lint_doc_links.py
+
+# Full check — converts the docs, drops them into a clone of the docs site, and
+# runs the same `mintlify broken-links` the docs repo uses (internal links only).
+# Needs network (clones nevermined-io/docs) + Node/npx.
+bash scripts/check_synced_doc_links.sh
+```
+
+The lint is the blocking gate (deterministic, never flakes). The staged Mintlify
+check is a non-blocking PR backstop and a hard gate in the release pipeline. Only
+**internal** links are gated; external-URL liveness is not (it is network-flaky).

--- a/scripts/check_synced_doc_links.sh
+++ b/scripts/check_synced_doc_links.sh
@@ -31,7 +31,7 @@
 # not fail this gate. (See the scoped-parse step at the end of this script.)
 #
 # Env knobs (all optional):
-#   DOCS_REPO       default nevermined-io/docs
+#   DOCS_REPO       default nevermined-io/docs_mintlify
 #   DOCS_REF        default main
 #   MINTLIFY_VERSION default 4.2.629 (pin; the docs repo tracks latest)
 #   DOCS_CHECKOUT   pre-cloned docs repo to reuse instead of cloning
@@ -121,6 +121,10 @@ cd "$DOCS_DIR"
 REPORT="$WORK_DIR/broken-links.txt"
 set +e
 "${MINTLIFY[@]}" broken-links 2>&1 | sed 's/\x1b\[[0-9;]*[A-Za-z]//g' | tr -d '\r' > "$REPORT"
+# The pipe's exit status is tr's (always 0), so grab mintlify's REAL exit code
+# from PIPESTATUS — used below to fail closed if mintlify crashed without
+# producing a parseable report.
+mintlify_rc="${PIPESTATUS[0]}"
 set -e
 
 cat "$REPORT"
@@ -130,7 +134,7 @@ echo ""
 # Output shape (one source block per file with broken links):
 #   docs/api-reference/python/a2a-module.mdx
 #    ⎿  ../../payments_py/x402/README.md
-SCOPE_PREFIX="$SCOPE_PREFIX" python3 - "$REPORT" <<'PY'
+SCOPE_PREFIX="$SCOPE_PREFIX" MINTLIFY_RC="$mintlify_rc" python3 - "$REPORT" <<'PY'
 import os, re, sys
 
 prefix = os.environ["SCOPE_PREFIX"]
@@ -158,6 +162,20 @@ with open(sys.argv[1], encoding="utf-8") as fh:
             total += 1
             if current.startswith(prefix):
                 scoped.append((current, b.group(1)))
+
+# Fail-closed guard: a non-zero mintlify exit with no broken-links header means
+# mintlify did not actually run (npx install failure, exec error, OOM) rather
+# than "ran and found links". Without this, an empty report → reported=None →
+# total==0 → the script would print "✓ no broken links" and exit 0 (fail-OPEN).
+# This is the sibling of the missing-docs.json / empty-dir / format-drift guards.
+rc = int(os.environ["MINTLIFY_RC"])
+if rc != 0 and reported is None:
+    print(
+        f"✗ mintlify broken-links produced no parseable report (exit {rc}) — "
+        "it likely failed to run. Failing closed.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 # False-green guard: the checker reported broken links but our parser attributed
 # none to any source — the output format drifted (e.g. a mintlify bump changed

--- a/scripts/check_synced_doc_links.sh
+++ b/scripts/check_synced_doc_links.sh
@@ -23,11 +23,19 @@
 # by default and only pings external URLs with --check-external (NOT passed —
 # external liveness is network-flaky and must not block a release).
 #
+# Scoped to OUR breakage: the whole site may carry pre-existing broken links we
+# don't own. We replace ALL python pages with freshly-converted ones, so any
+# broken link whose SOURCE file is under docs/api-reference/python/ is breakage
+# introduced by these staged pages. We parse the checker output and fail ONLY on
+# python-sourced broken links — pre-existing breakage elsewhere on the site does
+# not fail this gate. (See the scoped-parse step at the end of this script.)
+#
 # Env knobs (all optional):
 #   DOCS_REPO       default nevermined-io/docs
 #   DOCS_REF        default main
 #   MINTLIFY_VERSION default 4.2.629 (pin; the docs repo tracks latest)
 #   DOCS_CHECKOUT   pre-cloned docs repo to reuse instead of cloning
+#   SCOPE_PREFIX    site path whose broken links we own (default the python tree)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -39,6 +47,8 @@ DOCS_REF="${DOCS_REF:-main}"
 # Pin Mintlify for reproducibility. The docs repo itself installs floating
 # latest (npm i -g mintlify); bump this when that materially changes.
 MINTLIFY_VERSION="${MINTLIFY_VERSION:-4.2.629}"
+# Broken links whose source file starts with this site path are ours to fix.
+SCOPE_PREFIX="${SCOPE_PREFIX:-docs/api-reference/python/}"
 
 if [ ! -d "$SOURCE_DIR" ]; then
   echo "Error: source docs not found at $SOURCE_DIR" >&2
@@ -92,5 +102,72 @@ fi
 echo "Running mintlify@$MINTLIFY_VERSION broken-links (internal links only) on the staged site …"
 echo ""
 cd "$DOCS_DIR"
-# Exits non-zero when it finds broken internal links.
-"${MINTLIFY[@]}" broken-links
+
+# Capture the full report (strip ANSI/spinner CRs), then scope to our pages.
+# Do not let mintlify's own non-zero exit abort the script — we decide pass/fail
+# from the SCOPED parse, since pre-existing site breakage must not fail us.
+REPORT="$WORK_DIR/broken-links.txt"
+set +e
+"${MINTLIFY[@]}" broken-links 2>&1 | sed 's/\x1b\[[0-9;]*[A-Za-z]//g' | tr -d '\r' > "$REPORT"
+set -e
+
+cat "$REPORT"
+echo ""
+
+# Parse the report and fail ONLY on broken links sourced from our staged pages.
+# Output shape (one source block per file with broken links):
+#   docs/api-reference/python/a2a-module.mdx
+#    ⎿  ../../payments_py/x402/README.md
+SCOPE_PREFIX="$SCOPE_PREFIX" python3 - "$REPORT" <<'PY'
+import os, re, sys
+
+prefix = os.environ["SCOPE_PREFIX"]
+source_re = re.compile(r"^(\S+\.mdx)\s*$")
+broken_re = re.compile(r"^\s*⎿\s+(.+?)\s*$")
+# Header the checker prints, e.g. "found 2 broken links in 2 files".
+header_re = re.compile(r"found\s+(\d+)\s+broken\s+links?\b")
+
+reported = None  # broken-link count from the checker's own summary line
+total = 0  # broken links our parser attributed to ANY source file
+scoped, current = [], None
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        h = header_re.search(line)
+        if h:
+            reported = int(h.group(1))
+            continue
+        m = source_re.match(line)
+        if m:
+            current = m.group(1)
+            continue
+        b = broken_re.match(line)
+        if b and current:
+            total += 1
+            if current.startswith(prefix):
+                scoped.append((current, b.group(1)))
+
+# False-green guard: the checker reported broken links but our parser attributed
+# none to any source — the output format drifted (e.g. a mintlify bump changed
+# the glyph/layout). Fail loudly rather than pass silently on an unparsed report.
+if reported and reported > 0 and total == 0:
+    print(
+        "✗ mintlify reported broken links but this script parsed none — the "
+        "broken-links output format has likely changed. Update the parser in "
+        "scripts/check_synced_doc_links.sh (the source/⎿ line patterns).",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+if scoped:
+    print(f"✗ {len(scoped)} broken internal link(s) introduced by the staged "
+          f"pages ({prefix}):")
+    for src, target in scoped:
+        print(f"  {src} -> {target}")
+    print("\nThese links resolve in-repo but are dead on the docs site. Use a "
+          "chapter link the converter rewrites, a site-relative /docs/... path, "
+          "or an absolute https://github.com/... URL. See CONTRIBUTING.md.")
+    sys.exit(1)
+
+print(f"✓ No broken internal links sourced from the staged pages ({prefix}).")
+PY

--- a/scripts/check_synced_doc_links.sh
+++ b/scripts/check_synced_doc_links.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# check_synced_doc_links.sh — replicate the docs-site sync, then run the real
+# Mintlify link checker against the staged site.
+#
+# Why staged against the real site, not in-repo: the release pipeline
+# (publish-mintlify-docs.yml) converts docs/api/NN-*.md into
+# docs/api-reference/python/<slug>.mdx via scripts/convert_to_mintlify.py and
+# opens a PR against nevermined-io/docs. A plain mkdocs build here would PASS and
+# miss site-only breakage, because relative links resolve differently once the
+# files live under api-reference/python/ on the site (this broke
+# nevermined-io/docs#234, the v1.15.0 sync).
+#
+# Unlike the TypeScript sibling (payments#401), the Python pages legitimately
+# link to OTHER docs-site sections via site-relative paths (e.g.
+# /docs/integrate/add-to-your-agent/langchain). Those resolve only against the
+# *whole* site, so a self-contained mini-site of just the 13 python pages would
+# false-positive on the clean tree. We therefore clone the real (public)
+# nevermined-io/docs, drop the freshly-converted pages into
+# docs/api-reference/python/, and run `mintlify broken-links` on the whole site.
+#
+# Hard-gates INTERNAL links only: `mintlify broken-links` checks internal links
+# by default and only pings external URLs with --check-external (NOT passed —
+# external liveness is network-flaky and must not block a release).
+#
+# Env knobs (all optional):
+#   DOCS_REPO       default nevermined-io/docs
+#   DOCS_REF        default main
+#   MINTLIFY_VERSION default 4.2.629 (pin; the docs repo tracks latest)
+#   DOCS_CHECKOUT   pre-cloned docs repo to reuse instead of cloning
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_DIR="$PROJECT_ROOT/docs/api"
+
+DOCS_REPO="${DOCS_REPO:-nevermined-io/docs}"
+DOCS_REF="${DOCS_REF:-main}"
+# Pin Mintlify for reproducibility. The docs repo itself installs floating
+# latest (npm i -g mintlify); bump this when that materially changes.
+MINTLIFY_VERSION="${MINTLIFY_VERSION:-4.2.629}"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "Error: source docs not found at $SOURCE_DIR" >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+# 1. Convert docs/api/*.md -> *.mdx with the SAME transform the release bot uses.
+STAGED_MDX="$WORK_DIR/converted"
+mkdir -p "$STAGED_MDX"
+echo "Converting docs/api/** with scripts/convert_to_mintlify.py …"
+python3 "$SCRIPT_DIR/convert_to_mintlify.py" \
+  --source "$SOURCE_DIR" --target "$STAGED_MDX" --verbose
+
+# 2. Obtain the docs site (clone the public repo, or reuse a provided checkout).
+if [ -n "${DOCS_CHECKOUT:-}" ]; then
+  echo "Reusing docs checkout at $DOCS_CHECKOUT"
+  DOCS_DIR="$WORK_DIR/docs-site"
+  cp -r "$DOCS_CHECKOUT" "$DOCS_DIR"
+else
+  DOCS_DIR="$WORK_DIR/docs-site"
+  echo "Cloning $DOCS_REPO@$DOCS_REF (shallow) …"
+  git clone --depth 1 --branch "$DOCS_REF" \
+    "https://github.com/$DOCS_REPO.git" "$DOCS_DIR"
+fi
+
+TARGET_DIR="$DOCS_DIR/docs/api-reference/python"
+if [ ! -d "$TARGET_DIR" ]; then
+  echo "Error: $DOCS_REPO has no docs/api-reference/python — site layout changed?" >&2
+  exit 1
+fi
+
+# 3. Replace the python pages with the freshly-converted ones (mirror the bot:
+#    rm old *.mdx, copy new). Other sections stay so site-relative links resolve.
+rm -f "$TARGET_DIR"/*.mdx
+cp "$STAGED_MDX"/*.mdx "$TARGET_DIR/"
+echo "Staged $(find "$TARGET_DIR" -name '*.mdx' | wc -l) python page(s) into the site."
+
+# 4. Resolve a runnable, pinned mintlify. CI uses the globally-installed CLI when
+#    it already matches the pin; otherwise fall back to a pinned npx invocation.
+if command -v mintlify >/dev/null 2>&1 \
+   && [ "$(mintlify --version 2>/dev/null)" = "$MINTLIFY_VERSION" ]; then
+  MINTLIFY=(mintlify)
+else
+  MINTLIFY=(npx --yes "mintlify@$MINTLIFY_VERSION")
+fi
+
+echo "Running mintlify@$MINTLIFY_VERSION broken-links (internal links only) on the staged site …"
+echo ""
+cd "$DOCS_DIR"
+# Exits non-zero when it finds broken internal links.
+"${MINTLIFY[@]}" broken-links

--- a/scripts/check_synced_doc_links.sh
+++ b/scripts/check_synced_doc_links.sh
@@ -42,7 +42,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SOURCE_DIR="$PROJECT_ROOT/docs/api"
 
-DOCS_REPO="${DOCS_REPO:-nevermined-io/docs}"
+# Canonical docs-site repo. Matches the publish-mintlify-docs.yml convention
+# (it checks out nevermined-io/docs_mintlify); GitHub redirects the alias to the
+# current name, so cloning works either way.
+DOCS_REPO="${DOCS_REPO:-nevermined-io/docs_mintlify}"
 DOCS_REF="${DOCS_REF:-main}"
 # Pin Mintlify for reproducibility. The docs repo itself installs floating
 # latest (npm i -g mintlify); bump this when that materially changes.
@@ -76,6 +79,15 @@ else
   echo "Cloning $DOCS_REPO@$DOCS_REF (shallow) …"
   git clone --depth 1 --branch "$DOCS_REF" \
     "https://github.com/$DOCS_REPO.git" "$DOCS_DIR"
+fi
+
+# Fail closed if the Mintlify project config is missing: `mintlify broken-links`
+# silently no-ops to exit 0 when run with no docs.json/mint.json at its root, so
+# without this assertion a docs-site layout change would make the gate pass
+# vacuously (symmetric to the api-reference/python guard below).
+if [ ! -f "$DOCS_DIR/docs.json" ] && [ ! -f "$DOCS_DIR/mint.json" ]; then
+  echo "Error: no docs.json/mint.json at $DOCS_DIR — docs-site layout changed?" >&2
+  exit 1
 fi
 
 TARGET_DIR="$DOCS_DIR/docs/api-reference/python"

--- a/scripts/lint_doc_links.py
+++ b/scripts/lint_doc_links.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Cheap, deterministic, network-free escaping-link lint for docs/api/**.
+
+The release pipeline (`publish-mintlify-docs.yml`) converts every
+``docs/api/NN-*.md`` into ``docs/api-reference/python/<slug>.mdx`` on the docs
+site via ``scripts/convert_to_mintlify.py``. A link that resolves fine *inside
+this repo* — e.g. ``](../../payments_py/x402/README.md)`` — is dead once synced,
+because the site has no parent dirs and no repo source. This bit the docs site
+once (nevermined-io/docs#234, the v1.15.0 sync of a2a-module.mdx).
+
+This lint rejects exactly that class of relative link, while allowing every
+link the converter knows how to rewrite. The set of "convertible" links is read
+straight from ``convert_to_mintlify.LINK_MAPPING`` so the lint can never drift
+from the transform it is guarding: add a chapter to ``LINK_MAPPING`` and the
+lint accepts a relative link to it automatically.
+
+A markdown link in ``docs/api/**`` is FLAGGED when its destination is a
+relative path (not an anchor, a site-relative ``/docs/...`` path, or an absolute
+URL) that the converter will NOT rewrite — i.e. it escapes the synced tree
+(contains a ``/``, including any ``../``) or its basename is not one of the
+chapter files in ``LINK_MAPPING``.
+
+It intentionally ALLOWS:
+  - convertible chapter links: ``](11-x402.md)``, ``](./11-x402.md#anchor)``
+    (basename in LINK_MAPPING, no path separator) — rewritten to the site URL.
+  - site-relative paths: ``](/docs/integrate/...)`` — resolve on the site.
+  - in-page anchors: ``](#section)``.
+  - absolute URLs: ``](https://...)``, ``](mailto:...)``.
+
+Runs in milliseconds, never hits the network, never flakes — the first and
+always-on hard gate. Exit code 1 if any violation is found, else 0.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Import the converter's link map so this lint stays in lockstep with the
+# transform. ``scripts/`` is not a package, so add it to sys.path explicitly.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from convert_to_mintlify import LINK_MAPPING  # noqa: E402
+
+# Chapter files the converter rewrites to clean site URLs (e.g. "11-x402.md").
+CONVERTIBLE_BASENAMES = set(LINK_MAPPING.keys())
+
+# Inline markdown link: [text](destination). Captures the raw destination,
+# which may carry an optional "title" we discard.
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+# Fenced code blocks open/close with ``` or ~~~ (optionally indented). Links
+# inside fences are code samples, not navigation — skip them.
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+# Destinations that are NOT repo-relative and therefore always fine.
+NON_RELATIVE_PREFIXES = ("/", "#", "http://", "https://", "mailto:", "tel:")
+
+
+def is_violation(destination: str) -> bool:
+    """Return True if a link destination would be dead on the docs site."""
+    # Drop an optional link title: [x](path "Title") -> "path".
+    parts = destination.strip().split()
+    if not parts:  # whitespace-only destination — not a real link, ignore.
+        return False
+    target = parts[0]
+
+    if target.startswith(NON_RELATIVE_PREFIXES):
+        return False
+
+    # Normalise: strip a single leading "./" and any "#anchor" fragment.
+    if target.startswith("./"):
+        target = target[2:]
+    target = target.split("#", 1)[0]
+
+    if not target:  # was a bare "#anchor" — same-page link, fine.
+        return False
+
+    basename = target.rsplit("/", 1)[-1]
+
+    # Safe iff it stays in the synced tree (no path separator) AND names a
+    # chapter the converter rewrites. Everything else escapes or is unmapped.
+    return "/" in target or basename not in CONVERTIBLE_BASENAMES
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return [(line_number, destination), ...] for each violating link."""
+    violations: list[tuple[int, str]] = []
+    in_fence = False
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for match in LINK_RE.finditer(line):
+            destination = match.group(1)
+            if is_violation(destination):
+                violations.append((lineno, destination.strip().split()[0]))
+    return violations
+
+
+def main() -> int:
+    docs_dir = Path(__file__).resolve().parent.parent / "docs" / "api"
+    if not docs_dir.is_dir():
+        print(f"Error: docs directory not found at {docs_dir}", file=sys.stderr)
+        return 1
+
+    total = 0
+    for md_file in sorted(docs_dir.glob("*.md")):
+        for lineno, destination in check_file(md_file):
+            rel = md_file.relative_to(docs_dir.parent.parent)
+            print(
+                f"  ✗ {rel}:{lineno} — escaping/unmapped relative link: {destination}"
+            )
+            total += 1
+
+    if total:
+        print()
+        print(f"✗ Found {total} escaping/unmapped relative link(s) in docs/api/**.")
+        print()
+        print(
+            "Synced docs (docs/api/**) are converted to the docs site under\n"
+            "  docs/api-reference/python/. A relative link that escapes that tree\n"
+            "  (../…) or points at repo source resolves in-repo but is dead on the\n"
+            "  site (this broke nevermined-io/docs#234). Use a chapter link the\n"
+            "  converter rewrites (e.g. 11-x402.md — see LINK_MAPPING in\n"
+            "  scripts/convert_to_mintlify.py), a site-relative path (/docs/…), or\n"
+            "  an absolute https://github.com/… URL instead. See CONTRIBUTING.md."
+        )
+        return 1
+
+    print("✓ docs/api/** has no escaping or unmapped relative links.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint_doc_links.py
+++ b/scripts/lint_doc_links.py
@@ -47,6 +47,14 @@ CONVERTIBLE_BASENAMES = set(LINK_MAPPING.keys())
 # which may carry an optional "title" we discard.
 LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 
+# Reference-style link definition: `[label]: destination "optional title"` at
+# line start. The escaping target lives on the definition line (the `[text][ref]`
+# usage only names the label), so scanning definitions catches that target.
+REF_DEF_RE = re.compile(r"^\s{0,3}\[[^\]]+\]:\s+(\S+)")
+
+# HTML anchor: <a href="destination"> (single or double quoted).
+HTML_HREF_RE = re.compile(r"""<a\s[^>]*\bhref\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
+
 # Fenced code blocks open/close with ``` or ~~~ (optionally indented). Links
 # inside fences are code samples, not navigation — skip them.
 FENCE_RE = re.compile(r"^\s*(```|~~~)")
@@ -82,7 +90,11 @@ def is_violation(destination: str) -> bool:
 
 
 def check_file(path: Path) -> list[tuple[int, str]]:
-    """Return [(line_number, destination), ...] for each violating link."""
+    """Return [(line_number, destination), ...] for each violating link.
+
+    Scans inline links ``[t](dest)``, reference-style definitions
+    ``[ref]: dest``, and HTML ``<a href="dest">`` — skipping fenced code.
+    """
     violations: list[tuple[int, str]] = []
     in_fence = False
     for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
@@ -91,8 +103,12 @@ def check_file(path: Path) -> list[tuple[int, str]]:
             continue
         if in_fence:
             continue
-        for match in LINK_RE.finditer(line):
-            destination = match.group(1)
+        destinations = [m.group(1) for m in LINK_RE.finditer(line)]
+        destinations += [m.group(1) for m in HTML_HREF_RE.finditer(line)]
+        ref_def = REF_DEF_RE.match(line)
+        if ref_def:
+            destinations.append(ref_def.group(1))
+        for destination in destinations:
             if is_violation(destination):
                 violations.append((lineno, destination.strip().split()[0]))
     return violations
@@ -104,8 +120,15 @@ def main() -> int:
         print(f"Error: docs directory not found at {docs_dir}", file=sys.stderr)
         return 1
 
+    md_files = sorted(docs_dir.glob("*.md"))
+    if not md_files:
+        # Fail closed: an empty docs/api/ means the layout moved or the glob is
+        # wrong — never report "clean" on zero inspected files.
+        print(f"Error: no markdown files found in {docs_dir}", file=sys.stderr)
+        return 1
+
     total = 0
-    for md_file in sorted(docs_dir.glob("*.md")):
+    for md_file in md_files:
         for lineno, destination in check_file(md_file):
             rel = md_file.relative_to(docs_dir.parent.parent)
             print(


### PR DESCRIPTION
## Description

Add a CI gate that catches docs **link-rot before release** — the class of link
that resolves inside this repo but is **dead once `docs/api/**` is synced to the
docs site**. Today this only fails *after* release, when the bot's docs-sync PR
trips Mintlify link-rot (it bit `nevermined-io/docs#234` for v1.15.0:
`a2a-module.mdx` → `../../payments_py/x402/README.md`). The tree is currently
clean, so this is **preventive** — it stops the class from recurring.

Three layers:

1. **`scripts/lint_doc_links.py`** — deterministic, network-free escaping-link
   lint (**hard PR gate**). Flags any relative link in `docs/api/**` that the
   converter won't rewrite (escapes the synced tree, or basename not a chapter
   in `convert_to_mintlify.LINK_MAPPING`). Runs in ms, never flakes. Driven off
   `LINK_MAPPING`, so it can never drift from the transform it guards.
2. **`scripts/check_synced_doc_links.sh`** — converts via the real
   `convert_to_mintlify.py`, drops the pages into a clone of the docs site, and
   runs the same `mintlify broken-links` the docs repo uses (**internal links
   only** — no `--check-external`; external liveness is network-flaky). The
   Python pages legitimately link cross-section via site-relative `/docs/...`
   paths, so a python-only mini-site false-positives on the clean tree; this
   stages against the **whole** site. Blocking PR backstop (source-scoped to
   the staged python pages, so pre-existing site breakage elsewhere is ignored).
3. **`.github/workflows/docs-link-check.yml`** — lint (hard gate) +
   staged-Mintlify (blocking, source-scoped to the python pages) on
   `docs/api/**` changes; and
   **`publish-mintlify-docs.yml`** runs `mintlify broken-links` on the staged
   site before opening the docs PR (release-time backstop).

Plus **`CONTRIBUTING.md`** with the authoring rule: synced docs use chapter
links / site-relative paths / absolute GitHub URLs, never repo-relative.

Mintlify is pinned to `4.2.629` for reproducibility (the docs repo installs
floating latest; bump when that materially changes).

Verified: lint + staged check both pass on the current clean tree and both fail
(exit 1) when the `#234` link is injected.

## Is this PR related with an open issue?

Part of epic nevermined-io/nvm-monorepo#2004.

Closes #241.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

CI-only / docs-tooling change — no SDK source touched.

## Checklist:

- [x] Follows the code style of this project. (`black` clean; pre-commit passes)
- [x] Tests Cover Changes — both scripts verified against clean + injected-bad trees
- [x] Documentation — CONTRIBUTING.md authoring rule added

#### Funny gif

![dead link](https://media.giphy.com/media/3o7TKtnuHOHHUjR38Y/giphy.gif)

