### PR TITLE
docs: retire docs.nevermined.app references; follow the docs-site flatten

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -2,7 +2,7 @@ name: Docs link check
 
 # Catch docs link-rot BEFORE release. The release pipeline
 # (publish-mintlify-docs.yml) converts docs/api/**.md into the docs site's
-# docs/api-reference/python/**.mdx and opens a PR against nevermined-io/docs.
+# api-reference/python/**.mdx and opens a PR against nevermined-io/docs.
 # A link that resolves in this repo but is dead on the site (e.g.
 # `](../../payments_py/x402/README.md)`) only fails AFTER release, when the
 # bot's PR trips Mintlify link-rot — it bit nevermined-io/docs#234 (v1.15.0).
@@ -42,7 +42,7 @@ jobs:
   # FULL CHECK: replicate the docs-site sync, then run the REAL Mintlify checker
   # against the whole staged site. Internal links only (no --check-external —
   # external liveness is flaky and must not block). Fails ONLY on broken links
-  # sourced from the staged python pages (docs/api-reference/python/), so
+  # sourced from the staged python pages (api-reference/python/), so
   # pre-existing breakage elsewhere on the site never fails this PR. Clones the
   # public docs repo unauthenticated (no token). The deterministic lint above is
   # the first, always-on gate; the release pipeline runs the same check too.

--- a/.github/workflows/publish-mintlify-docs.yml
+++ b/.github/workflows/publish-mintlify-docs.yml
@@ -91,12 +91,29 @@ jobs:
       - name: Copy documentation files
         run: |
           SOURCE_DIR="mintlify-output"
-          TARGET_DIR="docs_mintlify/docs/api-reference/python"
+
+          # Locate the python tree. The docs site used to nest its pages under a
+          # top-level `docs/`; nevermined-io/docs#257 flattened that to the repo
+          # root for base-path hosting. Detect the layout rather than hard-code
+          # it — and never mkdir the target, since creating a missing tree is how
+          # a layout change ends up silently publishing into a dead directory.
+          PYTHON_TREE=""
+          for candidate in "api-reference/python" "docs/api-reference/python"; do
+            if [ -d "docs_mintlify/$candidate" ]; then
+              PYTHON_TREE="$candidate"
+              break
+            fi
+          done
+
+          if [ -z "$PYTHON_TREE" ]; then
+            echo "Error: docs_mintlify has no api-reference/python (looked at the repo root and under docs/) — site layout changed?"
+            exit 1
+          fi
+
+          TARGET_DIR="docs_mintlify/$PYTHON_TREE"
+          echo "python_tree=$PYTHON_TREE" >> $GITHUB_ENV
 
           echo "Copying documentation from $SOURCE_DIR to $TARGET_DIR"
