### PR TITLE
test(x402): pin Deep Agents compatibility for @requires_payment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,32 @@ jobs:
           TEST_BUILDER_API_KEY: ${{ secrets.TEST_BUILDER_API_KEY }}
         run: poetry run pytest -m "not slow" -v -s
 
+  deepagents_compat:
+    runs-on: ubuntu-latest
+    # Deep Agents compatibility (tests/unit/x402/test_deepagents_compat.py).
+    #
+    # Runs as its own job rather than inside `unit_integration` because that
+    # job deliberately pins Python 3.10 — the floor this package declares
+    # (`python = "^3.10"`) — while deepagents requires >=3.11. It also needs
+    # the LangChain v1 stack (langgraph >=1.2.11), which is disjoint from the
+    # `langgraph = "^0.6.0"` the test group pins, so it installs with pip in a
+    # clean environment instead of through the shared poetry lock. Keeping it
+    # separate means the 3.10 floor stays tested and this contract still runs.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install the SDK and the Deep Agents harness
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[langchain,langsmith]"
+          pip install deepagents pytest pytest-timeout pytest-asyncio
+      - name: Run Deep Agents compatibility tests
+        # -p no:randomly / no markers: these are pure unit tests, no network.
+        run: pytest tests/unit/x402/test_deepagents_compat.py -v
+
   e2e:
     runs-on: ubuntu-latest
 

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -482,12 +482,15 @@ the deep agent its own virtualenv.
 
 Compatibility is pinned by `tests/unit/x402/test_deepagents_compat.py`, which
 drives a real deep agent through a scripted fake model (no network, no LLM) and
-asserts the token reaches a subagent's tool. Those tests `importorskip` and are
-**skipped unless `deepagents` is installed**:
+asserts the token reaches a subagent's tool. They run in CI under the dedicated
+`deepagents_compat` job — separate from the main test job, which pins the
+Python 3.10 floor that `deepagents` cannot install on. To reproduce locally:
 
 ```bash
-poetry run pip install deepagents
-poetry run pytest tests/unit/x402/test_deepagents_compat.py
+python3.11 -m venv .venv-deepagents
+.venv-deepagents/bin/pip install -e ".[langchain,langsmith]"
+.venv-deepagents/bin/pip install deepagents pytest
+.venv-deepagents/bin/pytest tests/unit/x402/test_deepagents_compat.py
 ```
 
 ## Related

--- a/docs/api/12-langchain-integration.md
+++ b/docs/api/12-langchain-integration.md
@@ -384,8 +384,116 @@ with settlement_span(plan_ids=["plan-1"]) as span:
 
 Span emission failures are caught internally — observability is best-effort and will not interfere with the payment flow.
 
