### PR TITLE
fix(organizations): onboard_customer returns the Bearer (hash), not the encrypted blob

### DIFF
--- a/payments_py/api/organizations_api.py
+++ b/payments_py/api/organizations_api.py
@@ -256,9 +256,11 @@ class OrganizationsAPI(BasePaymentsAPI):
         Admin-only on the backend. Provisions a Nevermined account for the
         customer **without consuming a member seat** and returns a usable,
         scoped NVM API key the org can use to transparently act on the
-        customer's behalf (purchase plans / redeem credits). Unlike
-        :meth:`create_member`, this returns the **real** usable key
-        (``walletResult.nvmApiKey``), not the non-usable lookup hash.
+        customer's behalf (purchase plans / redeem credits). Like
+        :meth:`create_member`, the usable Bearer is ``walletResult.hash``
+        (``<prefix>:<jwt>``) and is surfaced as ``nvm_api_key``; the sibling
+        ``walletResult.nvmApiKey`` is the encrypted server-side blob and is
+        **not** a valid Bearer.
 
         If the email already belongs to an account the org does NOT own, no key
         is issued: the backend replies ``202`` and the result carries
@@ -307,10 +309,16 @@ class OrganizationsAPI(BasePaymentsAPI):
         # or key can leak even if the backend regresses.
         if response.status_code == 202 or result.consent_required:
             return CustomerOnboardingResponse(consent_required=True)
-        # New account or returning customer: a usable key MUST be present. A 2xx
-        # without one means a partial/unexpected payload — fail loudly rather
-        # than return a "success" carrying missing credentials.
-        if not result.nvm_api_key:
+        # New account or returning customer: the Bearer MUST be present. The
+        # backend returns the usable credential as ``walletResult.hash``
+        # (``<prefix>:<jwt>``); the sibling ``nvmApiKey`` — which the
+        # ``model_validate`` above mapped into ``nvm_api_key`` — is the encrypted
+        # server-side blob and is NOT a valid Bearer. Surface ``hash`` instead,
+        # exactly as create_member does. A 2xx without a hash means a
+        # partial/unexpected payload — fail loudly rather than return a "success"
+        # carrying no usable credential.
+        hash_key = wallet.get("hash")
+        if not hash_key:
             raise PaymentsError.from_backend(
                 "Unable to onboard customer",
                 {
@@ -320,7 +328,7 @@ class OrganizationsAPI(BasePaymentsAPI):
                     )
                 },
             )
