### PR TITLE
feat(orders): OrdersAPI client for browser-fiat Orders (create_order / get_order)

### DIFF
--- a/docs/api/16-orders.md
+++ b/docs/api/16-orders.md
@@ -60,15 +60,17 @@ print(order.client_secret)          # present only while the Order is payable
 
 The read is anonymous on the wire (the unguessable id is the access control) and returns a buyer-safe projection: it never includes the merchant identity, the Connect account or the fee.
 
+The read endpoint is rate-limited: all anonymous callers behind one IP share a bucket of 60 requests per minute. A throttled call raises `PaymentsError` with code `http_429` and no catalogue code (this is not the create-side `BCK.ORDER.0010`). Poll sparingly and back off on `http_429`.
+
 ## Order lifecycle
 
 | Status | Meaning |
 |---|---|
 | `requires_payment` | Created; the browser has not confirmed yet. `client_secret` is available. |
-| `paid` | Payment succeeded. |
+| `paid` | Payment succeeded. Also the state after a **won** dispute. |
 | `failed` | Payment failed, or the PaymentIntent could not be created. No money moved. |
 | `refunded` / `partially_refunded` | Refunded in full / in part (see `amount_refunded_minor`). |
-| `disputed` | A chargeback is open. |
+| `disputed` | A chargeback is open, or was lost. A won dispute returns the Order to `paid`. |
 
 ## Error codes
 
@@ -82,7 +84,10 @@ Errors raise `PaymentsError` with `code` set to the backend catalogue code:
 | `BCK.ORDER.0004` | 500 | The merchant has no Connect account able to receive card payments. |
 | `BCK.ORDER.0005` | 500 | The PaymentIntent could not be created; the Order is `failed`, no money moved. |
 | `BCK.ORDER.0007` | 409 | Idempotency-key conflict. |
-| `BCK.ORDER.0010` | 429 | Velocity cap exceeded. Retry after backoff. |
+| `BCK.ORDER.0010` | 429 | Velocity cap exceeded on `create_order`. Retry after backoff. |
+| `http_429` | 429 | The `get_order` read throttle (no catalogue code). Back off and retry. |
+
+A refusal that carries no catalogue code (a throttle or gateway response) surfaces with code `http_<status>`.
 
 ```python
 from payments_py import PaymentsError

--- a/docs/api/16-orders.md
+++ b/docs/api/16-orders.md
@@ -1,0 +1,96 @@
+# Orders
+
+This guide covers browser-fiat **Orders**: a merchant-initiated, off-plan charge for an arbitrary amount (the Stripe PaymentIntent analog) that the buyer's browser confirms client-side. No payment plan, no buyer Nevermined account, no delegation.
+
+## Overview
+
+1. `payments.orders.create_order(...)` — the merchant creates the Order server-side and receives a Stripe `client_secret`.
+2. The merchant hands the `client_secret` to its checkout page, which confirms the payment with Stripe.js.
+3. `payments.orders.get_order(order_id)` — anyone holding the unguessable `order_id` reads the buyer-safe status. No API key is sent on the wire.
+
+## Requirements
+
+`create_order` needs an **organization-scoped** NVM API key: the API resolves the merchant organization from the key's own org tag. A personal key is refused with `BCK.ORDER.0003`, and `payments.set_organization_id(...)` does not substitute for an org-scoped key. The organization must be active and have a Stripe Connect account able to receive card payments.
+
+## Create an Order
+
+```python
+from payments_py import Payments, PaymentOptions
+
+payments = Payments.get_instance(
+    PaymentOptions(nvm_api_key="nvm:your-org-scoped-key", environment="sandbox")
+)
+
+created = payments.orders.create_order(
+    3437,  # USD cents: $34.37 ($1.00 - $999,999.99)
+    description="Cart checkout - 3 items",
+    buyer_ref="merchant-order-4821",
+    idempotency_key="merchant-order-4821",
+    line_items=[{"sku": "PRO-PLAN", "quantity": 1, "amountMinor": 3437}],
+    metadata={"channel": "web"},
+)
+
+print(created.order_id)       # ord_... - the buyer-facing access control
+print(created.status)         # requires_payment
+print(created.client_secret)  # hand this to the browser (Stripe.js confirm)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `amount_minor` | `int` | Charge amount in USD cents, `100` to `99_999_999`. |
+| `currency` | `str` | ISO currency, lower-cased. Default and only value in Phase 1: `"usd"`. |
+| `description` | `str` | Optional. Human-readable description (max 1024 chars). |
+| `buyer_ref` | `str` | Optional. Your own reference for the buyer or cart (max 255 chars). |
+| `idempotency_key` | `str` | Optional. A retried create with the same key returns the same Order and `client_secret`; a conflicting body is refused with `BCK.ORDER.0007`. |
+| `line_items` | `list[dict]` | Optional. Recorded verbatim, opaque to the API. |
+| `metadata` | `dict` | Optional. Recorded verbatim, opaque to the API. |
+| `capture_mode` | `str` | Optional. `"automatic"` only in Phase 1. |
+| `payment_provider` | `str` | Optional. `"stripe"` only in Phase 1. |
+
+## Read an Order
+
+```python
+order = payments.orders.get_order(created.order_id)
+
+print(order.status)                 # OrderStatus.REQUIRES_PAYMENT, PAID, ...
+print(order.amount_minor)           # 3437
+print(order.amount_refunded_minor)  # 0
+print(order.client_secret)          # present only while the Order is payable
+```
+
+The read is anonymous on the wire (the unguessable id is the access control) and returns a buyer-safe projection: it never includes the merchant identity, the Connect account or the fee.
+
+## Order lifecycle
+
+| Status | Meaning |
+|---|---|
+| `requires_payment` | Created; the browser has not confirmed yet. `client_secret` is available. |
+| `paid` | Payment succeeded. |
+| `failed` | Payment failed, or the PaymentIntent could not be created. No money moved. |
+| `refunded` / `partially_refunded` | Refunded in full / in part (see `amount_refunded_minor`). |
+| `disputed` | A chargeback is open. |
+
+## Error codes
+
+Errors raise `PaymentsError` with `code` set to the backend catalogue code:
+
+| Code | HTTP | Meaning |
+|---|---|---|
+| `BCK.ORDER.0001` | 400 | Invalid request (amount out of range, unsupported currency / capture mode / provider). |
+| `BCK.ORDER.0002` | 404 | No Order with this id. |
+| `BCK.ORDER.0003` | 403 | The key is not an active organization, or the amount exceeds the per-order cap. |
+| `BCK.ORDER.0004` | 500 | The merchant has no Connect account able to receive card payments. |
+| `BCK.ORDER.0005` | 500 | The PaymentIntent could not be created; the Order is `failed`, no money moved. |
+| `BCK.ORDER.0007` | 409 | Idempotency-key conflict. |
+| `BCK.ORDER.0010` | 429 | Velocity cap exceeded. Retry after backoff. |
+
+```python
+from payments_py import PaymentsError
+
+try:
+    created = payments.orders.create_order(3437)
+except PaymentsError as e:
+    if e.code == "BCK.ORDER.0010":
+        ...  # back off and retry
+    raise
+```