+## Deep Agents
+
+[Deep Agents](https://docs.langchain.com/oss/python/deepagents/overview) is
+LangChain's agent *harness*: `create_deep_agent()` returns a compiled LangGraph
+graph with planning, a filesystem, and subagent delegation built in.
+
+**`requires_payment` needs no changes to work with it.** The decorator reads the
+token from `config["configurable"]["payment_token"]`, and LangGraph copies
+`configurable` down into subagent tool calls, so a paid tool keeps working when
+it sits behind a `task()` delegation:
+
+```
+main agent  --task()-->  research-sub  -->  market_research  [PAID]
+     ^                                             |
+     +--------- x402 token supplied here ----------+
+               config.configurable.payment_token
+```
+
+That property is what makes the harness usable for monetized capabilities at
+all: a deep agent's premise is that the supervisor hands work to subagents, so
+if payment context did not survive the hop, every paid tool would have to sit on
+the main agent.
+
+```python
+from deepagents import create_deep_agent
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+
+from payments_py.x402.langchain import PaymentRequiredError, requires_payment
+
+
+@requires_payment(payments=payments, plan_id=PLAN_ID, credits=5)
+def _market_research_paid(topic: str, config: RunnableConfig) -> str:
+    return run_analyst(topic)
+
+
+@tool
+def market_research(topic: str, config: RunnableConfig) -> str:
+    """Paid market research on a topic."""
+    try:
+        # `config` must be forwarded explicitly — the decorator reads the
+        # token from it.
+        return _market_research_paid(topic, config=config)
+    except PaymentRequiredError:
+        return "PAYMENT_REQUIRED: authorize and ask again."
+
+
+# The paid tool is given ONLY to the subagent, so every paid call crosses
+# a delegation boundary.
+graph = create_deep_agent(
+    model="openai:gpt-4o-mini",
+    tools=[],
+    subagents=[{
+        "name": "research-sub",
+        "description": "Performs paid market research.",
+        "system_prompt": "Call market_research once and return its output verbatim.",
+        "tools": [market_research],
+    }],
+    system_prompt="Delegate research requests to research-sub.",
+)
+```
+
+The buyer side is unchanged — the token goes on the run, and the buyer does not
+need to know the agent's internal topology:
+
+```python
+graph.invoke(
+    {"messages": [{"role": "user", "content": "Research the EV market"}]},
+    config={"configurable": {"payment_token": access_token}},
+)
+```
+
+### Two harness behaviours to design around
+
+**A deep agent can bill several times per user turn.** The supervisor, not you,
+decides how many subagent calls a request warrants, so one user message may
+settle credits more than once. Cap it explicitly rather than trusting the model
+to be frugal — count paid calls per run (key on
+`config["configurable"]["thread_id"]` or `run_id`) and return a plain refusal
+once the cap is hit. Refund the reservation when a call raises
+`PaymentRequiredError`, so a user who authorizes mid-run still gets what they
+paid for.
+
+**Two LLM layers can paraphrase the tool's output.** The subagent relays to the
+supervisor, which relays to the user; neither is guaranteed to pass text through
+verbatim, and a capable supervisor may even answer a paid question from its own
+knowledge instead of delegating — silently giving the capability away. Forbid
+that explicitly in both system prompts, and treat the tool's return value, not
+the chat reply, as the source of truth.
+
+### Version note
+
+`deepagents` requires the LangChain v1 stack (`langchain>=1.3.18`,
+`langchain-core>=1.6.1`). If your project pins an older `langchain-core`, give
+the deep agent its own virtualenv.
+
+Compatibility is pinned by `tests/unit/x402/test_deepagents_compat.py`, which
+drives a real deep agent through a scripted fake model (no network, no LLM) and
+asserts the token reaches a subagent's tool. Those tests `importorskip` and are
+**skipped unless `deepagents` is installed**:
+
+```bash
+poetry run pip install deepagents
+poetry run pytest tests/unit/x402/test_deepagents_compat.py
+```
+
 ## Related
 
 - [LangChain integration guide](/integrate/add-to-your-agent/langchain) — conceptual walk-through, the two integration approaches (decorator vs. HTTP middleware), and the TypeScript variant.
 - [x402 Protocol](11-x402.md) — token generation, delegation config, scheme resolution.
 - [`tutorials/langchain-paid-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-paid-agent-py) — the minimal end-to-end demo.
+- [`tutorials/langchain-research-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-research-agent-py) — freemium in-tool gating on `create_react_agent`.
+- [`tutorials/langchain-deep-agent-py`](https://github.com/nevermined-io/tutorials/tree/main/langchain-deep-agent-py) — the same pattern on the Deep Agents harness, with the paid tool inside a subagent.

--- a/tests/unit/x402/conftest.py
+++ b/tests/unit/x402/conftest.py
@@ -1,0 +1,34 @@
+"""Shared fixtures for the x402 unit tests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_last_settlement():
+    """Clear the decorator's module-level settlement holder between tests.
+
+    ``requires_payment`` stashes the most recent ``SettleResponse`` in a
+    module-level slot because LangGraph runs tools in worker contexts that
+    do not propagate ContextVar mutations back to the caller (see
+    ``payments_py.x402.langchain.decorator``). That slot is process-wide,
+    so without this reset one test's settlement leaks into the next.
+
+    The private ``_LAST_SETTLEMENT`` holder is reached directly because
+    ``last_settlement()`` is read-only and the SDK exposes no public
+    reset. Keeping that coupling in **one** place means a change to how
+    the value is stored breaks a single fixture rather than every test
+    module that needs a clean slate.
+
+    Imported lazily so this conftest stays importable — and the rest of
+    the x402 tests stay collectable — in environments without the
+    optional ``langchain-core`` dependency.
+    """
+    try:
+        from payments_py.x402.langchain import decorator as decorator_module
+    except ImportError:
+        yield
+        return
+
+    decorator_module._LAST_SETTLEMENT["value"] = None
+    yield
+    decorator_module._LAST_SETTLEMENT["value"] = None

--- a/tests/unit/x402/test_deepagents_compat.py
+++ b/tests/unit/x402/test_deepagents_compat.py
@@ -1,0 +1,226 @@
+"""Compatibility tests: `@requires_payment` under the Deep Agents harness.
+
+The contract these tests pin down is narrow but load-bearing:
+
+    main agent  --task()-->  subagent  -->  paid tool
+
+A buyer supplies the x402 access token once, on the run, at
+``config["configurable"]["payment_token"]``. The supervisor never handles
+it — it delegates through Deep Agents' built-in ``task`` tool, and
+LangGraph copies ``configurable`` down into the subagent's own tool
+calls. ``requires_payment`` therefore works **unchanged one delegation
+hop away** from where the token was supplied.
+
+That property is what makes the harness usable for monetized
+capabilities at all: a deep agent's premise is that the supervisor hands
+work to subagents, so if payment context did not survive the hop, every
+paid tool would have to sit on the main agent.
+
+No network and no LLM: a scripted fake chat model drives the graph
+through a fixed tool-call sequence, and `Payments` is mocked. The tests
+assert on the SDK's own behaviour, not on a model's willingness to
+delegate.
+
+.. note::
+
+   ``deepagents`` requires the LangChain v1 stack (``langchain>=1.3.18``,
+   ``langchain-core>=1.6.1``), which is newer than this repo's test
+   environment pins. These tests therefore ``importorskip`` and are
+   **skipped in the default test run** — they guard the contract only
+   where ``deepagents`` is actually installed::
+
+       poetry run pip install deepagents
+       poetry run pytest tests/unit/x402/test_deepagents_compat.py
+"""
+
+from typing import Any, Sequence
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.language_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+
+from payments_py.x402.langchain import (
+    PaymentRequiredError,
+    last_settlement,
+    requires_payment,
+)
+from payments_py.x402.langchain import decorator as decorator_module
+from payments_py.x402.types import SettleResponse, VerifyResponse
+
+create_deep_agent = pytest.importorskip(
+    "deepagents",
+    reason="deepagents requires the LangChain v1 stack; install it to run these",
+).create_deep_agent
+
+
+SENTINEL_TOKEN = "x402-token-sentinel"
+
+
+class ScriptedModel(FakeMessagesListChatModel):
+    """Fake chat model that replays a fixed message script.
+
+    ``FakeMessagesListChatModel`` raises ``NotImplementedError`` from
+    ``bind_tools``, which the agent factory calls unconditionally. We
+    accept the tools and ignore them — the script already encodes which
+    tool calls to emit.
+    """
+
+    def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> "ScriptedModel":
+        return self
+
+
+@pytest.fixture
+def mock_payments():
+    """A Payments-like mock with verify + settle stubbed."""
+    payments = MagicMock()
+    payments.facilitator.verify_permissions.return_value = VerifyResponse(
+        is_valid=True,
+        invalid_reason=None,
+        payer="0x1234567890abcdef",
+        agent_request_id="test-request-id-123",
+    )
+    payments.facilitator.settle_permissions.return_value = SettleResponse(
+        success=True,
+        error_reason=None,
+        payer="0x1234567890abcdef",
+        transaction="0xabc123",
+        network="eip155:84532",
+        credits_redeemed="5",
+        remaining_balance="95",
+    )
+    return payments
+
+
+@pytest.fixture(autouse=True)
+def reset_last_settlement():
+    """Reset the module-level holder between tests so they don't bleed state."""
+    decorator_module._LAST_SETTLEMENT["value"] = None
+    yield
+    decorator_module._LAST_SETTLEMENT["value"] = None
+
+
+def _delegating_script() -> list[AIMessage]:
+    """Supervisor delegates, subagent calls the paid tool, both finish.
+
+    The models are invoked sequentially (the ``task`` tool blocks until
+    the subagent returns), so a single scripted model serves both.
+    """
+    return [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "task",
+                    "args": {
+                        "description": "research the EV market",
+                        "subagent_type": "research-sub",
+                    },
+                    "id": "call-task-1",
+                }
+            ],
+        ),
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "market_research",
+                    "args": {"topic": "EV market"},
+                    "id": "call-tool-1",
+                }
+            ],
+        ),
+        AIMessage(content="subagent done"),
+        AIMessage(content="supervisor done"),
+    ]
+
+
+def _build_agent(mock_payments, seen: dict):
+    """Deep agent whose ONLY paid tool lives on a subagent."""
+
+    @tool
+    def market_research(topic: str, config: RunnableConfig) -> str:
+        """Paid market research on a topic."""
+        seen["config_received"] = config is not None
+        try:
+            return _paid_inner(topic, config=config)
+        except PaymentRequiredError as error:
+            seen["payment_required"] = str(error)
+            return "PAYMENT_REQUIRED"
+
+    @requires_payment(payments=mock_payments, plan_id="plan-123", credits=5)
+    def _paid_inner(topic: str, config: RunnableConfig) -> str:
+        seen["tool_body_ran"] = True
+        return f"insight for {topic}"
+
+    return create_deep_agent(
+        model=ScriptedModel(responses=_delegating_script()),
+        tools=[],
+        subagents=[
+            {
+                "name": "research-sub",
+                "description": "Performs paid market research.",
+                "system_prompt": "Call market_research once.",
+                "tools": [market_research],
+            }
+        ],
+        system_prompt="Delegate research to research-sub.",
+    )
+
+
+def test_payment_token_reaches_a_subagent_tool(mock_payments):
+    """The token survives the `task()` delegation hop."""
+    seen: dict = {}
+    agent = _build_agent(mock_payments, seen)
+
+    agent.invoke(
+        {"messages": [{"role": "user", "content": "research the EV market"}]},
+        config={"configurable": {"payment_token": SENTINEL_TOKEN}},
+    )
+
+    assert seen.get("config_received") is True
+    assert seen.get("tool_body_ran") is True
+
+    # The decorator verified against the token the buyer put on the run,
+    # one delegation hop above.
+    mock_payments.facilitator.verify_permissions.assert_called_once()
+    verify_args = mock_payments.facilitator.verify_permissions.call_args
+    assert SENTINEL_TOKEN in str(verify_args)
+
+
+def test_settlement_completes_from_inside_a_subagent(mock_payments):
+    """verify -> body -> settle runs to completion below a delegation."""
+    seen: dict = {}
+    agent = _build_agent(mock_payments, seen)
+
+    agent.invoke(
+        {"messages": [{"role": "user", "content": "research the EV market"}]},
+        config={"configurable": {"payment_token": SENTINEL_TOKEN}},
+    )
+
+    mock_payments.facilitator.settle_permissions.assert_called_once()
+
+    settlement = last_settlement()
+    assert settlement is not None
+    assert settlement.success is True
+    assert settlement.credits_redeemed == "5"
+    assert settlement.remaining_balance == "95"
+
+
+def test_missing_token_raises_payment_required_in_a_subagent(mock_payments):
+    """Without a token the paid body never runs, and nothing settles."""
+    seen: dict = {}
+    agent = _build_agent(mock_payments, seen)
+
+    agent.invoke(
+        {"messages": [{"role": "user", "content": "research the EV market"}]},
+        # No `payment_token` on the run.
+        config={"configurable": {}},
+    )
+
+    assert "payment_required" in seen
+    assert seen.get("tool_body_ran") is not True
+    mock_payments.facilitator.verify_permissions.assert_not_called()
+    mock_payments.facilitator.settle_permissions.assert_not_called()