-
-          # Create target directory if it doesn't exist
-          mkdir -p "$TARGET_DIR"
 
           # Remove old mdx files (keep any other files that might exist)
           rm -f "$TARGET_DIR"/*.mdx
@@ -228,7 +245,7 @@ jobs:
           echo "- **Source Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Target Repository**: nevermined-io/docs_mintlify" >> $GITHUB_STEP_SUMMARY
           echo "- **Target Branch**: ${{ steps.version.outputs.target_branch }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Target Path**: docs/api-reference/python/" >> $GITHUB_STEP_SUMMARY
+          echo "- **Target Path**: ${{ env.python_tree }}/" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ "${{ steps.create_pr.outputs.pull-request-number }}" != "" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ use one of the two builders — never hand-build headers. Constants live in
 - `LOCKED_API_VERSION` (`"1.1"`) — the **backend API version** (nvm-monorepo
   `MAJOR.MINOR`) this SDK release is built and tested against. It is **not**
   the package version in `pyproject.toml`; the two move independently. See
-  https://docs.nevermined.app/api-reference/versioning and
+  https://nevermined.ai/docs/development-guide/api-versioning and
   nvm-monorepo#1535 / nvm-monorepo#1938.
 - `API_VERSION_HEADER` (`"Nevermined-Version"`) — the request header name.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ numbered chapters (`NN-<slug>.md`). On release, `publish-mintlify-docs.yml`
 converts them to Mintlify MDX via
 [`scripts/convert_to_mintlify.py`](./scripts/convert_to_mintlify.py) and opens a
 PR against the docs site (`nevermined-io/docs`), publishing them at
-`docs/api-reference/python/<slug>`.
+`api-reference/python/<slug>`.
 
 When you change a public API, update the matching chapter in `docs/api/` (see
 [`CLAUDE.md`](./CLAUDE.md) for which files map to which APIs) and rebuild with
@@ -38,7 +38,7 @@ In `docs/api/**`, use only:
 
 - ✅ **Chapter links** to other `docs/api/` pages, by filename — `[x402](11-x402.md)`
   or `[x402](./11-x402.md#section)`. The converter rewrites these to the site URL
-  (`/docs/api-reference/python/x402-module`). The set of rewritable chapters is
+  (`/api-reference/python/x402-module`). The set of rewritable chapters is
   `LINK_MAPPING` in [`scripts/convert_to_mintlify.py`](./scripts/convert_to_mintlify.py);
   add a chapter there when you add a page.
 - ✅ **Site-relative links** to other docs-site pages — `[LangChain](/integrate/add-to-your-agent/langchain)`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ In `docs/api/**`, use only:
   (`/docs/api-reference/python/x402-module`). The set of rewritable chapters is
   `LINK_MAPPING` in [`scripts/convert_to_mintlify.py`](./scripts/convert_to_mintlify.py);
   add a chapter there when you add a page.
-- ✅ **Site-relative links** to other docs-site pages — `[LangChain](/docs/integrate/add-to-your-agent/langchain)`.
+- ✅ **Site-relative links** to other docs-site pages — `[LangChain](/integrate/add-to-your-agent/langchain)`.
 - ✅ **In-page anchors** — `[Credits](#credits-semantics)`.
 - ✅ **Absolute GitHub URLs** for anything in the repo (source, tests, READMEs,
   other directories) — `[x402 README](https://github.com/nevermined-io/payments-py/blob/main/payments_py/x402/README.md)`.

--- a/docs/api/02-initializing-the-library.md
+++ b/docs/api/02-initializing-the-library.md
@@ -100,7 +100,7 @@ payments = Payments.get_instance(
 )
 ```
 
-See the [API versioning reference](https://docs.nevermined.app/api-reference/versioning)
+See the [API versioning reference](https://nevermined.ai/docs/development-guide/api-versioning)
 for the list of versions and the changes between them.
 
 ## Environments

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -2,7 +2,7 @@
 
 This guide covers the LangChain and LangGraph integration shipped in the `[langchain]` optional extra of `payments-py`. The module `payments_py.x402.langchain` provides the decorator, helpers, and exceptions for monetizing LangChain tools with the x402 protocol.
 
-For the conceptual walk-through (two integration approaches, the discovery-first flow, dynamic credits patterns), see the [LangChain integration guide](/docs/integrate/add-to-your-agent/langchain). For a runnable end-to-end demo, see the [`langchain-paid-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-paid-agent-py) tutorial.
+For the conceptual walk-through (two integration approaches, the discovery-first flow, dynamic credits patterns), see the [LangChain integration guide](/integrate/add-to-your-agent/langchain). For a runnable end-to-end demo, see the [`langchain-paid-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-paid-agent-py) tutorial.
 
 > Looking to gate a **LangSmith Deployment** entry point (`/threads/{id}/runs/wait` etc.) rather than individual tools? See [LangSmith Deployment Middleware](./13-langsmith-deployment.md). The two integrations are complementary: the decorator covered here protects tools the agent calls; the LangSmith Deployment middleware protects the agent's HTTP entry point.
 
@@ -125,7 +125,7 @@ except PaymentRequiredError as err:
 |-----------|------|-------------|
 | `payment_required` | `X402PaymentRequired \| None` | The full x402 v2 payment-required payload. `accepts[0]` carries scheme / network / plan_id / agent_id. |
 
-For the discovery → acquire → retry flow, see the [LangChain integration guide](/docs/integrate/add-to-your-agent/langchain).
+For the discovery → acquire → retry flow, see the [LangChain integration guide](/integrate/add-to-your-agent/langchain).
 
 ## `last_settlement`
 
@@ -386,6 +386,6 @@ Span emission failures are caught internally — observability is best-effort an
 
 ## Related
 
-- [LangChain integration guide](/docs/integrate/add-to-your-agent/langchain) — conceptual walk-through, the two integration approaches (decorator vs. HTTP middleware), and the TypeScript variant.
+- [LangChain integration guide](/integrate/add-to-your-agent/langchain) — conceptual walk-through, the two integration approaches (decorator vs. HTTP middleware), and the TypeScript variant.
 - [x402 Protocol](11-x402.md) — token generation, delegation config, scheme resolution.
 - [`tutorials/langchain-paid-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-paid-agent-py) — the minimal end-to-end demo.

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,5 +64,5 @@ Detailed API documentation:
 ## Support
 
 - [GitHub Repository](https://github.com/nevermined-io/payments-py)
-- [Nevermined Documentation](https://docs.nevermined.app)
+- [Nevermined Documentation](https://nevermined.ai/docs)
 - [Nevermined App](https://nevermined.app)

--- a/payments_py/common/api_version.py
+++ b/payments_py/common/api_version.py
@@ -7,7 +7,7 @@ against via the ``Nevermined-Version`` header, so the backend can keep
 serving the pinned contract (or reject the call) instead of silently
 changing response shapes under the SDK.
 
-See https://docs.nevermined.app/api-reference/versioning and
+See https://nevermined.ai/docs/development-guide/api-versioning and
 nvm-monorepo#1535 / nvm-monorepo#1938.
 """
 

--- a/payments_py/x402/README.md
+++ b/payments_py/x402/README.md
@@ -1036,7 +1036,7 @@ export NVM_ENVIRONMENT="sandbox"  # or "live"
 
 ## See Also
 
-- [Nevermined Documentation](https://docs.nevermined.app/) - Complete platform documentation
+- [Nevermined Documentation](https://nevermined.ai/docs) - Complete platform documentation
 - [X402 Protocol Specification](https://github.com/coinbase/x402) - X402 payment protocol
 - [A2A Protocol](https://github.com/google-a2a/a2a) - Agent-to-Agent communication
 - [A2A X402 Specification](https://github.com/google-a2a/a2a-x402) - X402 with A2A

--- a/scripts/check_synced_doc_links.sh
+++ b/scripts/check_synced_doc_links.sh
@@ -35,7 +35,8 @@
 #   DOCS_REF        default main
 #   MINTLIFY_VERSION default 4.2.629 (pin; the docs repo tracks latest)
 #   DOCS_CHECKOUT   pre-cloned docs repo to reuse instead of cloning
-#   SCOPE_PREFIX    site path whose broken links we own (default the python tree)
+#   SCOPE_PREFIX    site path whose broken links we own (default: the python
+#                   tree, auto-detected from the checkout's layout)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,8 +51,9 @@ DOCS_REF="${DOCS_REF:-main}"
 # Pin Mintlify for reproducibility. The docs repo itself installs floating
 # latest (npm i -g mintlify); bump this when that materially changes.
 MINTLIFY_VERSION="${MINTLIFY_VERSION:-4.2.629}"
-# Broken links whose source file starts with this site path are ours to fix.
-SCOPE_PREFIX="${SCOPE_PREFIX:-docs/api-reference/python/}"
+# SCOPE_PREFIX (broken links whose source file starts with this site path are
+# ours to fix) defaults to the python tree, resolved after the checkout — see
+# PYTHON_TREE below.
 
 if [ ! -d "$SOURCE_DIR" ]; then
   echo "Error: source docs not found at $SOURCE_DIR" >&2
@@ -90,11 +92,27 @@ if [ ! -f "$DOCS_DIR/docs.json" ] && [ ! -f "$DOCS_DIR/mint.json" ]; then
   exit 1
 fi
 
-TARGET_DIR="$DOCS_DIR/docs/api-reference/python"
-if [ ! -d "$TARGET_DIR" ]; then
-  echo "Error: $DOCS_REPO has no docs/api-reference/python — site layout changed?" >&2
+# Locate the python tree. The docs site used to nest its pages under a
+# top-level `docs/`; nevermined-io/docs#257 flattened that to the repo root for
+# base-path hosting. Detect the layout instead of hard-coding either one, so a
+# future move fails loudly rather than silently staging into the wrong place.
+PYTHON_TREE=""
+for candidate in "api-reference/python" "docs/api-reference/python"; do
+  if [ -d "$DOCS_DIR/$candidate" ]; then
+    PYTHON_TREE="$candidate"
+    break
+  fi
+done
+if [ -z "$PYTHON_TREE" ]; then
+  echo "Error: $DOCS_REPO has no api-reference/python (looked at the repo root" \
+       "and under docs/) — site layout changed?" >&2
   exit 1
 fi
+TARGET_DIR="$DOCS_DIR/$PYTHON_TREE"
+# Mintlify reports broken-link sources as paths relative to the project root,
+# so the scope prefix tracks whichever layout we just found.
+SCOPE_PREFIX="${SCOPE_PREFIX:-$PYTHON_TREE/}"
+echo "Docs-site python tree: $PYTHON_TREE"
 
 # 3. Replace the python pages with the freshly-converted ones (mirror the bot:
 #    rm old *.mdx, copy new). Other sections stay so site-relative links resolve.

--- a/scripts/check_synced_doc_links.sh
+++ b/scripts/check_synced_doc_links.sh
@@ -5,7 +5,7 @@
 #
 # Why staged against the real site, not in-repo: the release pipeline
 # (publish-mintlify-docs.yml) converts docs/api/NN-*.md into
-# docs/api-reference/python/<slug>.mdx via scripts/convert_to_mintlify.py and
+# api-reference/python/<slug>.mdx via scripts/convert_to_mintlify.py and
 # opens a PR against nevermined-io/docs. A plain mkdocs build here would PASS and
 # miss site-only breakage, because relative links resolve differently once the
 # files live under api-reference/python/ on the site (this broke
@@ -13,11 +13,11 @@
 #
 # Unlike the TypeScript sibling (payments#401), the Python pages legitimately
 # link to OTHER docs-site sections via site-relative paths (e.g.
-# /docs/integrate/add-to-your-agent/langchain). Those resolve only against the
+# /integrate/add-to-your-agent/langchain). Those resolve only against the
 # *whole* site, so a self-contained mini-site of just the 13 python pages would
 # false-positive on the clean tree. We therefore clone the real (public)
 # nevermined-io/docs, drop the freshly-converted pages into
-# docs/api-reference/python/, and run `mintlify broken-links` on the whole site.
+# api-reference/python/, and run `mintlify broken-links` on the whole site.
 #
 # Hard-gates INTERNAL links only: `mintlify broken-links` checks internal links
 # by default and only pings external URLs with --check-external (NOT passed —
@@ -25,7 +25,7 @@
 #
 # Scoped to OUR breakage: the whole site may carry pre-existing broken links we
 # don't own. We replace ALL python pages with freshly-converted ones, so any
-# broken link whose SOURCE file is under docs/api-reference/python/ is breakage
+# broken link whose SOURCE file is under api-reference/python/ is breakage
 # introduced by these staged pages. We parse the checker output and fail ONLY on
 # python-sourced broken links — pre-existing breakage elsewhere on the site does
 # not fail this gate. (See the scoped-parse step at the end of this script.)
@@ -150,7 +150,7 @@ echo ""
 
 # Parse the report and fail ONLY on broken links sourced from our staged pages.
 # Output shape (one source block per file with broken links):
-#   docs/api-reference/python/a2a-module.mdx
+#   api-reference/python/a2a-module.mdx
 #    ⎿  ../../payments_py/x402/README.md
 SCOPE_PREFIX="$SCOPE_PREFIX" MINTLIFY_RC="$mintlify_rc" python3 - "$REPORT" <<'PY'
 import os, re, sys
@@ -213,7 +213,7 @@ if scoped:
     for src, target in scoped:
         print(f"  {src} -> {target}")
     print("\nThese links resolve in-repo but are dead on the docs site. Use a "
-          "chapter link the converter rewrites, a site-relative /docs/... path, "
+          "chapter link the converter rewrites, a site-relative /... path, "
           "or an absolute https://github.com/... URL. See CONTRIBUTING.md.")
     sys.exit(1)
 

--- a/scripts/convert_to_mintlify.py
+++ b/scripts/convert_to_mintlify.py
@@ -94,19 +94,19 @@ FILE_MAPPING = {
 
 # Link mapping for internal references
 LINK_MAPPING = {
-    "01-installation.md": "/docs/api-reference/python/installation",
-    "02-initializing-the-library.md": "/docs/api-reference/python/payments-class",
-    "03-payment-plans.md": "/docs/api-reference/python/plans-module",
-    "04-agents.md": "/docs/api-reference/python/agents-module",
-    "05-publishing-static-resources.md": "/docs/api-reference/python/resources-module",
-    "06-payments-and-balance.md": "/docs/api-reference/python/balance-module",
-    "07-querying-an-agent.md": "/docs/api-reference/python/requests-module",
-    "08-validation-of-requests.md": "/docs/api-reference/python/validation-module",
-    "09-mcp-integration.md": "/docs/api-reference/python/mcp-module",
-    "10-a2a-integration.md": "/docs/api-reference/python/a2a-module",
-    "11-x402.md": "/docs/api-reference/python/x402-module",
-    "12-langchain-integration.md": "/docs/api-reference/python/langchain-module",
-    "13-langsmith-deployment.md": "/docs/api-reference/python/langsmith-deployment-module",
+    "01-installation.md": "/api-reference/python/installation",
+    "02-initializing-the-library.md": "/api-reference/python/payments-class",
+    "03-payment-plans.md": "/api-reference/python/plans-module",
+    "04-agents.md": "/api-reference/python/agents-module",
+    "05-publishing-static-resources.md": "/api-reference/python/resources-module",
+    "06-payments-and-balance.md": "/api-reference/python/balance-module",
+    "07-querying-an-agent.md": "/api-reference/python/requests-module",
+    "08-validation-of-requests.md": "/api-reference/python/validation-module",
+    "09-mcp-integration.md": "/api-reference/python/mcp-module",
+    "10-a2a-integration.md": "/api-reference/python/a2a-module",
+    "11-x402.md": "/api-reference/python/x402-module",
+    "12-langchain-integration.md": "/api-reference/python/langchain-module",
+    "13-langsmith-deployment.md": "/api-reference/python/langsmith-deployment-module",
 }
 
 

--- a/scripts/lint_doc_links.py
+++ b/scripts/lint_doc_links.py
@@ -2,7 +2,7 @@
 """Cheap, deterministic, network-free escaping-link lint for docs/api/**.
 
 The release pipeline (`publish-mintlify-docs.yml`) converts every
-``docs/api/NN-*.md`` into ``docs/api-reference/python/<slug>.mdx`` on the docs
+``docs/api/NN-*.md`` into ``api-reference/python/<slug>.mdx`` on the docs
 site via ``scripts/convert_to_mintlify.py``. A link that resolves fine *inside
 this repo* — e.g. ``](../../payments_py/x402/README.md)`` — is dead once synced,
 because the site has no parent dirs and no repo source. This bit the docs site
@@ -15,7 +15,7 @@ from the transform it is guarding: add a chapter to ``LINK_MAPPING`` and the
 lint accepts a relative link to it automatically.
 
 A markdown link in ``docs/api/**`` is FLAGGED when its destination is a
-relative path (not an anchor, a site-relative ``/docs/...`` path, or an absolute
+relative path (not an anchor, a site-relative ``/...`` path, or an absolute
 URL) that the converter will NOT rewrite — i.e. it escapes the synced tree
 (contains a ``/``, including any ``../``) or its basename is not one of the
 chapter files in ``LINK_MAPPING``.
@@ -142,11 +142,11 @@ def main() -> int:
         print()
         print(
             "Synced docs (docs/api/**) are converted to the docs site under\n"
-            "  docs/api-reference/python/. A relative link that escapes that tree\n"
+            "  api-reference/python/. A relative link that escapes that tree\n"
             "  (../…) or points at repo source resolves in-repo but is dead on the\n"
             "  site (this broke nevermined-io/docs#234). Use a chapter link the\n"
             "  converter rewrites (e.g. 11-x402.md — see LINK_MAPPING in\n"
-            "  scripts/convert_to_mintlify.py), a site-relative path (/docs/…), or\n"
+            "  scripts/convert_to_mintlify.py), a site-relative path (/…), or\n"
             "  an absolute https://github.com/… URL instead. See CONTRIBUTING.md."
         )
         return 1

--- a/scripts/lint_doc_links.py
+++ b/scripts/lint_doc_links.py
@@ -23,7 +23,7 @@ chapter files in ``LINK_MAPPING``.
 It intentionally ALLOWS:
   - convertible chapter links: ``](11-x402.md)``, ``](./11-x402.md#anchor)``
     (basename in LINK_MAPPING, no path separator) — rewritten to the site URL.
-  - site-relative paths: ``](/docs/integrate/...)`` — resolve on the site.
+  - site-relative paths: ``](/integrate/...)`` — resolve on the site.
   - in-page anchors: ``](#section)``.
   - absolute URLs: ``](https://...)``, ``](mailto:...)``.
 

--- a/tests/unit/test_convert_to_mintlify.py
+++ b/tests/unit/test_convert_to_mintlify.py
@@ -21,21 +21,21 @@ _spec.loader.exec_module(convert)
 def test_unanchored_internal_link_is_rewritten():
     md = "- [MCP Integration](09-mcp-integration.md) - x402 with MCP servers"
     out = convert.convert_internal_links(md)
-    assert "(/docs/api-reference/python/mcp-module)" in out
+    assert "(/api-reference/python/mcp-module)" in out
     assert "09-mcp-integration.md" not in out
 
 
 def test_anchored_internal_link_keeps_its_fragment():
     md = "[MCP OAuth and x402 Discovery](09-mcp-integration.md#mcp-oauth-and-x402-discovery)"
     out = convert.convert_internal_links(md)
-    assert "(/docs/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery)" in out
+    assert "(/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery)" in out
     assert "09-mcp-integration.md" not in out
 
 
 def test_relative_path_prefix_with_anchor_is_rewritten():
     md = "see [rel](../api/09-mcp-integration.md#mcp-oauth-and-x402-discovery) here"
     out = convert.convert_internal_links(md)
-    assert "(/docs/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery)" in out
+    assert "(/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery)" in out
 
 
 def test_next_steps_anchored_link_becomes_card_with_docs_site_href():
@@ -49,8 +49,5 @@ def test_next_steps_anchored_link_becomes_card_with_docs_site_href():
         " - Experimental MCP payment discovery metadata\n"
     )
     out = convert.convert_next_steps_to_cards(convert.convert_internal_links(md))
-    assert (
-        'href="/docs/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery"'
-        in out
-    )
+    assert 'href="/api-reference/python/mcp-module#mcp-oauth-and-x402-discovery"' in out
     assert "09-mcp-integration.md" not in out


### PR DESCRIPTION
Started as the `payments-py` slice of the `docs.nevermined.app` sweep (nevermined-io/nevermined.ai-website#233). The first push exposed a second, unrelated breakage from the same epic, so this PR carries both.

## 1. Retire `docs.nevermined.app` (the original ask)

`docs.nevermined.app` 301s to `nevermined.ai/docs/*`. The redirect works, so nothing is broken, but these references live in surfaces users **copy** (docstrings, synced docs) rather than click. All five occurrences now point at the final URLs.

Three of the five were dead links, not just stale hosts:

```
https://docs.nevermined.app/api-reference/versioning
  → 301 https://nevermined.ai/docs/api-reference/versioning
  → 404
```

A host-only rewrite would have produced a working URL to a 404. The live page is `https://nevermined.ai/docs/development-guide/api-versioning` (verified 200).

| File | Change |
| --- | --- |
| `docs/index.md` | host swap |
| `payments_py/x402/README.md` | host swap |
| `docs/api/02-initializing-the-library.md` | retarget dead versioning link |
| `payments_py/common/api_version.py` | retarget dead versioning link |
| `CLAUDE.md` | retarget dead versioning link |

`docs/api/02-initializing-the-library.md` is synced to the docs site, and is the source of the last remaining `docs.nevermined.app` occurrence in the published `nevermined.ai/docs/llms-full.txt` — this drops that count from 1 to 0 on the next release.

## 2. Follow the docs-site flatten (found by CI on this branch)

nevermined-io/docs#257 ("flatten `docs/` to the repo root for base-path hosting", also #214) moved the site's pages out of the top-level `docs/` directory on 2026-07-29. This repo still assumed the old layout in two ways. The `staged-mintlify-check` gate had not run since 2026-07-24, so this PR is where it surfaced.

**Target path.** `scripts/check_synced_doc_links.sh` hard-coded `docs/api-reference/python` and hard-failed:

```
Error: nevermined-io/docs_mintlify has no docs/api-reference/python — site layout changed?
```

`publish-mintlify-docs.yml` had the same stale path but `mkdir -p`'d it, so **the release would not have failed** — it would have recreated the dead directory and published the `.mdx` files into it, then opened a docs PR adding pages nothing links to. Both now detect the tree (repo root first, then under `docs/`), and the workflow no longer creates it: a missing tree means the layout moved again and must fail loudly. `SCOPE_PREFIX` follows the detected path, since mintlify reports broken-link sources relative to the project root.

**Link prefix.** With the site no longer nested, internal links dropped their `/docs` prefix — `docs.json` navigates to `api-reference/python/*`, and the site now contains zero `](/docs/...)` links. Every link we emitted was therefore dead: 32 broken links sourced from the staged pages. Rewritten in `convert_to_mintlify.py` `LINK_MAPPING` (13), `docs/api/12-langchain-integration.md` (3), `tests/unit/test_convert_to_mintlify.py` (4 pinned assertions), plus the two docs describing the convention.

## Verification

```
$ grep -rn 'docs\.nevermined\.app' --exclude-dir=.git .   # no matches
$ grep -rn '](/docs/' --exclude-dir=.git .                # no matches
$ python3 scripts/lint_doc_links.py                       # ✓ no escaping links
$ bash scripts/check_synced_doc_links.sh                  # success no broken links found
$ poetry run black --check .                              # 164 files unchanged
$ poetry run pytest -m "not slow"                         # green (see note)
$ poetry run mkdocs build                                 # OK
```

`check_synced_doc_links.sh` was run locally against the real docs site, and passes in CI (`staged-mintlify-check`).

Refs nevermined-io/nevermined.ai-website#233, nevermined-io/docs#257

🤖 Generated with [Claude Code](https://claude.com/claude-code)