-        return result
+        return result.model_copy(update={"nvm_api_key": hash_key})
 
     def get_members(
         self,

--- a/payments_py/api/organizations_api.py
+++ b/payments_py/api/organizations_api.py
@@ -317,8 +317,11 @@ class OrganizationsAPI(BasePaymentsAPI):
         # exactly as create_member does. A 2xx without a hash means a
         # partial/unexpected payload — fail loudly rather than return a "success"
         # carrying no usable credential.
+        # ``model_copy(update=…)`` below does not validate, so assert the shape
+        # here: the backend contract is ``<env>:<JWT>`` — a non-string truthy
+        # ``hash`` must never reach ``Payments`` as the Bearer.
         hash_key = wallet.get("hash")
-        if not hash_key:
+        if not isinstance(hash_key, str) or not hash_key:
             raise PaymentsError.from_backend(
                 "Unable to onboard customer",
                 {

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -701,6 +701,10 @@ class CustomerOnboardingResponse(BaseModel):
     user_wallet: Optional[str] = Field(default=None, alias="userWallet")
     is_customer: bool = Field(default=False, alias="isCustomer")
     customer_recorded: Optional[bool] = Field(default=None, alias="customerRecorded")
+    # ISO-8601 expiry of the credential (#2924). Track it and re-onboard to
+    # refresh before it lapses. Optional: returned for the credential outcome,
+    # but an older backend may omit it.
+    expires_at: Optional[str] = Field(default=None, alias="expiresAt")
 
 
 class StripeAccountConnectResult(BaseModel):

--- a/tests/unit/test_organizations_api.py
+++ b/tests/unit/test_organizations_api.py
@@ -689,6 +689,25 @@ class TestOnboardCustomer:
             with pytest.raises(PaymentsError, match="no API key"):
                 payments.organizations.onboard_customer("customer@example.com")
 
+    def test_raises_when_hash_is_not_a_string(self):
+        # model_copy does not validate, so a non-string truthy hash must be
+        # rejected before it reaches Payments as the Bearer.
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.post(
+                f"{BACKEND}/api/v1/organizations/account",
+                status_code=201,
+                json={
+                    "success": True,
+                    "walletResult": {
+                        "hash": {"unexpected": "object"},
+                        "userId": "us-1",
+                    },
+                },
+            )
+            with pytest.raises(PaymentsError, match="no API key"):
+                payments.organizations.onboard_customer("customer@example.com")
+
     def test_raises_on_5xx(self):
         payments = _make_payments()
         with requests_mock.Mocker() as m:

--- a/tests/unit/test_organizations_api.py
+++ b/tests/unit/test_organizations_api.py
@@ -600,7 +600,7 @@ class TestConnectStripeAccount:
 
 
 class TestOnboardCustomer:
-    def test_new_customer_returns_real_key_and_sends_as_customer(self):
+    def test_new_customer_returns_hash_as_bearer_and_sends_as_customer(self):
         payments = _make_payments()
         with requests_mock.Mocker() as m:
             m.post(
@@ -610,10 +610,14 @@ class TestOnboardCustomer:
                     "success": True,
                     "message": "Customer onboarded",
                     "walletResult": {
-                        "hash": "lookup-hash",
+                        # ``hash`` is the Bearer credential (``<prefix>:<jwt>``) —
+                        # the value to send as ``Authorization: Bearer …``.
+                        "hash": "sandbox:jwt-bearer-token",
                         "userId": "us-123",
                         "userWallet": "0xabc",
-                        "nvmApiKey": "nvm-real-usable-key",
+                        # ``nvmApiKey`` is the encrypted server-side blob — NOT a
+                        # Bearer; it must never leak through as a credential.
+                        "nvmApiKey": "encrypted-blob-not-a-bearer",
                         "isCustomer": True,
                         "customerRecorded": True,
                         "alreadyMember": False,
@@ -626,8 +630,9 @@ class TestOnboardCustomer:
         # Opts into the customer outcome.
         assert body == {"email": "customer@example.com", "as": "customer"}
         assert isinstance(result, CustomerOnboardingResponse)
-        # The USABLE key is returned — not the (non-usable) lookup hash.
-        assert result.nvm_api_key == "nvm-real-usable-key"
+        # The USABLE Bearer (``hash``) is surfaced as ``nvm_api_key`` (mirroring
+        # create_member) — the raw ``nvmApiKey`` blob must never leak through.
+        assert result.nvm_api_key == "sandbox:jwt-bearer-token"
         assert result.is_customer is True
         assert result.customer_recorded is True
         assert result.user_id == "us-123"

--- a/tests/unit/test_organizations_api.py
+++ b/tests/unit/test_organizations_api.py
@@ -620,6 +620,7 @@ class TestOnboardCustomer:
                         "nvmApiKey": "encrypted-blob-not-a-bearer",
                         "isCustomer": True,
                         "customerRecorded": True,
+                        "expiresAt": "2026-09-27T12:00:00.000Z",
                         "alreadyMember": False,
                     },
                 },
@@ -637,6 +638,8 @@ class TestOnboardCustomer:
         assert result.customer_recorded is True
         assert result.user_id == "us-123"
         assert result.consent_required is False
+        # The credential expiry the paired docs tell integrators to track.
+        assert result.expires_at == "2026-09-27T12:00:00.000Z"
 
     def test_existing_non_owned_account_requires_consent_opaque(self):
         payments = _make_payments()


### PR DESCRIPTION
## Why this matters

White-label customer onboarding through the Python SDK is currently broken: `onboard_customer` hands callers a credential that cannot authenticate. Any integrator following our docs — onboard a customer, then act on their behalf with the returned key — gets `401`s, because the value we return is an encrypted internal blob, not a usable Bearer token. This fixes the SDK so the documented flow works. It's the Python twin of the TypeScript fix ([payments#420](https://github.com/nevermined-io/payments/pull/420)), both surfaced by [docs#301](https://github.com/nevermined-io/docs/pull/301).

## The bug

`onboard_customer` builds its result with `CustomerOnboardingResponse.model_validate(walletResult)`, and the model's `nvm_api_key` field is aliased to `nvmApiKey`. The backend documents that field (for the `as=customer` outcome, #2924) as *"the encrypted SDK/server-side blob — NOT a Bearer; do not send it as a header. To authenticate an HTTP request use `hash`."* So `model_validate` populated `nvm_api_key` from the blob, and the method returned it.

`create_member` already does the right thing — it constructs `CreateUserResponse(nvm_api_key=wallet["hash"], …)`. `onboard_customer` relied on the alias instead and picked up the blob.

## The fix

- Surface `wallet["hash"]` (the Bearer) as `nvm_api_key`, via `result.model_copy(update=…)` so the response object stays immutable.
- Guard on `wallet["hash"]` (the field we now return) instead of the blob, so a partial payload still fails loudly.
- Corrected the docstring, which had the semantics inverted.

## Test plan

- Corrected the unit test, which had encoded the inverted premise (it called `hash` a "lookup hash" and asserted the raw blob was returned). It now asserts `hash` is surfaced as the Bearer and the blob never leaks.
- `poetry run pytest tests/unit/test_organizations_api.py` → 34/34 pass.
- `poetry run black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZ3y8ptZEYfscAKfhyfs1h