--- a/tests/unit/x402/test_deepagents_compat.py
+++ b/tests/unit/x402/test_deepagents_compat.py
@@ -23,14 +23,21 @@ delegate.
 
 .. note::
 
-   ``deepagents`` requires the LangChain v1 stack (``langchain>=1.3.18``,
-   ``langchain-core>=1.6.1``), which is newer than this repo's test
-   environment pins. These tests therefore ``importorskip`` and are
-   **skipped in the default test run** — they guard the contract only
-   where ``deepagents`` is actually installed::
+   ``deepagents`` requires Python >=3.11 and the LangChain v1 stack
+   (``langchain>=1.3.18``, ``langgraph>=1.2.11``). The default
+   ``unit_integration`` CI job pins Python 3.10 — the floor this package
+   declares — and the test group pins ``langgraph = "^0.6.0"``, which is
+   disjoint from what deepagents needs. So these tests ``importorskip``
+   and are skipped there.
 
-       poetry run pip install deepagents
-       poetry run pytest tests/unit/x402/test_deepagents_compat.py
+   They are **not** unguarded: the ``deepagents_compat`` job in
+   ``.github/workflows/test.yaml`` runs them on Python 3.11 with a pip
+   install of the v1 stack. To reproduce that locally::
+
+       python3.11 -m venv .venv-deepagents
+       .venv-deepagents/bin/pip install -e ".[langchain,langsmith]"
+       .venv-deepagents/bin/pip install deepagents pytest
+       .venv-deepagents/bin/pytest tests/unit/x402/test_deepagents_compat.py
 """
 
 from typing import Any, Sequence

--- a/tests/unit/x402/test_deepagents_compat.py
+++ b/tests/unit/x402/test_deepagents_compat.py
@@ -54,7 +54,6 @@ from payments_py.x402.langchain import (
     last_settlement,
     requires_payment,
 )
-from payments_py.x402.langchain import decorator as decorator_module
 from payments_py.x402.types import SettleResponse, VerifyResponse
 
 create_deep_agent = pytest.importorskip(
@@ -99,14 +98,6 @@ def mock_payments():
         remaining_balance="95",
     )
     return payments
-
-
-@pytest.fixture(autouse=True)
-def reset_last_settlement():
-    """Reset the module-level holder between tests so they don't bleed state."""
-    decorator_module._LAST_SETTLEMENT["value"] = None
-    yield
-    decorator_module._LAST_SETTLEMENT["value"] = None
 
 
 def _delegating_script() -> list[AIMessage]:

