### PR TITLE
feat: derive environment from API-key prefix; deprecate `environment`

### DIFF
--- a/docs/api/02-initializing-the-library.md
+++ b/docs/api/02-initializing-the-library.md
@@ -22,11 +22,10 @@ Before using the SDK, you need a Nevermined API Key:
 ```python
 from payments_py import Payments, PaymentOptions
 
-# Initialize with API key and environment
+# The environment is derived from your API key's prefix — just pass the key.
 payments = Payments.get_instance(
     PaymentOptions(
-        nvm_api_key="nvm:your-api-key-here",
-        environment="sandbox"
+        nvm_api_key="sandbox:your-api-key-here",
     )
 )
 
@@ -34,6 +33,15 @@ payments = Payments.get_instance(
 print(f"Connected to: {payments.environment.backend}")
 print(f"Account: {payments.account_address}")
 ```
+
+!!! note "`environment` is deprecated"
+    The `environment` option is **deprecated**. The SDK now derives the
+    environment from the API-key prefix (`<prefix>:<jwt>`) — a key minted for
+    sandbox starts with `sandbox:`, for production with `live:`, and so on. When
+    the prefix is recognized it always wins; passing `environment` is ignored
+    (with a warning). It is still accepted only as a fallback for local/custom
+    keys whose prefix the SDK doesn't recognize (see
+    [Custom Environment](#custom-environment)).
 
 ### Using Environment Variables
 
@@ -44,7 +52,6 @@ from payments_py import Payments, PaymentOptions
 payments = Payments.get_instance(
     PaymentOptions(
         nvm_api_key=os.getenv("NVM_API_KEY"),
-        environment=os.getenv("NVM_ENVIRONMENT", "sandbox")
     )
 )
 ```
@@ -55,8 +62,8 @@ The `PaymentOptions` class accepts the following parameters:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `nvm_api_key` | `str` | Yes | Your Nevermined API key |
-| `environment` | `str` | Yes | Environment name (see below) |
+| `nvm_api_key` | `str` | Yes | Your Nevermined API key (its prefix sets the environment) |
+| `environment` | `str` | No | **Deprecated.** Derived from the API-key prefix; only used as a fallback for unrecognized (local/custom) prefixes (see below) |
 | `app_id` | `str` | No | Application identifier |
 | `version` | `str` | No | Application version |
 | `api_version` | `str` | No | Backend API version sent as the `Nevermined-Version` header. Defaults to the version this SDK release targets (see below) |
@@ -68,8 +75,7 @@ from payments_py import Payments, PaymentOptions
 
 payments = Payments.get_instance(
     PaymentOptions(
-        nvm_api_key="nvm:your-api-key",
-        environment="sandbox",
+        nvm_api_key="sandbox:your-api-key",
         app_id="my-app",
         version="1.0.0",
         headers={"X-Custom-Header": "value"}
@@ -88,8 +94,7 @@ different backend contract explicitly:
 ```python
 payments = Payments.get_instance(
     PaymentOptions(
-        nvm_api_key="nvm:your-api-key",
-        environment="sandbox",
+        nvm_api_key="sandbox:your-api-key",
         api_version="1.1",  # override the pinned backend API version
     )
 )
@@ -100,15 +105,24 @@ for the list of versions and the changes between them.
 
 ## Environments
 
+The environment is determined by your API key's prefix — you don't select it
+explicitly. The prefix-to-environment mapping is:
+
+| API-key prefix | Environment |
+|----------------|-------------|
+| `sandbox:` | `sandbox` |
+| `live:` | `live` |
+| `sandbox-staging:` | `staging_sandbox` |
+| `live-staging:` | `staging_live` |
+
 ### Sandbox Environment (Testing)
 
-Use `sandbox` for development and testing:
+A key minted for sandbox starts with `sandbox:`:
 
 ```python
 payments = Payments.get_instance(
     PaymentOptions(
-        nvm_api_key="nvm:your-api-key",
-        environment="sandbox"
+        nvm_api_key="sandbox:your-api-key",
     )
 )
 ```
@@ -119,13 +133,12 @@ payments = Payments.get_instance(
 
 ### Live Environment (Production)
 
-Use `live` for production:
+A key minted for production starts with `live:`:
 
 ```python
 payments = Payments.get_instance(
     PaymentOptions(
-        nvm_api_key="nvm:your-api-key",
-        environment="live"
+        nvm_api_key="live:your-api-key",
     )
 )
 ```
@@ -136,7 +149,10 @@ payments = Payments.get_instance(
 
 ### Custom Environment
 
-For self-hosted or development setups:
+For self-hosted or local development setups, the API key's prefix won't be one
+the SDK recognizes, so it falls back to the (still-accepted) `environment`
+option. Pass `environment="custom"` to point the SDK at URLs from environment
+variables:
 
 ```python
 import os
@@ -147,8 +163,8 @@ os.environ["NVM_PROXY_URL"] = "http://localhost:443"
 
 payments = Payments.get_instance(
     PaymentOptions(
-        nvm_api_key="nvm:your-api-key",
-        environment="custom"
+        nvm_api_key="local:your-api-key",
+        environment="custom",  # fallback for unrecognized key prefixes
     )
 )
 ```
@@ -159,6 +175,8 @@ payments = Payments.get_instance(
 |-------------|-------------|
 | `sandbox` | Production sandbox (testing) |
 | `live` | Production mainnet |
+| `staging_sandbox` | Staging sandbox |
+| `staging_live` | Staging mainnet |
 | `custom` | Custom URLs via environment variables |
 
 ## Accessing Sub-APIs

--- a/payments_py/api/base_payments.py
+++ b/payments_py/api/base_payments.py
@@ -116,7 +116,7 @@ class BasePaymentsAPI:
     @staticmethod
     def _resolve_environment(
         nvm_api_key: Optional[str], environment_option: Optional[str]
-    ) -> EnvironmentName:
+    ) -> str:
         """Resolve the effective SDK environment.
 
         Precedence (non-breaking deprecation of the ``environment`` option):
@@ -128,12 +128,16 @@ class BasePaymentsAPI:
            use emits a deprecation warning.
         3. Otherwise :data:`_DEFAULT_ENVIRONMENT` (``"custom"``).
 
+        Returns ``str`` rather than :data:`EnvironmentName`: a recognized prefix
+        yields a valid ``EnvironmentName``, but the deprecated-option fallback is
+        arbitrary caller input that :func:`get_environment` validates at runtime.
+
         Args:
             nvm_api_key: The NVM API key (its prefix drives resolution).
             environment_option: The deprecated ``environment`` init option.
 
         Returns:
-            The resolved :data:`EnvironmentName`.
+            The resolved environment name.
         """
         derived = environment_from_api_key(nvm_api_key)
         if derived is not None:

--- a/payments_py/api/base_payments.py
+++ b/payments_py/api/base_payments.py
@@ -5,13 +5,31 @@ Provides common functionality such as parsing the NVM API Key and getting the ac
 
 import jwt
 import json
+import logging
+import warnings
 from typing import Optional, Dict, Any
 from enum import Enum
 from payments_py.common.api_version import API_VERSION_HEADER, LOCKED_API_VERSION
 from payments_py.common.payments_error import PaymentsError
 from payments_py.common.types import PaymentOptions
-from payments_py.environments import get_environment
+from payments_py.environments import (
+    EnvironmentName,
+    environment_from_api_key,
+    get_environment,
+)
 from payments_py.common.helper import dict_keys_to_camel
+
+logger = logging.getLogger(__name__)
+
+# Default environment when neither the API-key prefix nor the deprecated
+# ``environment`` option resolves one (e.g. a local/custom dev key with an
+# unrecognized prefix and no ``environment`` passed).
+_DEFAULT_ENVIRONMENT: EnvironmentName = "custom"
+
+# Guards the once-per-process stdlib logging nudge for the deprecated
+# ``environment`` option (``warnings.warn`` already dedupes by message+location;
+# this keeps the logging channel from repeating on every sub-API construction).
+_environment_deprecation_logged = False
 
 # Default timeout for HTTP requests in seconds (connect, read)
 DEFAULT_HTTP_TIMEOUT = (10, 30)
@@ -74,8 +92,15 @@ class BasePaymentsAPI:
         """
         self.nvm_api_key = options.nvm_api_key
         self.return_url = options.return_url or ""
-        self.environment = get_environment(options.environment)
-        self.environment_name = options.environment
+        # Preserve the raw (possibly None) ``environment`` option so internal
+        # re-inits (e.g. ``Payments._build_options``) reproduce the caller's
+        # intent without re-deriving ``custom`` into a spurious deprecation
+        # warning.
+        self._environment_option = options.environment
+        self.environment_name = self._resolve_environment(
+            options.nvm_api_key, options.environment
+        )
+        self.environment = get_environment(self.environment_name)
         self.app_id = options.app_id
         self.version = options.version
         # Backend API version (monorepo MAJOR.MINOR) declared on every
@@ -87,6 +112,71 @@ class BasePaymentsAPI:
         self.is_browser_instance = True
         self.current_organization_id: Optional[str] = options.organization_id
         self._parse_nvm_api_key()
+
+    @staticmethod
+    def _resolve_environment(
+        nvm_api_key: Optional[str], environment_option: Optional[str]
+    ) -> EnvironmentName:
+        """Resolve the effective SDK environment.
+
+        Precedence (non-breaking deprecation of the ``environment`` option):
+
+        1. The API-key prefix (``<prefix>:<jwt>``) when recognized — it always
+           wins. If ``environment_option`` was also passed it is ignored, and a
+           warning notes the override.
+        2. Otherwise the deprecated ``environment`` option, if provided — its
+           use emits a deprecation warning.
+        3. Otherwise :data:`_DEFAULT_ENVIRONMENT` (``"custom"``).
+
+        Args:
+            nvm_api_key: The NVM API key (its prefix drives resolution).
+            environment_option: The deprecated ``environment`` init option.
+
+        Returns:
+            The resolved :data:`EnvironmentName`.
+        """
+        derived = environment_from_api_key(nvm_api_key)
+        if derived is not None:
+            if environment_option is not None:
+                # Key prefix wins; the passed option is ignored. Note the
+                # override explicitly when the two disagree.
+                detail = (
+                    f"ignoring the passed '{environment_option}'"
+                    if environment_option != derived
+                    else "the passed value matched and was redundant"
+                )
+                BasePaymentsAPI._warn_environment_deprecated(
+                    "The 'environment' option is deprecated and is now derived "
+                    f"from the API-key prefix. Using '{derived}' from the API "
+                    f"key ({detail}). Remove the 'environment' option."
+                )
+            return derived
+
+        if environment_option is not None:
+            BasePaymentsAPI._warn_environment_deprecated(
+                "The 'environment' option is deprecated; the environment is now "
+                "derived from the API-key prefix. The key prefix was not "
+                f"recognized, so falling back to the passed '{environment_option}'."
+            )
+            return environment_option
+
+        return _DEFAULT_ENVIRONMENT
+
+    @staticmethod
+    def _warn_environment_deprecated(message: str) -> None:
+        """Emit the ``environment``-deprecation nudge.
+
+        Uses ``FutureWarning`` (not ``DeprecationWarning``) for runtime
+        visibility — ``DeprecationWarning`` is filtered out by default outside
+        ``__main__``, so agents under FastAPI / gunicorn / Docker workers would
+        never see it (same rationale as ``payments_py/x402/token.py``). Also
+        logs once per process so the nudge reaches log-based observability.
+        """
+        global _environment_deprecation_logged
+        warnings.warn(message, FutureWarning, stacklevel=3)
+        if not _environment_deprecation_logged:
+            logger.warning(message)
+            _environment_deprecation_logged = True
 
     def _parse_nvm_api_key(self) -> None:
         """

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -15,7 +15,12 @@ class PaymentOptions(BaseModel):
     Options for initializing the Payments class.
 
     Args:
-        environment: Nevermined environment (e.g. ``"sandbox"``, ``"live"``).
+        environment: **Deprecated.** Nevermined environment (e.g.
+            ``"sandbox"``, ``"live"``). The environment is now derived from the
+            ``nvm_api_key`` prefix (``<prefix>:<jwt>``); when the prefix is
+            recognized it always wins and this option is ignored (with a
+            warning). Still accepted as a fallback for local/custom dev keys
+            whose prefix is unrecognized. Will be removed in a future release.
         nvm_api_key: NVM API key used to authenticate against the backend.
         return_url: Optional URL to return to after login (browser flows).
         app_id: Optional application identifier stamped on registered assets.
@@ -41,7 +46,7 @@ class PaymentOptions(BaseModel):
             via the ``organization_id`` argument on publish methods.
     """
 
-    environment: str
+    environment: Optional[str] = None
     nvm_api_key: Optional[str] = None
     return_url: Optional[str] = None
     app_id: Optional[str] = None

--- a/payments_py/environments.py
+++ b/payments_py/environments.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Optional
 
 
 @dataclass
@@ -66,6 +66,43 @@ Environments = {
         helicone_url=os.getenv("HELICONE_URL", "http://localhost:8585"),
     ),
 }
+
+
+# Known API-key prefixes mapped to their SDK environment name. This is the
+# inverse of the backend's ``addPrefixToToken`` (nvm-monorepo
+# ``apps/api/src/common/helpers/utils.ts``), which builds the prefix as
+# ``{environment}`` or ``{environment}-{deploymentName}`` (the deployment
+# segment is omitted for ``production``). So ``sandbox-staging`` is the
+# ``staging`` deployment of the ``sandbox`` environment → ``staging_sandbox``.
+# Keep this table in sync with the TS SDK (payments#399) — both must map the
+# same prefixes to the same environment names.
+_API_KEY_PREFIX_TO_ENVIRONMENT: dict[str, EnvironmentName] = {
+    "sandbox-staging": "staging_sandbox",
+    "live-staging": "staging_live",
+    "sandbox": "sandbox",
+    "live": "live",
+}
+
+
+def environment_from_api_key(nvm_api_key: Optional[str]) -> Optional[EnvironmentName]:
+    """Derive the SDK environment from an NVM API key's prefix.
+
+    Keys are ``<prefix>:<jwt>``. The prefix encodes the environment the key was
+    minted for (see ``_API_KEY_PREFIX_TO_ENVIRONMENT``). Returns the mapped
+    :data:`EnvironmentName`, or ``None`` when the key is missing, has no prefix,
+    or carries an unrecognized prefix (e.g. local/custom dev keys) — callers
+    fall back to the deprecated ``environment`` option in that case.
+
+    Args:
+        nvm_api_key: The NVM API key, or ``None``.
+
+    Returns:
+        The mapped environment name, or ``None`` if it cannot be derived.
+    """
+    if not nvm_api_key or ":" not in nvm_api_key:
+        return None
+    prefix = nvm_api_key.split(":", 1)[0].lower()
+    return _API_KEY_PREFIX_TO_ENVIRONMENT.get(prefix)
 
 
 def get_environment(name: EnvironmentName) -> EnvironmentInfo:

--- a/payments_py/environments.py
+++ b/payments_py/environments.py
@@ -105,9 +105,13 @@ def environment_from_api_key(nvm_api_key: Optional[str]) -> Optional[Environment
     return _API_KEY_PREFIX_TO_ENVIRONMENT.get(prefix)
 
 
-def get_environment(name: EnvironmentName) -> EnvironmentInfo:
+def get_environment(name: str) -> EnvironmentInfo:
     """
     Get the environment configuration by name.
+
+    Accepts ``str`` because the name may come from the deprecated, free-form
+    ``environment`` option (not just a known :data:`EnvironmentName`); unknown
+    names are rejected at runtime below.
 
     Args:
         name: The name of the environment.

--- a/payments_py/payments.py
+++ b/payments_py/payments.py
@@ -178,7 +178,11 @@ class Payments(BasePaymentsAPI):
         """Build PaymentOptions from current state."""
         return PaymentOptions(
             nvm_api_key=self.nvm_api_key,
-            environment=self.environment_name,
+            # Pass through the caller's original ``environment`` option (often
+            # None) rather than the resolved name — the key prefix re-derives
+            # the environment, and re-passing the resolved name would surface a
+            # spurious deprecation warning on this internal re-init.
+            environment=self._environment_option,
             app_id=self.app_id,
             version=self.version,
             api_version=self.api_version,

--- a/tests/unit/test_environment_resolution.py
+++ b/tests/unit/test_environment_resolution.py
@@ -1,0 +1,125 @@
+"""Unit tests for deriving the SDK environment from the API-key prefix.
+
+The ``environment`` init option is deprecated: keys are ``<prefix>:<jwt>`` and
+the prefix (the inverse of the backend's ``addPrefixToToken``) now drives the
+environment. The option is still accepted as a fallback for unrecognized
+(local/custom) prefixes, and using it emits a ``FutureWarning``. These tests
+pin the precedence (key wins), the fallback, and the deprecation warning.
+"""
+
+import logging
+import warnings
+from contextlib import contextmanager
+
+import pytest
+
+import payments_py.api.base_payments as base_payments
+from payments_py.api.base_payments import BasePaymentsAPI
+from payments_py.environments import environment_from_api_key
+
+
+@contextmanager
+def _no_warning():
+    """Assert that the wrapped block emits no warning."""
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        yield
+    assert not records, f"expected no warnings, got {[str(r.message) for r in records]}"
+
+
+# Unsigned JWT body (``sub`` + ``o11y`` claims) — the prefix before ``:`` is
+# what these tests vary.
+_JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIweDEyMyIsIm8xMXkiOiJoZWxpY29uZS1rZXkifQ.fake"
+
+
+def _key(prefix: str) -> str:
+    return f"{prefix}:{_JWT}"
+
+
+@pytest.fixture(autouse=True)
+def _reset_once_flag():
+    """The once-per-process logging guard is module-level; reset it so each
+    test exercising the logging channel sees a clean slate."""
+    base_payments._environment_deprecation_logged = False
+    yield
+    base_payments._environment_deprecation_logged = False
+
+
+class TestEnvironmentFromApiKey:
+    @pytest.mark.parametrize(
+        "prefix,expected",
+        [
+            ("sandbox-staging", "staging_sandbox"),
+            ("live-staging", "staging_live"),
+            ("sandbox", "sandbox"),
+            ("live", "live"),
+        ],
+    )
+    def test_recognized_prefixes_map(self, prefix, expected):
+        assert environment_from_api_key(_key(prefix)) == expected
+
+    def test_prefix_is_case_insensitive(self):
+        assert environment_from_api_key(_key("SANDBOX-STAGING")) == "staging_sandbox"
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            None,
+            "",
+            "no-colon-here",
+            _key("nvm"),
+            _key("local"),
+            _key("unknown-prefix"),
+        ],
+    )
+    def test_unrecognized_or_missing_returns_none(self, key):
+        assert environment_from_api_key(key) is None
+
+
+class TestResolveEnvironment:
+    def test_recognized_prefix_wins_no_option(self):
+        with _no_warning():
+            resolved = BasePaymentsAPI._resolve_environment(
+                _key("sandbox-staging"), None
+            )
+        assert resolved == "staging_sandbox"
+
+    def test_recognized_prefix_wins_over_conflicting_option(self):
+        with pytest.warns(FutureWarning, match="ignoring the passed 'live'"):
+            resolved = BasePaymentsAPI._resolve_environment(
+                _key("sandbox-staging"), "live"
+            )
+        assert resolved == "staging_sandbox"
+
+    def test_recognized_prefix_with_matching_option_still_warns(self):
+        with pytest.warns(FutureWarning, match="matched and was redundant"):
+            resolved = BasePaymentsAPI._resolve_environment(_key("sandbox"), "sandbox")
+        assert resolved == "sandbox"
+
+    def test_unrecognized_prefix_falls_back_to_option_with_warning(self):
+        with pytest.warns(FutureWarning, match="was not.*recognized"):
+            resolved = BasePaymentsAPI._resolve_environment(_key("nvm"), "sandbox")
+        assert resolved == "sandbox"
+
+    def test_no_prefix_no_option_defaults_to_custom(self):
+        with _no_warning():
+            resolved = BasePaymentsAPI._resolve_environment(_key("nvm"), None)
+        assert resolved == "custom"
+
+    def test_missing_key_no_option_defaults_to_custom(self):
+        with _no_warning():
+            resolved = BasePaymentsAPI._resolve_environment(None, None)
+        assert resolved == "custom"
+
+    def test_deprecation_logs_once_per_process(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="payments_py.api.base_payments"):
+            with pytest.warns(FutureWarning):
+                BasePaymentsAPI._resolve_environment(_key("nvm"), "sandbox")
+            with pytest.warns(FutureWarning):
+                BasePaymentsAPI._resolve_environment(_key("nvm"), "sandbox")
+        deprecation_logs = [
+            r
+            for r in caplog.records
+            if "'environment' option is deprecated" in r.message
+        ]
+        assert len(deprecation_logs) == 1


### PR DESCRIPTION
## Description

API keys are prefixed with the environment they were minted for
(`<prefix>:<jwt>`, e.g. `sandbox-staging:eyJ…`). This change derives the SDK
environment from that prefix and **deprecates** the `environment` init option.
**Non-breaking:** `environment` is still accepted (now optional) and emits a
warning; when the key prefix is recognized it always wins.

Changes:
- `environment_from_api_key()` (in `payments_py/environments.py`) maps the key
  prefix to an `EnvironmentName` — the inverse of the backend's
  `addPrefixToToken` (`nvm-monorepo apps/api/src/common/helpers/utils.ts`):

  | API-key prefix | Environment |
  |----------------|-------------|
  | `sandbox` | `sandbox` |
  | `live` | `live` |
  | `sandbox-staging` | `staging_sandbox` |
  | `live-staging` | `staging_live` |
  | other / none | falls back to the deprecated `environment`, else `custom` |

- `BasePaymentsAPI._resolve_environment()` — precedence: **recognized key
  prefix wins** (passed `environment` ignored, warns; notes the override on
  conflict) → else fall back to the passed `environment` (warns) → else
  `custom`.
- `PaymentOptions.environment` is now `Optional[str] = None` (was required) and
  documented as deprecated.
- Deprecation channel: `FutureWarning` (not `DeprecationWarning`, which is
  filtered out by default under FastAPI/gunicorn/Docker) **plus** a
  once-per-process stdlib `logging` warning — matching the SDK's existing
  convention (`payments_py/x402/token.py`).
- `Payments._build_options()` passes the caller's **original** `environment`
  option (often `None`) on internal sub-API re-inits, so they don't surface a
  spurious deprecation warning.

The mapping was verified against the backend source and against this repo's own
test key (`tests/unit/test_payments.py` uses a real `sandbox-staging:` key with
`environment="staging_sandbox"`), not invented.

## Is this PR related with an open issue?

Closes #242
Part of nevermined-io/nvm-monorepo#2004

Sibling (identical mapping in the TS SDK): payments#399 — `_API_KEY_PREFIX_TO_ENVIRONMENT` must stay in sync.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes (new `tests/unit/test_environment_resolution.py`; full unit suite 676 passed)
- [x] Documentation (`docs/api/02-initializing-the-library.md`)

#### Funny gif

![it just works](https://media.giphy.com/media/l0HlNaQ6gWfllcjDO/giphy.gif)