--- a/docs/api/16-orders.md
+++ b/docs/api/16-orders.md
@@ -41,7 +41,7 @@ print(created.client_secret)  # hand this to the browser (Stripe.js confirm)
 | `currency` | `str` | ISO currency, lower-cased. Default and only value in Phase 1: `"usd"`. |
 | `description` | `str` | Optional. Human-readable description (max 1024 chars). |
 | `buyer_ref` | `str` | Optional. Your own reference for the buyer or cart (max 255 chars). |
-| `idempotency_key` | `str` | Optional. A retried create with the same key returns the same Order and `client_secret`; a conflicting body is refused with `BCK.ORDER.0007`. |
+| `idempotency_key` | `str` | Optional. A retry with the same key returns the original Order unchanged (and its `client_secret` while the Order is still payable); the other fields of the retry are ignored, not merged. A retry with a different `amount_minor` or `currency` is refused with `BCK.ORDER.0007`. |
 | `line_items` | `list[dict]` | Optional. Merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. |
 | `metadata` | `dict` | Optional. Merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. |
 | `capture_mode` | `str` | Optional. `"automatic"` only in Phase 1. |
@@ -83,7 +83,7 @@ Errors raise `PaymentsError` with `code` set to the backend catalogue code:
 | `BCK.ORDER.0003` | 403 | The key is not an active organization, or the amount exceeds the per-order cap. |
 | `BCK.ORDER.0004` | 500 | The merchant has no Connect account able to receive card payments. |
 | `BCK.ORDER.0005` | 500 | The PaymentIntent could not be created; the Order is `failed`, no money moved. |
-| `BCK.ORDER.0007` | 409 | Idempotency-key conflict. |
+| `BCK.ORDER.0007` | 409 | Idempotency key reused with a different `amount_minor` or `currency`. |
 | `BCK.ORDER.0010` | 429 | Velocity cap exceeded on `create_order`. Retry after backoff. |
 | `http_429` | 429 | The `get_order` read throttle (no catalogue code). Back off and retry. |
 

--- a/docs/api/16-orders.md
+++ b/docs/api/16-orders.md
@@ -22,11 +22,11 @@ payments = Payments.get_instance(
 )
 
 created = payments.orders.create_order(
-    3437,  # USD cents: $34.37 ($1.00 - $999,999.99)
+    3437,  # USD cents: $34.37
     description="Cart checkout - 3 items",
     buyer_ref="merchant-order-4821",
     idempotency_key="merchant-order-4821",
-    line_items=[{"sku": "PRO-PLAN", "quantity": 1, "amountMinor": 3437}],
+    line_items=[{"sku": "PRO-PLAN", "quantity": 1, "unit_price": 3437}],
     metadata={"channel": "web"},
 )
 
@@ -37,13 +37,13 @@ print(created.client_secret)  # hand this to the browser (Stripe.js confirm)
 
 | Parameter | Type | Description |
 |---|---|---|
-| `amount_minor` | `int` | Charge amount in USD cents, `100` to `99_999_999`. |
+| `amount_minor` | `int` | Charge amount in USD cents (at least `100`, i.e. $1.00). The API validates the upper bound (`BCK.ORDER.0001`); a deployment may enforce a lower per-order cap (`BCK.ORDER.0003`). |
 | `currency` | `str` | ISO currency, lower-cased. Default and only value in Phase 1: `"usd"`. |
 | `description` | `str` | Optional. Human-readable description (max 1024 chars). |
 | `buyer_ref` | `str` | Optional. Your own reference for the buyer or cart (max 255 chars). |
 | `idempotency_key` | `str` | Optional. A retried create with the same key returns the same Order and `client_secret`; a conflicting body is refused with `BCK.ORDER.0007`. |
-| `line_items` | `list[dict]` | Optional. Recorded verbatim, opaque to the API. |
-| `metadata` | `dict` | Optional. Recorded verbatim, opaque to the API. |
+| `line_items` | `list[dict]` | Optional. Merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. |
+| `metadata` | `dict` | Optional. Merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. |
 | `capture_mode` | `str` | Optional. `"automatic"` only in Phase 1. |
 | `payment_provider` | `str` | Optional. `"stripe"` only in Phase 1. |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - 13. LangSmith Deployment: api/13-langsmith-deployment.md
     - 14. Onboarding Customers: api/14-onboarding-customers.md
     - 15. MPP Protocol: api/15-mpp.md
+    - 16. Orders: api/16-orders.md
   - Reference:
     - Payments Class: reference/payments.md
     - Data Models: reference/data_models.md

--- a/payments_py/__init__.py
+++ b/payments_py/__init__.py
@@ -28,6 +28,8 @@ from payments_py.common.types import (
     OrganizationMembersResponse,
     OrganizationType,
     StripeAccountConnectResult,
+    CreateOrderResult,
+    Order,
 )
 from payments_py.common.payments_error import PaymentsError
 from payments_py.api.query_api import AIQueryApi
@@ -37,6 +39,7 @@ from payments_py.api.requests_api import AgentRequestsAPI
 from payments_py.api.base_payments import BasePaymentsAPI, CURRENT_ORG_ID_HEADER
 from payments_py.api.observability_api import ObservabilityAPI
 from payments_py.api.organizations_api import OrganizationsAPI