--- a/tests/unit/x402/test_langchain_decorator.py
+++ b/tests/unit/x402/test_langchain_decorator.py
@@ -39,14 +39,6 @@ def mock_payments():
     return payments
 
 
-@pytest.fixture(autouse=True)
-def reset_last_settlement():
-    """Reset the module-level holder between tests so they don't bleed state."""
-    decorator_module._LAST_SETTLEMENT["value"] = None
-    yield
-    decorator_module._LAST_SETTLEMENT["value"] = None
-
-
 def _make_protected_tool(mock_payments, *, credits=1):
     """Build a minimal @tool wrapped with @requires_payment."""
 


### PR DESCRIPTION
## Description

`@requires_payment` works unchanged under LangChain's [Deep Agents](https://docs.langchain.com/oss/python/deepagents/overview) harness — including on a tool that lives **inside a subagent**. Nothing guarded that, so this PR pins it with tests and documents it.

The load-bearing property:

```
main agent  --task()-->  research-sub  -->  market_research  [PAID]
     ^                                            |
     +--------- x402 token supplied here ---------+
                config.configurable.payment_token
```

A buyer supplies the token once, on the run. The supervisor never handles it — it delegates through Deep Agents' built-in `task` tool, and LangGraph copies `configurable` down into the subagent's tool calls. Without this, a paid tool could never sit behind a delegation, which is the harness's whole premise.