+from payments_py.api.orders_api import OrdersAPI
 
 # X402 Payment Protocol Module
 from payments_py.x402 import (
@@ -145,6 +148,9 @@ __all__ = [
     "OrganizationMembersResponse",
     "OrganizationType",
     "StripeAccountConnectResult",
+    "OrdersAPI",
+    "CreateOrderResult",
+    "Order",
     # X402 APIs
     "FacilitatorAPI",
     "X402TokenAPI",

--- a/payments_py/__init__.py
+++ b/payments_py/__init__.py
@@ -30,6 +30,7 @@ from payments_py.common.types import (
     StripeAccountConnectResult,
     CreateOrderResult,
     Order,
+    OrderStatus,
 )
 from payments_py.common.payments_error import PaymentsError
 from payments_py.api.query_api import AIQueryApi
@@ -151,6 +152,7 @@ __all__ = [
     "OrdersAPI",
     "CreateOrderResult",
     "Order",
+    "OrderStatus",
     # X402 APIs
     "FacilitatorAPI",
     "X402TokenAPI",

--- a/payments_py/api/__init__.py
+++ b/payments_py/api/__init__.py
@@ -8,6 +8,7 @@ from payments_py.api.observability_api import ObservabilityAPI
 from payments_py.api.contracts_api import ContractsAPI
 from payments_py.api.base_payments import BasePaymentsAPI
 from payments_py.api.organizations_api import OrganizationsAPI
+from payments_py.api.orders_api import OrdersAPI
 
 __all__ = [
     "AgentsAPI",
@@ -18,4 +19,5 @@ __all__ = [
     "ContractsAPI",
     "BasePaymentsAPI",
     "OrganizationsAPI",
+    "OrdersAPI",
 ]

--- a/payments_py/api/nvm_api.py
+++ b/payments_py/api/nvm_api.py
@@ -19,6 +19,10 @@ API_URL_MINT_EXPIRABLE_PLAN = "/api/v1/protocol/plans/mintExpirable"
 API_URL_BURN_PLAN = "/api/v1/protocol/plans/burn"
 API_URL_GET_PLAN_AGENTS = "/api/v1/protocol/plans/{plan_id}/agents"
 API_URL_REDEEM_PLAN = "/api/v1/protocol/plans/redeem"
+# Browser-fiat Orders (nvm-monorepo epic #3238). POST is merchant-authenticated
+# (org-scoped NVM API key); GET is anonymous - the unguessable id is the access control.
+API_URL_CREATE_ORDER = "/api/v1/orders"
+API_URL_GET_ORDER = "/api/v1/orders/{order_id}"
 
 # Agent endpoints
 API_URL_REGISTER_AGENT = "/api/v1/protocol/agents"

--- a/payments_py/api/nvm_api.py
+++ b/payments_py/api/nvm_api.py
@@ -19,6 +19,8 @@ API_URL_MINT_EXPIRABLE_PLAN = "/api/v1/protocol/plans/mintExpirable"
 API_URL_BURN_PLAN = "/api/v1/protocol/plans/burn"
 API_URL_GET_PLAN_AGENTS = "/api/v1/protocol/plans/{plan_id}/agents"
 API_URL_REDEEM_PLAN = "/api/v1/protocol/plans/redeem"
+
+# Order endpoints
 # Browser-fiat Orders (nvm-monorepo epic #3238). POST is merchant-authenticated
 # (org-scoped NVM API key); GET is anonymous - the unguessable id is the access control.
 API_URL_CREATE_ORDER = "/api/v1/orders"

--- a/payments_py/api/orders_api.py
+++ b/payments_py/api/orders_api.py
@@ -11,7 +11,12 @@ no plan, no buyer Nevermined account, no delegation. Wraps
   ``BCK.ORDER.0003``; :meth:`Payments.set_organization_id` (the
   ``X-Current-Org-Id`` header) does not substitute for an org-scoped key.
 - ``GET /api/v1/orders/{id}`` — anonymous; the unguessable id is the sole
-  access control, so no API key is sent.
+  access control, so no API key is sent on that call.
+
+This client is the merchant's: a :class:`Payments` instance is always
+constructed with an NVM API key. The buyer never needs one — the buyer's
+browser confirms the ``client_secret`` with Stripe.js and can poll the GET
+endpoint directly, which is why :meth:`OrdersAPI.get_order` sends no key.
 """
 
 import json
@@ -118,9 +123,10 @@ class OrdersAPI(BasePaymentsAPI):
         """Read the buyer-safe view of an Order (``GET /api/v1/orders/{id}``).
 
         The endpoint is anonymous — the unguessable id is the sole access
-        control — so no API key is sent. The response never includes the
-        merchant identity or the fee, and carries ``client_secret`` only while
-        the Order is payable.
+        control — so this call sends no API key (the :class:`Payments`
+        instance still needs one to be constructed). The response never
+        includes the merchant identity or the fee, and carries
+        ``client_secret`` only while the Order is payable.
 
         Args:
             order_id: The unguessable Order id returned by

--- a/payments_py/api/orders_api.py
+++ b/payments_py/api/orders_api.py
@@ -1,0 +1,141 @@
+"""Orders API — browser-fiat Orders (nvm-monorepo epic #3238).
+
+An Order is a merchant-initiated, off-plan charge for an arbitrary amount (the
+Stripe PaymentIntent analog) that the buyer's browser confirms client-side —
+no plan, no buyer Nevermined account, no delegation. Wraps
+``apps/api/src/orders/`` in nvm-monorepo:
+
+- ``POST /api/v1/orders`` — merchant, server-to-server, authenticated with an
+  **organization-scoped** NVM API key. The API reads the merchant organization
+  from the key's own org tag, so a personal key is refused with
+  ``BCK.ORDER.0003``; :meth:`Payments.set_organization_id` (the
+  ``X-Current-Org-Id`` header) does not substitute for an org-scoped key.
+- ``GET /api/v1/orders/{id}`` — anonymous; the unguessable id is the sole
+  access control, so no API key is sent.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from payments_py.api.base_payments import BasePaymentsAPI
+from payments_py.api.nvm_api import API_URL_CREATE_ORDER, API_URL_GET_ORDER
+from payments_py.common.payments_error import PaymentsError
+from payments_py.common.types import CreateOrderResult, Order, PaymentOptions
+
+
+class OrdersAPI(BasePaymentsAPI):
+    """Browser-fiat Orders: create a charge, read its buyer-safe view.
+
+    Example::
+
+        payments = Payments.get_instance(PaymentOptions(nvm_api_key=ORG_KEY))
+        created = payments.orders.create_order(3437, description="Cart")
+        # hand created.client_secret to the browser (Stripe.js confirm) ...
+        order = payments.orders.get_order(created.order_id)
+        if order.status == "paid":
+            fulfil(order)
+    """
+
+    @classmethod
+    def get_instance(cls, options: PaymentOptions) -> "OrdersAPI":
+        return cls(options)
+
+    def create_order(
+        self,
+        amount_minor: int,
+        currency: str = "usd",
+        *,
+        description: Optional[str] = None,
+        buyer_ref: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+        line_items: Optional[List[Dict[str, Any]]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        capture_mode: Optional[str] = None,
+        payment_provider: Optional[str] = None,
+    ) -> CreateOrderResult:
+        """Create an Order and its PaymentIntent (``POST /api/v1/orders``).
+
+        Oriented to merchants: the NVM API key must be scoped to an active
+        organization whose Stripe Connect account can receive card payments.
+
+        Args:
+            amount_minor: Charge amount in USD cents, $1.00–$999,999.99
+                (``100``–``99_999_999``).
+            currency: ISO currency, lower-cased. Phase 1 is USD-only.
+            description: Human-readable description of the charge (max 1024
+                chars).
+            buyer_ref: Opaque merchant-supplied buyer reference, e.g. the
+                merchant's own order id (max 255 chars).
+            idempotency_key: A retried create with the same key returns the
+                same Order and ``client_secret`` (max 255 chars).
+            line_items: Cart line items, recorded verbatim and opaque to the
+                API.
+            metadata: Opaque merchant metadata, recorded verbatim.
+            capture_mode: Stripe capture mode. Phase 1 supports
+                ``"automatic"`` only (the default).
+            payment_provider: PSP that settles the Order. Phase 1 implements
+                ``"stripe"`` only (the default).
+
+        Returns:
+            The new Order id, its status and — while payable — the
+            ``client_secret`` the browser confirms against.
+
+        Raises:
+            PaymentsError: carrying the backend catalogue code —
+                ``BCK.ORDER.0001`` (invalid request), ``BCK.ORDER.0003`` (not
+                an active organization / over the per-order cap),
+                ``BCK.ORDER.0007`` (idempotency-key conflict),
+                ``BCK.ORDER.0010`` (velocity cap, retryable),
+                ``BCK.ORDER.0004`` / ``0005`` (Connect account / PaymentIntent
+                failure, no money moved).
+        """
+        optional = {
+            "description": description,
+            "buyerRef": buyer_ref,
+            "idempotencyKey": idempotency_key,
+            "lineItems": line_items,
+            "metadata": metadata,
+            "captureMode": capture_mode,
+            "paymentProvider": payment_provider,
+        }
+        body = {"amountMinor": amount_minor, "currency": currency}
+        body.update({k: v for k, v in optional.items() if v is not None})
+        # Serialised here rather than via ``get_backend_http_options(body=...)``:
+        # that helper camelCases dict keys RECURSIVELY, which would rewrite the
+        # merchant's opaque ``metadata`` / ``line_items`` keys. The wire keys
+        # above are already camelCase and the amount is DTO-bounded far below
+        # the JS safe-integer range, so a plain ``json.dumps`` is the exact body.
+        options = self.get_backend_http_options("POST")
+        url = f"{self.environment.backend}{API_URL_CREATE_ORDER}"
+        response = requests.post(url, data=json.dumps(body), **options)
+        if not response.ok:
+            raise PaymentsError.from_response(response, "Unable to create order")
+        return CreateOrderResult.model_validate(response.json())
+
+    def get_order(self, order_id: str) -> Order:
+        """Read the buyer-safe view of an Order (``GET /api/v1/orders/{id}``).
+
+        The endpoint is anonymous — the unguessable id is the sole access
+        control — so no API key is sent. The response never includes the
+        merchant identity or the fee, and carries ``client_secret`` only while
+        the Order is payable.
+
+        Args:
+            order_id: The unguessable Order id returned by
+                :meth:`create_order`.
+
+        Returns:
+            The :class:`Order` projection.
+
+        Raises:
+            PaymentsError: with code ``BCK.ORDER.0002`` when no Order has this
+                id.
+        """
+        path = API_URL_GET_ORDER.format(order_id=order_id)
+        url = f"{self.environment.backend}{path}"
+        response = requests.get(url, **self.get_public_http_options("GET"))
+        if not response.ok:
+            raise PaymentsError.from_response(response, "Unable to get order")
+        return Order.model_validate(response.json())

--- a/payments_py/api/orders_api.py
+++ b/payments_py/api/orders_api.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
-from payments_py.api.base_payments import BasePaymentsAPI
+from payments_py.api.base_payments import BasePaymentsAPI, _stringify_unsafe_ints
 from payments_py.api.nvm_api import API_URL_CREATE_ORDER, API_URL_GET_ORDER
 from payments_py.common.payments_error import PaymentsError
 from payments_py.common.types import CreateOrderResult, Order, PaymentOptions
@@ -110,11 +110,14 @@ class OrdersAPI(BasePaymentsAPI):
         # Serialised here rather than via ``get_backend_http_options(body=...)``:
         # that helper camelCases dict keys RECURSIVELY, which would rewrite the
         # merchant's opaque ``metadata`` / ``line_items`` keys. The wire keys
-        # above are already camelCase and the amount is DTO-bounded far below
-        # the JS safe-integer range, so a plain ``json.dumps`` is the exact body.
+        # above are already camelCase. The SDK-wide unsafe-int policy still
+        # applies: an int above 2**53-1 anywhere in the payload is sent as a
+        # decimal string, since the Node backend's JSON parser would otherwise
+        # round it.
         options = self.get_backend_http_options("POST")
         url = f"{self.environment.backend}{API_URL_CREATE_ORDER}"
-        response = requests.post(url, data=json.dumps(body), **options)
+        payload = json.dumps(_stringify_unsafe_ints(body))
+        response = requests.post(url, data=payload, **options)
         if not response.ok:
             raise PaymentsError.from_response(response, "Unable to create order")
         return CreateOrderResult.model_validate(response.json())

--- a/payments_py/api/orders_api.py
+++ b/payments_py/api/orders_api.py
@@ -76,8 +76,12 @@ class OrdersAPI(BasePaymentsAPI):
                 chars).
             buyer_ref: Opaque merchant-supplied buyer reference, e.g. the
                 merchant's own order id (max 255 chars).
-            idempotency_key: A retried create with the same key returns the
-                same Order and ``client_secret`` (max 255 chars).
+            idempotency_key: Idempotency key (max 255 chars). A retry with the
+                same key returns the original Order unchanged (and its
+                ``client_secret`` while the Order is still payable); the other
+                fields of the retry are ignored, not merged. A retry with a
+                different ``amount_minor`` or ``currency`` is refused with
+                ``BCK.ORDER.0007``.
             line_items: Cart line items, recorded verbatim and opaque to the
                 API.
             metadata: Opaque merchant metadata, recorded verbatim.

--- a/payments_py/api/orders_api.py
+++ b/payments_py/api/orders_api.py
@@ -66,8 +66,10 @@ class OrdersAPI(BasePaymentsAPI):
         organization whose Stripe Connect account can receive card payments.
 
         Args:
-            amount_minor: Charge amount in USD cents, $1.00–$999,999.99
-                (``100``–``99_999_999``).
+            amount_minor: Charge amount in USD cents (at least ``100``,
+                i.e. $1.00). The API validates the upper bound
+                (``BCK.ORDER.0001``); a deployment may enforce a lower
+                per-order cap (``BCK.ORDER.0003``).
             currency: ISO currency, lower-cased. Phase 1 is USD-only.
             description: Human-readable description of the charge (max 1024
                 chars).

--- a/payments_py/api/orders_api.py
+++ b/payments_py/api/orders_api.py
@@ -21,6 +21,7 @@ endpoint directly, which is why :meth:`OrdersAPI.get_order` sends no key.
 
 import json
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 
 import requests
 
@@ -96,7 +97,9 @@ class OrdersAPI(BasePaymentsAPI):
                 ``BCK.ORDER.0007`` (idempotency-key conflict),
                 ``BCK.ORDER.0010`` (velocity cap, retryable),
                 ``BCK.ORDER.0004`` / ``0005`` (Connect account / PaymentIntent
-                failure, no money moved).
+                failure, no money moved). A refusal without a catalogue code
+                (e.g. a gateway or throttle response) carries ``http_<status>``
+                instead.
         """
         optional = {
             "description": description,
@@ -142,9 +145,16 @@ class OrdersAPI(BasePaymentsAPI):
 
         Raises:
             PaymentsError: with code ``BCK.ORDER.0002`` when no Order has this
-                id.
+                id. The read endpoint is rate-limited — all anonymous callers
+                behind one IP share a bucket of 60 requests per minute — and a
+                throttled call carries no catalogue code, so it surfaces as
+                code ``http_429``. That is distinct from the create-side
+                velocity cap ``BCK.ORDER.0010``; poll sparingly and back off on
+                ``http_429``.
         """
-        path = API_URL_GET_ORDER.format(order_id=order_id)
+        # Encode the id so a stray ``?``, ``#`` or ``..`` cannot retarget the
+        # request (the id is buyer-facing and often arrives from a URL param).
+        path = API_URL_GET_ORDER.format(order_id=quote(order_id, safe=""))
         url = f"{self.environment.backend}{path}"
         response = requests.get(url, **self.get_public_http_options("GET"))
         if not response.ok:

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -726,3 +726,50 @@ class StripeAccountConnectResult(BaseModel):
     user_country_code: str = Field(alias="userCountryCode")
     link_created_at: int = Field(alias="linkCreatedAt")
     link_expires_at: int = Field(alias="linkExpiresAt")
+
+
+class CreateOrderResult(BaseModel):
+    """Result of :meth:`OrdersAPI.create_order` (``POST /api/v1/orders``).
+
+    Mirrors ``CreateOrderResponseDto`` in the Nevermined backend
+    (``apps/api/src/orders/dto/create-order-response.dto.ts``).
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    #: Unguessable Order id — the buyer-facing access control for ``get_order``.
+    order_id: str = Field(alias="orderId")
+    #: Buyer-facing lifecycle status: ``requires_payment``, ``paid``,
+    #: ``refunded``, ``partially_refunded``, ``disputed`` or ``failed``.
+    status: str
+    #: Stripe PaymentIntent client secret the browser confirms against.
+    #: Present only while the Order is payable.
+    client_secret: Optional[str] = Field(default=None, alias="clientSecret")
+
+
+class Order(BaseModel):
+    """Buyer-safe view of an Order returned by :meth:`OrdersAPI.get_order`.
+
+    Mirrors ``OrderResponseDto`` (``apps/api/src/orders/dto/order-response.dto.ts``).
+    It never carries the merchant identity, the Connect account or the fee.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    #: Unguessable Order id.
+    id: str
+    #: Charge amount in USD cents.
+    amount_minor: int = Field(alias="amountMinor")
+    currency: str
+    #: Same value set as :attr:`CreateOrderResult.status`.
+    status: str
+    #: Total refunded so far, in cents.
+    amount_refunded_minor: int = Field(default=0, alias="amountRefundedMinor")
+    description: Optional[str] = None
+    buyer_ref: Optional[str] = Field(default=None, alias="buyerRef")
+    #: The Stripe PaymentIntent backing this Order; ``None`` until it is created.
+    payment_intent_id: Optional[str] = Field(default=None, alias="paymentIntentId")
+    #: ISO-8601 instant when the Order stops being payable; ``None`` if it never expires.
+    expires_at: Optional[str] = Field(default=None, alias="expiresAt")
+    #: Present only while the Order is payable.
+    client_secret: Optional[str] = Field(default=None, alias="clientSecret")

--- a/payments_py/common/types.py
+++ b/payments_py/common/types.py
@@ -728,6 +728,23 @@ class StripeAccountConnectResult(BaseModel):
     link_expires_at: int = Field(alias="linkExpiresAt")
 
 
+class OrderStatus(str, Enum):
+    """Buyer-facing lifecycle status of an Order — the wire ``WireOrderStatus``
+    in nvm-monorepo ``apps/api/src/orders/order-status.ts``.
+
+    Model fields are typed ``Union[OrderStatus, str]`` so a value the backend
+    adds before the SDK ships an enum update validates as a bare string instead
+    of raising (the :attr:`MyMembership.org_type` forward-compat pattern).
+    """
+
+    REQUIRES_PAYMENT = "requires_payment"
+    PAID = "paid"
+    REFUNDED = "refunded"
+    PARTIALLY_REFUNDED = "partially_refunded"
+    DISPUTED = "disputed"
+    FAILED = "failed"
+
+
 class CreateOrderResult(BaseModel):
     """Result of :meth:`OrdersAPI.create_order` (``POST /api/v1/orders``).
 
@@ -739,9 +756,10 @@ class CreateOrderResult(BaseModel):
 
     #: Unguessable Order id — the buyer-facing access control for ``get_order``.
     order_id: str = Field(alias="orderId")
-    #: Buyer-facing lifecycle status: ``requires_payment``, ``paid``,
-    #: ``refunded``, ``partially_refunded``, ``disputed`` or ``failed``.
-    status: str
+    #: Buyer-facing lifecycle status — see :class:`OrderStatus`. Left-to-right
+    #: union so a known value parses to the enum and an unknown one to ``str``
+    #: (smart mode would pick ``str`` for every string input).
+    status: Union[OrderStatus, str] = Field(union_mode="left_to_right")
     #: Stripe PaymentIntent client secret the browser confirms against.
     #: Present only while the Order is payable.
     client_secret: Optional[str] = Field(default=None, alias="clientSecret")
@@ -761,15 +779,21 @@ class Order(BaseModel):
     #: Charge amount in USD cents.
     amount_minor: int = Field(alias="amountMinor")
     currency: str
-    #: Same value set as :attr:`CreateOrderResult.status`.
-    status: str
-    #: Total refunded so far, in cents.
-    amount_refunded_minor: int = Field(default=0, alias="amountRefundedMinor")
-    description: Optional[str] = None
-    buyer_ref: Optional[str] = Field(default=None, alias="buyerRef")
+    #: Buyer-facing lifecycle status — see :class:`OrderStatus`. Left-to-right
+    #: union so a known value parses to the enum and an unknown one to ``str``
+    #: (smart mode would pick ``str`` for every string input).
+    status: Union[OrderStatus, str] = Field(union_mode="left_to_right")
+    #: Total refunded so far, in cents. Always present on the wire — a money
+    #: field with no default, so a missing value fails loudly rather than
+    #: silently reading as ``0``.
+    amount_refunded_minor: int = Field(alias="amountRefundedMinor")
+    # The four fields below are always present but may be ``None``
+    # (required-but-nullable, exactly as the DTO), so they carry no default.
+    description: Optional[str]
+    buyer_ref: Optional[str] = Field(alias="buyerRef")
     #: The Stripe PaymentIntent backing this Order; ``None`` until it is created.
-    payment_intent_id: Optional[str] = Field(default=None, alias="paymentIntentId")
+    payment_intent_id: Optional[str] = Field(alias="paymentIntentId")
     #: ISO-8601 instant when the Order stops being payable; ``None`` if it never expires.
-    expires_at: Optional[str] = Field(default=None, alias="expiresAt")
+    expires_at: Optional[str] = Field(alias="expiresAt")
     #: Present only while the Order is payable.
     client_secret: Optional[str] = Field(default=None, alias="clientSecret")

--- a/payments_py/payments.py
+++ b/payments_py/payments.py
@@ -12,6 +12,7 @@ from payments_py.api.agents_api import AgentsAPI
 from payments_py.api.requests_api import AgentRequestsAPI
 from payments_py.api.observability_api import ObservabilityAPI
 from payments_py.api.organizations_api import OrganizationsAPI
+from payments_py.api.orders_api import OrdersAPI
 from payments_py.api.contracts_api import ContractsAPI
 from payments_py.x402.facilitator_api import FacilitatorAPI
 from payments_py.mpp.mpp_api import MppAPI
@@ -31,6 +32,7 @@ class Payments(BasePaymentsAPI):
 
     Each of these functionalities is encapsulated in its own API class:
     - `plans`: Manages AI Plans, including registration and ordering and retrieving plan details.
+    - `orders`: Browser-fiat Orders - merchant-initiated, off-plan charges for an arbitrary amount.
     - `agents`: Handles AI Agents, including registration of AI Agents and access token generation.
     - `requests`: Manages requests received by AI Agents, including validation and tracking.
     - `facilitator`: Handles X402 permission verification and settlement for AI Agents acting as facilitators.
@@ -94,6 +96,7 @@ class Payments(BasePaymentsAPI):
         self.query = AIQueryApi.get_instance()
         self.observability = ObservabilityAPI.get_instance(options)
         self.organizations = OrganizationsAPI.get_instance(options)
+        self.orders = OrdersAPI.get_instance(options)
         self.facilitator = FacilitatorAPI.get_instance(options)
         # MPP: a second payment framing over the same plans/credits/
         # delegations core. Namespaced next to ``x402`` for symmetry.

--- a/tests/unit/test_orders_api.py
+++ b/tests/unit/test_orders_api.py
@@ -212,6 +212,34 @@ class TestGetOrder:
             with pytest.raises(ValidationError):
                 payments.orders.get_order(ORDER_ID)
 
+    def test_url_encodes_the_order_id(self):
+        # A stray ``?`` / ``#`` / ``..`` in a buyer-facing id must not retarget
+        # the request; it must reach the API as part of the path.
+        payments = _make_payments()
+        with requests_mock.Mocker(case_sensitive=True) as m:
+            m.get(f"{BACKEND}/api/v1/orders/ord_x%3Ffoo%3D1", json=ORDER)
+            payments.orders.get_order("ord_x?foo=1")
+            req = m.request_history[0]
+        assert req.path == "/api/v1/orders/ord_x%3Ffoo%3D1"
+        assert req.query == ""
+
+    def test_surfaces_the_read_throttle_without_catalogue_code_as_http_429(self):
+        # Nest ThrottlerException body: no ``code``, unlike NVMException envelopes.
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/orders/{ORDER_ID}",
+                status_code=429,
+                json={
+                    "statusCode": 429,
+                    "message": "ThrottlerException: Too Many Requests",
+                },
+            )
+            with pytest.raises(PaymentsError) as exc:
+                payments.orders.get_order(ORDER_ID)
+        assert exc.value.code == "http_429"
+        assert "Too Many Requests" in str(exc.value)
+
     def test_surfaces_bck_order_0002_on_miss(self):
         payments = _make_payments()
         with requests_mock.Mocker() as m:

--- a/tests/unit/test_orders_api.py
+++ b/tests/unit/test_orders_api.py
@@ -1,0 +1,167 @@
+"""Unit tests for ``payments.orders`` (OrdersAPI) — the SDK client for the
+browser-fiat Orders endpoints (nvm-monorepo epic #3238, task #3250):
+
+- ``POST /api/v1/orders`` — merchant, server-to-server, authenticated with an
+  org-scoped NVM API key.
+- ``GET /api/v1/orders/{id}`` — anonymous; the unguessable id is the access
+  control, so the SDK sends NO ``Authorization`` header.
+
+``requests`` is mocked with ``requests_mock`` so we can assert on URLs,
+headers and bodies without hitting the network. The mock NVM API key is the
+same fixture used in ``test_payments.py``.
+"""
+
+import json
+import os
+
+import pytest
+import requests_mock
+
+from payments_py.common.api_version import API_VERSION_HEADER, LOCKED_API_VERSION
+from payments_py.common.payments_error import PaymentsError
+from payments_py.common.types import CreateOrderResult, Order, PaymentOptions
+from payments_py.environments import Environments
+from payments_py.payments import Payments
+
+TEST_API_KEY = os.getenv(
+    "TEST_PROXY_BEARER_TOKEN",
+    "sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweEVCNDk3OTU2OTRBMDc1QTY0ZTY2MzdmMUU5MGYwMjE0Mzg5YjI0YTMiLCJqdGkiOiIweGMzYjYyMWJkYTM5ZDllYWQyMTUyMDliZWY0MDBhMDEzYjM1YjQ2Zjc1NzM4YWFjY2I5ZjdkYWI0ZjQ5MmM5YjgiLCJleHAiOjE3OTQ2NTUwNjAsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.YMkQUjGh7_m07nj8SKXZReNKSryg9mTU3qwJr_TKYATUixbYQTte3CKucjqvgAGzJAd1Kq2ubz3b37n5Zsllxs",
+)
+
+BACKEND = Environments["staging_sandbox"].backend.rstrip("/")
+ORDER_ID = "ord_9f2c1a7e-3b4d-4c8a-9e21-0a5b6c7d8e9f"
+CLIENT_SECRET = "pi_3PGh9k_secret_9x8y7z"
+CREATED = {
+    "orderId": ORDER_ID,
+    "status": "requires_payment",
+    "clientSecret": CLIENT_SECRET,
+}
+ORDER = {
+    "id": ORDER_ID,
+    "amountMinor": 3437,
+    "currency": "usd",
+    "status": "requires_payment",
+    "amountRefundedMinor": 0,
+    "description": "Cart checkout — 3 items",
+    "buyerRef": None,
+    "paymentIntentId": "pi_3PGh9k",
+    "expiresAt": None,
+    "clientSecret": CLIENT_SECRET,
+}
+
+
+def _make_payments():
+    return Payments.get_instance(
+        PaymentOptions(nvm_api_key=TEST_API_KEY, environment="staging_sandbox")
+    )
+
+
+def test_orders_is_wired_and_follows_the_org_pin():
+    payments = _make_payments()
+    assert payments.orders is not None
+    payments.set_organization_id("org-abc")
+    assert payments.orders.get_organization_id() == "org-abc"
+
+
+class TestCreateOrder:
+    def test_posts_body_with_merchant_key_and_returns_result(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.post(f"{BACKEND}/api/v1/orders", status_code=201, json=CREATED)
+            result = payments.orders.create_order(
+                3437,
+                description="Cart checkout — 3 items",
+                idempotency_key="idem-8f2c1a",
+                # Opaque merchant data must reach the wire verbatim — the SDK's
+                # snake→camel body helper must NOT rewrite these keys.
+                metadata={"channel": "web", "unit_price": 3437},
+                line_items=[{"sku": "PRO-PLAN", "unit_price": 3437, "quantity": 1}],
+            )
+            req = m.request_history[0]
+
+        assert isinstance(result, CreateOrderResult)
+        assert result.order_id == ORDER_ID
+        assert result.status == "requires_payment"
+        assert result.client_secret == CLIENT_SECRET
+        assert req.headers["Authorization"] == f"Bearer {TEST_API_KEY}"
+        assert req.headers[API_VERSION_HEADER] == LOCKED_API_VERSION
+        assert json.loads(req.body) == {
+            "amountMinor": 3437,
+            "currency": "usd",
+            "description": "Cart checkout — 3 items",
+            "idempotencyKey": "idem-8f2c1a",
+            "metadata": {"channel": "web", "unit_price": 3437},
+            "lineItems": [{"sku": "PRO-PLAN", "unit_price": 3437, "quantity": 1}],
+        }
+
+    def test_sends_only_the_fields_the_caller_set(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.post(f"{BACKEND}/api/v1/orders", status_code=201, json=CREATED)
+            payments.orders.create_order(100)
+            body = json.loads(m.request_history[0].body)
+        assert body == {"amountMinor": 100, "currency": "usd"}
+
+    def test_omits_client_secret_when_backend_withholds_it(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.post(
+                f"{BACKEND}/api/v1/orders",
+                status_code=201,
+                json={"orderId": ORDER_ID, "status": "failed"},
+            )
+            result = payments.orders.create_order(100)
+        assert result.status == "failed"
+        assert result.client_secret is None
+
+    def test_surfaces_catalogue_code_on_refusal(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.post(
+                f"{BACKEND}/api/v1/orders",
+                status_code=403,
+                json={
+                    "code": "BCK.ORDER.0003",
+                    "message": "Order not initiated by an active organization",
+                },
+            )
+            with pytest.raises(PaymentsError) as exc:
+                payments.orders.create_order(3437)
+        assert exc.value.code == "BCK.ORDER.0003"
+        assert "active organization" in str(exc.value)
+
+
+class TestGetOrder:
+    def test_gets_anonymously_and_returns_buyer_safe_view(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(f"{BACKEND}/api/v1/orders/{ORDER_ID}", json=ORDER)
+            order = payments.orders.get_order(ORDER_ID)
+            req = m.request_history[0]
+
+        assert isinstance(order, Order)
+        assert order.id == ORDER_ID
+        assert order.amount_minor == 3437
+        assert order.currency == "usd"
+        assert order.status == "requires_payment"
+        assert order.amount_refunded_minor == 0
+        assert order.description == "Cart checkout — 3 items"
+        assert order.buyer_ref is None
+        assert order.payment_intent_id == "pi_3PGh9k"
+        assert order.expires_at is None
+        assert order.client_secret == CLIENT_SECRET
+        # The id IS the access control — never leak the merchant key on the read.
+        assert "Authorization" not in req.headers
+        assert req.headers[API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_surfaces_bck_order_0002_on_miss(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{BACKEND}/api/v1/orders/ord_missing",
+                status_code=404,
+                json={"code": "BCK.ORDER.0002", "message": "No order exists"},
+            )
+            with pytest.raises(PaymentsError) as exc:
+                payments.orders.get_order("ord_missing")
+        assert exc.value.code == "BCK.ORDER.0002"

--- a/tests/unit/test_orders_api.py
+++ b/tests/unit/test_orders_api.py
@@ -16,11 +16,17 @@ import os
 
 import pytest
 import requests_mock
+from pydantic import ValidationError
 
 from payments_py.api.base_payments import CURRENT_ORG_ID_HEADER
 from payments_py.common.api_version import API_VERSION_HEADER, LOCKED_API_VERSION
 from payments_py.common.payments_error import PaymentsError
-from payments_py.common.types import CreateOrderResult, Order, PaymentOptions
+from payments_py.common.types import (
+    CreateOrderResult,
+    Order,
+    OrderStatus,
+    PaymentOptions,
+)
 from payments_py.environments import Environments
 from payments_py.payments import Payments
 
@@ -107,6 +113,23 @@ class TestCreateOrder:
             body = json.loads(m.request_history[0].body)
         assert body == {"amountMinor": 100, "currency": "usd"}
 
+    def test_stringifies_unsafe_ints_in_opaque_payloads(self):
+        # Ints above 2**53-1 would be rounded by the Node backend's JSON
+        # parser; the SDK-wide policy (``_stringify_unsafe_ints``) is to send
+        # them as decimal strings. Keys stay verbatim, safe ints stay ints.
+        payments = _make_payments()
+        big = 1_725_600_000_000_000_000  # a nanosecond timestamp
+        with requests_mock.Mocker() as m:
+            m.post(f"{BACKEND}/api/v1/orders", status_code=201, json=CREATED)
+            payments.orders.create_order(
+                100,
+                metadata={"ts_ns": big, "n": 7},
+                line_items=[{"unit_price": big}],
+            )
+            body = json.loads(m.request_history[0].body)
+        assert body["metadata"] == {"ts_ns": str(big), "n": 7}
+        assert body["lineItems"] == [{"unit_price": str(big)}]
+
     def test_omits_client_secret_when_backend_withholds_it(self):
         payments = _make_payments()
         with requests_mock.Mocker() as m:
@@ -158,6 +181,32 @@ class TestGetOrder:
         # The id IS the access control — never leak the merchant key on the read.
         assert "Authorization" not in req.headers
         assert req.headers[API_VERSION_HEADER] == LOCKED_API_VERSION
+
+    def test_parses_status_into_the_enum_and_tolerates_unknown_values(self):
+        payments = _make_payments()
+        with requests_mock.Mocker() as m:
+            m.get(f"{BACKEND}/api/v1/orders/{ORDER_ID}", json=ORDER)
+            known = payments.orders.get_order(ORDER_ID).status
+            m.get(
+                f"{BACKEND}/api/v1/orders/{ORDER_ID}",
+                json={**ORDER, "status": "canceled"},
+            )
+            unknown = payments.orders.get_order(ORDER_ID).status
+        assert known == OrderStatus.REQUIRES_PAYMENT
+        assert isinstance(known, OrderStatus)
+        # A status added server-side before the SDK enum catches up must not
+        # crash the read — it degrades to the bare string.
+        assert unknown == "canceled"
+
+    def test_fails_loudly_when_a_money_field_is_missing(self):
+        # ``amountRefundedMinor`` is always present on the wire; a missing value
+        # is a contract regression and must never silently read as 0.
+        payments = _make_payments()
+        body = {k: v for k, v in ORDER.items() if k != "amountRefundedMinor"}
+        with requests_mock.Mocker() as m:
+            m.get(f"{BACKEND}/api/v1/orders/{ORDER_ID}", json=body)
+            with pytest.raises(ValidationError):
+                payments.orders.get_order(ORDER_ID)
 
     def test_surfaces_bck_order_0002_on_miss(self):
         payments = _make_payments()

--- a/tests/unit/test_orders_api.py
+++ b/tests/unit/test_orders_api.py
@@ -7,13 +7,13 @@ browser-fiat Orders endpoints (nvm-monorepo epic #3238, task #3250):
   control, so the SDK sends NO ``Authorization`` header.
 
 ``requests`` is mocked with ``requests_mock`` so we can assert on URLs,
-headers and bodies without hitting the network. The mock NVM API key is the
-same fixture used in ``test_payments.py``.
+headers and bodies without hitting the network. The NVM API key is a
+throwaway JWT minted per test run, never a committed credential.
 """
 
 import json
-import os
 
+import jwt
 import pytest
 import requests_mock
 from pydantic import ValidationError
@@ -30,9 +30,13 @@ from payments_py.common.types import (
 from payments_py.environments import Environments
 from payments_py.payments import Payments
 
-TEST_API_KEY = os.getenv(
-    "TEST_PROXY_BEARER_TOKEN",
-    "sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweEVCNDk3OTU2OTRBMDc1QTY0ZTY2MzdmMUU5MGYwMjE0Mzg5YjI0YTMiLCJqdGkiOiIweGMzYjYyMWJkYTM5ZDllYWQyMTUyMDliZWY0MDBhMDEzYjM1YjQ2Zjc1NzM4YWFjY2I5ZjdkYWI0ZjQ5MmM5YjgiLCJleHAiOjE3OTQ2NTUwNjAsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.YMkQUjGh7_m07nj8SKXZReNKSryg9mTU3qwJr_TKYATUixbYQTte3CKucjqvgAGzJAd1Kq2ubz3b37n5Zsllxs",
+# A throwaway, locally-signed JWT — NOT a real credential. ``_parse_nvm_api_key``
+# only needs a decodable token carrying ``sub`` + ``o11y``; the ``sandbox-staging:``
+# prefix drives environment resolution. Same approach as test_user_scoped_listing.py.
+TEST_API_KEY = "sandbox-staging:" + jwt.encode(
+    {"sub": "0x0000000000000000000000000000000000000001", "o11y": "test-o11y"},
+    "unit-test-secret-not-a-real-credential-0123456789",
+    algorithm="HS256",
 )
 
 BACKEND = Environments["staging_sandbox"].backend.rstrip("/")

--- a/tests/unit/test_orders_api.py
+++ b/tests/unit/test_orders_api.py
@@ -17,6 +17,7 @@ import os
 import pytest
 import requests_mock
 
+from payments_py.api.base_payments import CURRENT_ORG_ID_HEADER
 from payments_py.common.api_version import API_VERSION_HEADER, LOCKED_API_VERSION
 from payments_py.common.payments_error import PaymentsError
 from payments_py.common.types import CreateOrderResult, Order, PaymentOptions
@@ -56,11 +57,15 @@ def _make_payments():
     )
 
 
-def test_orders_is_wired_and_follows_the_org_pin():
+def test_orders_is_wired_and_forwards_the_org_pin_to_the_wire():
     payments = _make_payments()
     assert payments.orders is not None
     payments.set_organization_id("org-abc")
-    assert payments.orders.get_organization_id() == "org-abc"
+    with requests_mock.Mocker() as m:
+        m.post(f"{BACKEND}/api/v1/orders", status_code=201, json=CREATED)
+        payments.orders.create_order(100)
+        req = m.request_history[0]
+    assert req.headers[CURRENT_ORG_ID_HEADER] == "org-abc"
 
 
 class TestCreateOrder:


### PR DESCRIPTION
## Why this matters

Merchants can now charge a customer an arbitrary amount by card straight from the Nevermined Python SDK, without first publishing a payment plan or asking the buyer to create a Nevermined account. One call creates the order and returns the Stripe client secret the checkout page needs; a second call reads the order's status so the merchant can fulfil once it is paid. This delivers the Python half of nvm-monorepo#3250 (P1.8) for the "dynamic pricing: goods & services" epic (#3238).

## Description

### What

`payments.orders` (new `OrdersAPI`) wrapping the Orders endpoints shipped in nvm-monorepo#3311:

- `create_order(amount_minor, currency="usd", *, description=None, buyer_ref=None, idempotency_key=None, line_items=None, metadata=None, capture_mode=None, payment_provider=None)` → `POST /api/v1/orders` (merchant, authenticated). Returns a `CreateOrderResult` (`order_id`, `status`, `client_secret`).
- `get_order(order_id)` → `GET /api/v1/orders/{id}` (anonymous, public HTTP options — the unguessable id is the access control). Returns the buyer-safe `Order` model.
- New guide `docs/api/16-orders.md` (+ mkdocs nav) covering the flow, the org-scoped-key requirement, the status lifecycle and the `BCK.ORDER.*` codes.

Modelled on `PlansAPI` / `OrganizationsAPI`: same `BasePaymentsAPI` request layer (`get_backend_http_options` / `get_public_http_options`), same `Bearer` + `Nevermined-Version` headers, errors surfaced via `PaymentsError.from_response(...)` so `err.code` is the catalogue code (`BCK.ORDER.0001..0011`). No new error types, no hand-rolled HTTP, no server changes.

### Decisions (left to the implementer by #3250)

- **Keyword-only optionals** are Python's typed options object: one required positional (`amount_minor`), `currency` defaulting to `"usd"` (Phase 1 is USD-only; the wire still requires it), everything else keyword-only. `get_order(order_id)` stays positional like `get_plan(plan_id)`.
- **Body serialised directly, not via `get_backend_http_options(body=...)`.** The shared helper camelCases dict keys *recursively*, which would rewrite the merchant's opaque `metadata` / `line_items` keys (`unit_price` → `unitPrice`) — data the contract says is recorded verbatim. The wire keys are already camelCase, and the SDK-wide `_stringify_unsafe_ints` policy is still applied before `json.dumps` so an int above 2**53-1 anywhere in the payload goes out as a decimal string rather than being rounded by the Node backend. Headers / auth / timeout still come from the base layer. Unit tests pin both the verbatim keys and the big-int case.
- **Full response typing** with two pydantic models, `CreateOrderResult` and `Order`, mirroring `CreateOrderResponseDto` / `OrderResponseDto` (camelCase aliases + `populate_by_name`, the `MyMembership` pattern). `status` is `Union[OrderStatus, str]` parsed left-to-right: known values become the new `OrderStatus(str, Enum)`, a value the backend adds later degrades to a bare string instead of raising (the `MyMembership.org_type` forward-compat pattern). `amount_refunded_minor` (a money field) and the four always-present nullable fields carry **no default**, exactly as the DTO's required-but-nullable shape, so a contract regression fails loudly instead of silently reading `0`. No merchant-identity or fee fields, per the buyer-safe contract.
- **No client-side range validation.** The server owns the bounds (`BCK.ORDER.0001`; the max is env-configurable), so duplicating them would only drift.
- **Tests: unit, `requests_mock` style** (same pattern as `test_organizations_api.py`): URL, headers (Bearer present on create, absent on get, `X-Current-Org-Id` forwarded from the instance pin), the exact JSON body including verbatim opaque keys and stringified big ints, `client_secret` absent when withheld, enum / unknown-status parsing, missing-money-field failure, and catalogue-code propagation for `BCK.ORDER.0003` / `0002`. No e2e: creating an order on staging needs an org-scoped key with an active org and a Connect account, which the CI test keys are not, and staging may not carry #3311 yet (argocd#611).

### Escalations (per the #3250 brief) — @aaitor

1. **No release / publish.** This PR stops at merge; no version bump. Cutting `payments-py` with this needs your explicit go-ahead.
2. **Org-scoped API key.** The API derives the merchant organization from the key's own org tag, not from the `X-Current-Org-Id` header. The SDK's key model is "any NVM API key string", so an org-scoped key is expressible today with no change: construct `Payments` with it. `set_organization_id()` on a personal key does **not** substitute (the org gate #3317 ignores the header → `BCK.ORDER.0003`). Documented in the module docstring and the guide; no workaround attempted.

## Is this PR related with an open issue?

Related to nevermined-io/nvm-monorepo#3250 (P1.8 — SDK OrdersAPI), epic nevermined-io/nvm-monorepo#3238.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation — `docs/api/16-orders.md` guide + nav entry; docstrings on `OrdersAPI` and the models publish under `docs/reference/`

### Test plan

- [x] `poetry run black --check .` and `pre-commit run --all-files` — pass
- [x] `poetry run pytest -m "not slow"` — 979 passed, 1 skipped
- [x] `poetry run mkdocs build` — exit 0 (warnings pre-existing)
- [x] Deep pre-PR review — first pass 0 blockers / 3 should-fix / 2 nits, all addressed in the third commit; the re-run hit the daily review budget, so human review + CI are the second pass
- [ ] CI green

Refs nevermined-io/nvm-monorepo#3250 · epic #3238 · server contract nvm-monorepo#3311 · org gate #3317. Companion PR: nevermined-io/payments#429 (TypeScript SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSHvoA2jHxfARTVwEmrR33