**No SDK code changes.** Tests and docs only.

### What's here

- **`tests/unit/x402/test_deepagents_compat.py`** — 3 tests driving a real deep agent through a scripted fake chat model (no network, no LLM): the token reaches a subagent's tool, verify → body → settle completes below the delegation, and a missing token raises `PaymentRequiredError` without settling.
- **`.github/workflows/test.yaml`** — a dedicated `deepagents_compat` job so those tests actually run (see below).
- **`docs/api/12-langchain-integration.md`** — a Deep Agents section covering the delegation hop and the two harness behaviours that need designing around.

### Why a separate CI job rather than a dependency bump

The tests `importorskip`, and they cannot join `unit_integration`:

- That job pins **Python 3.10** — the floor this package declares (`python = "^3.10"`) — while `deepagents` requires **>=3.11**.
- `deepagents` cannot go in the poetry lock at all: it needs `langgraph>=1.2.11` via langchain v1, which is **disjoint** from the test group's `langgraph = "^0.6.0"`. Poetry version solving fails outright.

So `deepagents_compat` runs on 3.11 with a pip install of the v1 stack. The 3.10 floor stays tested by the existing job, and the contract now actually runs.

### Verification

- Compat tests: **3 passed**, reproducing the exact CI recipe in a clean venv (deepagents 0.7.11 / langchain 1.3.18 / langgraph 1.2.11).
- Default poetry env: **1 skipped**, as intended.
- Existing suite unchanged: **273 passed, 1 skipped**.
- `mkdocs build` clean (the 94 `--strict` griffe warnings are pre-existing — verified identical on clean `main`).

Companion tutorial: [`langchain-deep-agent-py`](https://github.com/nevermined-io/tutorials/tree/r-marques/langchain-demo/langchain-deep-agent-py). Docs-site page: nevermined-io/docs `docs/deep-agents-integration`.

## Is this PR related with an open issue?

No.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation