### PR TITLE
test(x402): build real Settle/VerifyResponse models instead of attribute-bag doubles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,32 @@ poetry run pytest tests/unit/test_example.py -v
 poetry run pytest --cov=payments_py --cov-report=term-missing
 ```
 
+### Never hand-roll a settle/verify test double
+
+Tests that stub `facilitator.verify_permissions` / `settle_permissions` must
+build the **real** model via `tests/x402_responses.py`, never an attribute bag:
+
+```python
+from tests.x402_responses import make_settle_response, make_verify_response
+
+facilitator.settle_permissions = lambda **k: make_settle_response(transaction="0xabc")
+```
+
+A hand-rolled class only ever carries the fields production code read the day it
+was written. All 12 such doubles in this suite had drifted from the model
+(#273), and adding two fields to `SettleResponse` turned **28 unrelated tests
+red** with `AttributeError` (#272). Building the model means every field exists,
+populated by the model's own defaults, so a new field is inert in tests that do
+not care about it — measured: the same probe produces 28 failures against the
+old doubles and 0 against these.
+
+Do **not** "fix" that by making production code use `getattr(result, "f", None)`
+— that bends the SDK around its fixtures and hides the drift. Note the factories
+reject an unknown or aliased keyword themselves: both models use Pydantic's
+default `extra="ignore"`, so constructing them directly would silently drop a
+typo'd or since-removed field name. `tests/unit/test_x402_response_doubles.py`
+fails if a hand-rolled bag reappears.
+
 ### Test Markers
 
 - No marker: Unit and integration tests (fast)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,11 +126,26 @@ not care about it — measured: the same probe produces 28 failures against the
 old doubles and 0 against these.
 
 Do **not** "fix" that by making production code use `getattr(result, "f", None)`
-— that bends the SDK around its fixtures and hides the drift. Note the factories
-reject an unknown or aliased keyword themselves: both models use Pydantic's
-default `extra="ignore"`, so constructing them directly would silently drop a
-typo'd or since-removed field name. `tests/unit/test_x402_response_doubles.py`
-fails if a hand-rolled bag reappears.
+— that bends the SDK around its fixtures and hides the drift.
+
+The factories validate keyword **names** themselves, for both the overrides and
+their own defaults, and the check is **not** redundant with Pydantic:
+
+- **Unknown name** — both models use Pydantic's default `extra="ignore"`, so
+  constructing them directly *silently drops* a typo'd or since-removed field.
+  The model does no enforcing; `_reject_unknown` does.
+- **camelCase alias** — this one is **not** dropped. `populate_by_name=True`
+  means `SettleResponse(creditsRedeemed="5")` is accepted and sets
+  `credits_redeemed`. It is rejected because of the defaults/overrides dict
+  merge: two spellings of one field survive as two keys, and Pydantic resolves
+  the alias in preference to the field name *whatever the dict order* — so a
+  mixed-spelling merge silently discards one of them, in the direction where the
+  override is the loser.
+
+`tests/unit/test_x402_response_doubles.py` fails if a hand-rolled bag reappears,
+and carries its own positive control so it cannot silently stop detecting. Its
+sweep parses `ast.ClassDef` only, so `dict` / `Mock` / `SimpleNamespace` stubs
+are **outside** what it can see — those are on review to catch.
 
 ### Test Markers
 

--- a/tests/e2e/mcp_tests/test_mcp_oauth_server.py
+++ b/tests/e2e/mcp_tests/test_mcp_oauth_server.py
@@ -12,6 +12,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from payments_py.mcp import build_mcp_integration
+from tests.x402_responses import make_settle_response, make_verify_response
 
 
 def mock_decode_access_token(token: str):
@@ -42,14 +43,13 @@ class PaymentsMock:
     def __init__(self):
         self._environment_name = "sandbox"
         self.facilitator = MagicMock()
-        self.facilitator.verify_permissions = AsyncMock(return_value={"isValid": True})
+        self.facilitator.verify_permissions = AsyncMock(
+            return_value=make_verify_response(is_valid=True)
+        )
         self.facilitator.settle_permissions = AsyncMock(
-            return_value={
-                "success": True,
-                "transaction": "0xtest123",
-                "network": "eip155:84532",
-                "creditsRedeemed": "5",
-            }
+            return_value=make_settle_response(
+                transaction="0xtest123", credits_redeemed="5"
+            )
         )
         self.agents = MagicMock()
         self.agents.get_agent_plans = AsyncMock(

--- a/tests/integration/a2a/test_payments_server.py
+++ b/tests/integration/a2a/test_payments_server.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from payments_py.a2a.server import PaymentsA2AServer
 from payments_py.a2a.types import AgentCard
+from tests.x402_responses import make_settle_response, make_verify_response
 
 
 # Mock decode_access_token to return x402-compliant token structure
@@ -59,30 +60,13 @@ def agent_card() -> AgentCard:  # noqa: D401
     }
 
 
-class VerifyResult:
-    """Mock verify permissions result."""
-
-    def __init__(self, is_valid=True, payer=None):
-        self.is_valid = is_valid
-        self.payer = payer
-
-
-class SettleResult:
-    """Mock settle permissions result."""
-
-    def __init__(self, success=True, transaction="0x123", credits_redeemed="1"):
-        self.success = success
-        self.transaction = transaction
-        self.credits_redeemed = credits_redeemed
-
-
 @pytest.fixture()  # noqa: D401
 def dummy_payments(monkeypatch):  # noqa: D401
     # Stub verify_permissions & settle_permissions to avoid HTTP (x402 flow)
     payments = SimpleNamespace(
         facilitator=SimpleNamespace(
-            verify_permissions=lambda **k: VerifyResult(is_valid=True),
-            settle_permissions=lambda **k: SettleResult(
+            verify_permissions=lambda **k: make_verify_response(is_valid=True),
+            settle_permissions=lambda **k: make_settle_response(
                 success=True,
                 transaction="0x123",
                 credits_redeemed="1",

--- a/tests/integration/a2a/test_payments_stream_and_push.py
+++ b/tests/integration/a2a/test_payments_stream_and_push.py
@@ -19,6 +19,7 @@ from a2a.types import (
 )
 from payments_py.a2a.payments_request_handler import PaymentsRequestHandler
 from payments_py.a2a.types import MessageSendParams, AgentCard, HttpRequestContext
+from tests.x402_responses import make_settle_response, make_verify_response
 
 
 class DummyStreamingExecutor(AgentExecutor):  # noqa: D101
@@ -86,15 +87,14 @@ def payments_stub(monkeypatch):  # noqa: D401
 
     def settle(**kwargs):  # noqa: D401
         settle_called["called"] = kwargs
-        return {
-            "success": True,
-            "txHash": "0x123",
-            "data": {"creditsBurned": str(kwargs.get("max_amount", 0))},
-        }
+        return make_settle_response(
+            transaction="0x123",
+            credits_redeemed=str(kwargs.get("max_amount", 0)),
+        )
 
     payments = SimpleNamespace(
         facilitator=SimpleNamespace(
-            verify_permissions=lambda **k: {"success": True},
+            verify_permissions=lambda **k: make_verify_response(is_valid=True),
             settle_permissions=settle,
         )
     )

--- a/tests/integration/a2a/test_push_notifications.py
+++ b/tests/integration/a2a/test_push_notifications.py
@@ -24,6 +24,7 @@ from a2a.types import (
 
 from payments_py.a2a.payments_request_handler import PaymentsRequestHandler
 from payments_py.a2a.types import MessageSendParams, HttpRequestContext
+from tests.x402_responses import make_settle_response, make_verify_response
 
 
 class DummyWebhookExecutor(AgentExecutor):
@@ -100,16 +101,15 @@ class MockPaymentsService:
             self.validation_call_count += 1
             if self.should_fail_validation:
                 raise RuntimeError("Validation failed")
-            return {"success": True}
+            return make_verify_response(is_valid=True)
 
         def settle_permissions(**kwargs) -> dict:
             self.settle_call_count += 1
             self.last_settle_credits = int(kwargs.get("max_amount", 0))
-            return {
-                "success": True,
-                "txHash": "0x123",
-                "data": {"creditsBurned": kwargs.get("max_amount", "0")},
-            }
+            return make_settle_response(
+                transaction="0x123",
+                credits_redeemed=str(kwargs.get("max_amount", "0")),
+            )
 
         return SimpleNamespace(
             verify_permissions=verify_permissions,

--- a/tests/integration/mcp_tests/test_auth_header_propagation.py
+++ b/tests/integration/mcp_tests/test_auth_header_propagation.py
@@ -8,6 +8,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from payments_py.mcp.core.auth import PaywallAuthenticator
+from tests.x402_responses import make_verify_response
 
 
 def mock_decode_access_token(token: str):
@@ -32,13 +33,6 @@ def mock_decode_access_token(token: str):
     }
 
 
-class MockVerifyResult:
-    """Mock verify permissions result."""
-
-    def __init__(self, is_valid: bool):
-        self.is_valid = is_valid
-
-
 class PaymentsMockWithTracking:
     """Mock Payments with call tracking for integration tests."""
 
@@ -54,7 +48,7 @@ class PaymentsMockWithTracking:
 
     async def _verify_permissions(self, **kwargs):
         self.calls.append(("verify_permissions", kwargs))
-        return MockVerifyResult(is_valid=True)
+        return make_verify_response(is_valid=True)
 
     def _get_agent_plans_sync(self, agent_id: str):
         """Sync version for non-awaited calls."""

--- a/tests/integration/mcp_tests/test_paywall_invalid_token_flow.py
+++ b/tests/integration/mcp_tests/test_paywall_invalid_token_flow.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from payments_py.mcp import build_mcp_integration
 from payments_py.mcp.utils.errors import SettlementFailedError
+from tests.x402_responses import make_settle_response, make_verify_response
 
 
 def mock_decode_access_token(token: str):
@@ -31,30 +32,6 @@ def mock_decode_access_token(token: str):
         },
         "extensions": {},
     }
-
-
-class MockVerifyResult:
-    """Mock verify permissions result."""
-
-    def __init__(self, is_valid: bool, invalid_reason: str = None):
-        self.is_valid = is_valid
-        self.invalid_reason = invalid_reason
-
-
-class MockSettleResult:
-    """Mock settle permissions result."""
-
-    def __init__(
-        self,
-        success: bool,
-        transaction: str = None,
-        credits_redeemed: str = "0",
-        remaining_balance: str = "100",
-    ):
-        self.success = success
-        self.transaction = transaction
-        self.credits_redeemed = credits_redeemed
-        self.remaining_balance = remaining_balance
 
 
 class PaymentsMockWithFailures:
@@ -80,14 +57,16 @@ class PaymentsMockWithFailures:
     async def _verify_permissions(self, **kwargs):
         self.calls.append(("verify_permissions", kwargs))
         if self.failure_mode in ("invalid-token", "not-subscriber"):
-            return MockVerifyResult(is_valid=False, invalid_reason="Payment required")
-        return MockVerifyResult(is_valid=True)
+            return make_verify_response(
+                is_valid=False, invalid_reason="Payment required"
+            )
+        return make_verify_response(is_valid=True)
 
     async def _settle_permissions(self, **kwargs):
         self.calls.append(("settle", kwargs))
         if self.failure_mode == "insufficient-balance":
             raise Exception("Insufficient balance for redemption")
-        return MockSettleResult(
+        return make_settle_response(
             success=True,
             transaction="0xtest123",
             credits_redeemed=str(kwargs.get("max_amount", 0)),

--- a/tests/integration/mcp_tests/test_paywall_invalid_token_flow.py
+++ b/tests/integration/mcp_tests/test_paywall_invalid_token_flow.py
@@ -58,7 +58,11 @@ class PaymentsMockWithFailures:
         self.calls.append(("verify_permissions", kwargs))
         if self.failure_mode in ("invalid-token", "not-subscriber"):
             return make_verify_response(
-                is_valid=False, invalid_reason="Payment required"
+                is_valid=False,
+                invalid_reason="Payment required",
+                # A rejected verify identifies no payer; VERIFY_DEFAULTS is the
+                # successful shape, so clear it rather than inherit it.
+                payer=None,
             )
         return make_verify_response(is_valid=True)
 

--- a/tests/integration/test_mcp_integration.py
+++ b/tests/integration/test_mcp_integration.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest.mock import patch
 
 from payments_py.mcp import build_mcp_integration
+from tests.x402_responses import make_settle_response, make_verify_response
 
 # Mock decode_access_token to return x402-compliant token structure
 mock_decode_token = lambda token: {
@@ -24,29 +25,6 @@ mock_decode_token = lambda token: {
 }
 
 
-class VerifyResult:
-    """Mock verify permissions result."""
-
-    def __init__(self, is_valid=True):
-        self.is_valid = is_valid
-
-
-class SettleResult:
-    """Mock settle permissions result."""
-
-    def __init__(
-        self,
-        success=True,
-        transaction="0x123",
-        credits_redeemed="1",
-        remaining_balance="100",
-    ):
-        self.success = success
-        self.transaction = transaction
-        self.credits_redeemed = credits_redeemed
-        self.remaining_balance = remaining_balance
-
-
 class PaymentsMinimal:
     def __init__(self, subscriber=True):
         class Facilitator:
@@ -59,7 +37,7 @@ class PaymentsMinimal:
             ):
                 if not self._subscriber:
                     raise Exception("Not a subscriber")
-                return VerifyResult(is_valid=True)
+                return make_verify_response(is_valid=True)
 
             def settle_permissions(
                 self,
@@ -68,7 +46,7 @@ class PaymentsMinimal:
                 x402_access_token=None,
                 agent_request_id=None,
             ):
-                return SettleResult(
+                return make_settle_response(
                     success=True, transaction="0x123", credits_redeemed=str(max_amount)
                 )
 
@@ -141,7 +119,7 @@ def test_context_integration_with_real_like_data():
                 ):
                     if not self._subscriber:
                         raise Exception("Not a subscriber")
-                    return VerifyResult(is_valid=True)
+                    return make_verify_response(is_valid=True)
 
                 def settle_permissions(
                     self,
@@ -150,7 +128,7 @@ def test_context_integration_with_real_like_data():
                     x402_access_token=None,
                     agent_request_id=None,
                 ):
-                    return SettleResult(
+                    return make_settle_response(
                         success=True,
                         transaction=f"0x{hash(f'{max_amount}') % 1000000000:x}",
                         credits_redeemed=str(max_amount),

--- a/tests/unit/a2a/test_decorator.py
+++ b/tests/unit/a2a/test_decorator.py
@@ -18,6 +18,7 @@ from payments_py.a2a.decorator import (
     _DecoratorExecutor,
     a2a_requires_payment,
 )
+from tests.x402_responses import make_verify_response
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +52,7 @@ class _SpyEventQueue(EventQueue):
 def _make_payments():
     return SimpleNamespace(
         facilitator=SimpleNamespace(
-            verify_permissions=Mock(return_value=SimpleNamespace(is_valid=True)),
+            verify_permissions=Mock(return_value=make_verify_response(is_valid=True)),
             settle_permissions=Mock(return_value={"success": True}),
         ),
     )

--- a/tests/unit/a2a/test_decorator.py
+++ b/tests/unit/a2a/test_decorator.py
@@ -18,7 +18,7 @@ from payments_py.a2a.decorator import (
     _DecoratorExecutor,
     a2a_requires_payment,
 )
-from tests.x402_responses import make_verify_response
+from tests.x402_responses import make_settle_response, make_verify_response
 
 
 # ---------------------------------------------------------------------------
@@ -53,7 +53,7 @@ def _make_payments():
     return SimpleNamespace(
         facilitator=SimpleNamespace(
             verify_permissions=Mock(return_value=make_verify_response(is_valid=True)),
-            settle_permissions=Mock(return_value={"success": True}),
+            settle_permissions=Mock(return_value=make_settle_response()),
         ),
     )
 

--- a/tests/unit/a2a/test_payments_request_handler.py
+++ b/tests/unit/a2a/test_payments_request_handler.py
@@ -22,6 +22,7 @@ from a2a.types import (
 from payments_py.a2a.payments_request_handler import PaymentsRequestHandler
 from payments_py.a2a.types import HttpRequestContext
 from payments_py.common.payments_error import PaymentsError
+from tests.x402_responses import make_verify_response
 
 
 class DummyExecutor:  # noqa: D101
@@ -679,9 +680,7 @@ async def test_validate_request_captures_agent_request_attributes():  # noqa: D4
     """Test that validate_request sets latest_agent_request and latest_agent_request_id."""
 
     # Mock verify_permissions result
-    verify_result = SimpleNamespace(
-        is_valid=True,
-        invalid_reason=None,
+    verify_result = make_verify_response(
         agent_request={"agent_request_id": "req-xyz", "some": "data"},
         agent_request_id="req-xyz",
     )

--- a/tests/unit/mcp_tests/test_x402_inband.py
+++ b/tests/unit/mcp_tests/test_x402_inband.py
@@ -34,6 +34,7 @@ from payments_py.mcp.core.server_manager import (
     McpServerManager,
     _get_mcp_server_class,
 )
+from tests.x402_responses import make_settle_response, make_verify_response
 
 # ---------------------------------------------------------------------------
 # Helpers / fakes
@@ -54,41 +55,21 @@ SAMPLE_PAYLOAD = {
 }
 
 
-class _FakeSettlement:
-    """Mimics the facilitator settlement model (pydantic-like)."""
+def _settlement(success=True, **overrides):
+    """A real ``SettleResponse`` shaped the way the facilitator answers here.
 
-    def __init__(
-        self,
-        success=True,
-        transaction="0xabc",
+    ``order_tx`` / ``error_reason`` are deliberately left unset on the success
+    shape so the receipt assertions still exercise ``exclude_none``.
+    """
+    return make_settle_response(
+        success=success,
+        transaction="0xabc" if success else "",
         credits_redeemed="5",
         remaining_balance="100",
-    ):
-        self.success = success
-        self.transaction = transaction
-        self.credits_redeemed = credits_redeemed
-        self.remaining_balance = remaining_balance
-
-    def model_dump(self, by_alias=False, exclude_none=False):
-        data = {
-            "success": self.success,
-            "transaction": self.transaction,
-            "network": "eip155:84532",
-            "payer": "0x123",
-            ("creditsRedeemed" if by_alias else "credits_redeemed"): (
-                self.credits_redeemed
-            ),
-            ("remainingBalance" if by_alias else "remaining_balance"): (
-                self.remaining_balance
-            ),
-            # Null-valued fields the real model carries — used to exercise
-            # exclude_none in the spec receipt.
-            ("orderTx" if by_alias else "order_tx"): None,
-            ("errorReason" if by_alias else "error_reason"): None,
-        }
-        if exclude_none:
-            data = {k: v for k, v in data.items() if v is not None}
-        return data
+        payer="0x123",
+        **({} if success else {"error_reason": "insufficient credits"}),
+        **overrides,
+    )
 
 
 class _FakeRequestContext:
@@ -241,7 +222,7 @@ class TestReadPaymentPayload:
 class TestPaywallSettlementReceipt:
     @pytest.mark.asyncio
     async def test_attaches_spec_and_nevermined_meta(self):
-        decorator = _make_decorator(_FakeSettlement(success=True))
+        decorator = _make_decorator(_settlement(success=True))
 
         def handler(args, extra, ctx):
             return {"content": [{"type": "text", "text": "ok"}]}
@@ -275,7 +256,7 @@ class TestPaywallSettlementReceipt:
 class TestSettlementFailureSuppressesContent:
     @pytest.mark.asyncio
     async def test_raises_settlement_failed_and_dispatch_suppresses_content(self):
-        decorator = _make_decorator(_FakeSettlement(success=False))
+        decorator = _make_decorator(_settlement(success=False))
 
         def handler(args, extra, ctx):
             return {"content": [{"type": "text", "text": "secret-paid-result"}]}
@@ -412,7 +393,7 @@ class TestAuthBuildsPaymentRequired:
 class TestFreeCallNoReceipt:
     @pytest.mark.asyncio
     async def test_no_settlement_receipt_for_free_call(self):
-        decorator = _make_decorator(_FakeSettlement(success=True))
+        decorator = _make_decorator(_settlement(success=True))
         # Zero credits → no settlement happens.
         decorator._credits.resolve = MagicMock(return_value=0)
 
@@ -433,18 +414,11 @@ class TestFreeCallNoReceipt:
 # ---------------------------------------------------------------------------
 
 
-class _DispatchVerifyResult:
-    def __init__(self, is_valid=True):
-        self.is_valid = is_valid
-        self.agent_request = None
-        self.agent_request_id = None
-
-
 def _make_dispatch_payments(settlement):
     payments = MagicMock()
     payments.environment_name = "staging_sandbox"
     payments.facilitator.verify_permissions = MagicMock(
-        return_value=_DispatchVerifyResult(True)
+        return_value=make_verify_response(is_valid=True)
     )
     payments.facilitator.settle_permissions = MagicMock(return_value=settlement)
     payments.agents.get_agent_plans = MagicMock(
@@ -515,7 +489,7 @@ async def _invoke_call_tool(manager, *, inband_payload=None, session_headers=Non
 class TestDispatcherInBand:
     @pytest.mark.asyncio
     async def test_inband_payload_reencoded_to_bearer(self):
-        payments = _make_dispatch_payments(_FakeSettlement(success=True))
+        payments = _make_dispatch_payments(_settlement(success=True))
         manager, recorded = await _build_dispatch_manager(payments)
 
         result = await _invoke_call_tool(manager, inband_payload=SAMPLE_PAYLOAD)
@@ -527,7 +501,7 @@ class TestDispatcherInBand:
 
     @pytest.mark.asyncio
     async def test_payment_required_converted_to_error_result(self):
-        payments = _make_dispatch_payments(_FakeSettlement(success=False))
+        payments = _make_dispatch_payments(_settlement(success=False))
         manager, _ = await _build_dispatch_manager(payments)
 
         result = await _invoke_call_tool(manager, inband_payload=SAMPLE_PAYLOAD)
@@ -543,7 +517,7 @@ class TestDispatcherInBand:
     @pytest.mark.asyncio
     async def test_header_fallback_when_no_inband_payload(self):
         logs = []
-        payments = _make_dispatch_payments(_FakeSettlement(success=True))
+        payments = _make_dispatch_payments(_settlement(success=True))
         manager, recorded = await _build_dispatch_manager(payments, on_log=logs.append)
 
         token = encode_access_token(SAMPLE_PAYLOAD)
@@ -566,7 +540,7 @@ class TestDispatcherInBand:
         # header and forward the rest of the request context to the user handler
         # (tenant/tracing/custom headers), mirroring the TS sibling. Replacing
         # `extra` wholesale silently dropped them on the in-band transport.
-        payments = _make_dispatch_payments(_FakeSettlement(success=True))
+        payments = _make_dispatch_payments(_settlement(success=True))
         manager, recorded = await _build_dispatch_manager(payments)
 
         result = await _invoke_call_tool(
@@ -627,7 +601,7 @@ class TestSettleFallbackRetry:
     async def test_fallback_uses_http_url_not_verb(self):
         http_url = "https://api.example.com/tools/premium"
         settle_mock = MagicMock(
-            side_effect=[RuntimeError("primary boom"), _FakeSettlement(success=True)]
+            side_effect=[RuntimeError("primary boom"), _settlement(success=True)]
         )
         payments = MagicMock()
         payments.environment_name = "staging_sandbox"
@@ -735,7 +709,7 @@ class TestAgentIdOptional:
         # A server configured with planId and NO agentId must NOT raise the
         # misconfiguration error; verify/settle run plan-only (the facilitator is
         # plan-centric — proven against staging).
-        decorator = _make_decorator(_FakeSettlement(success=True))
+        decorator = _make_decorator(_settlement(success=True))
         decorator.config = {"planId": "plan-123", "agentId": "", "serverName": "srv"}
 
         def handler(args, extra, ctx):
@@ -751,7 +725,7 @@ class TestAgentIdOptional:
     @pytest.mark.asyncio
     async def test_missing_plan_id_raises_misconfiguration(self):
         # No planId anywhere (config or per-tool) -> Misconfiguration "missing planId".
-        decorator = _make_decorator(_FakeSettlement(success=True))
+        decorator = _make_decorator(_settlement(success=True))
         decorator.config = {"planId": "", "agentId": "agent-9", "serverName": "srv"}
 
         def handler(args, extra, ctx):

--- a/tests/unit/mcp_tests/test_x402_inband.py
+++ b/tests/unit/mcp_tests/test_x402_inband.py
@@ -61,15 +61,19 @@ def _settlement(success=True, **overrides):
     ``order_tx`` / ``error_reason`` are deliberately left unset on the success
     shape so the receipt assertions still exercise ``exclude_none``.
     """
-    return make_settle_response(
-        success=success,
-        transaction="0xabc" if success else "",
-        credits_redeemed="5",
-        remaining_balance="100",
-        payer="0x123",
-        **({} if success else {"error_reason": "insufficient credits"}),
-        **overrides,
-    )
+    shape = {
+        "success": success,
+        "transaction": "0xabc" if success else "",
+        "credits_redeemed": "5",
+        "remaining_balance": "100",
+        "payer": "0x123",
+    }
+    if not success:
+        shape["error_reason"] = "insufficient credits"
+    # Merge rather than splat: `**shape, **overrides` is a duplicate-keyword
+    # TypeError for any of the five names above, i.e. for 5 of the model's 8
+    # fields — the caller could only override the three it did not set.
+    return make_settle_response(**{**shape, **overrides})
 
 
 class _FakeRequestContext:

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -4,6 +4,8 @@ import pytest
 
 from payments_py.mcp import build_mcp_integration
 from payments_py.mcp.utils.errors import SettlementFailedError
+from payments_py.x402.types import SettleResponse
+from tests.x402_responses import make_settle_response, make_verify_response
 
 
 # Mock the decode_access_token to return x402-compliant token structure
@@ -28,54 +30,20 @@ def mock_decode_token(token):
     }
 
 
-class VerifyResult:
-    """Mock verify permissions result with is_valid attribute."""
-
-    def __init__(self, is_valid=True):
-        self.is_valid = is_valid
-
-
-class SettleResult:
-    """Mock settle permissions result."""
-
-    def __init__(
-        self,
-        success=True,
-        transaction=None,
-        credits_redeemed="1",
-        remaining_balance="100",
-    ):
-        self.success = success
-        self.transaction = transaction
-        self.credits_redeemed = credits_redeemed
-        self.remaining_balance = remaining_balance
-
-    def model_dump(self, by_alias=False, exclude_none=False):
-        data = {
-            "success": self.success,
-            "transaction": self.transaction,
-            "network": "eip155:84532",
-            "payer": "0x123subscriber",
-            ("remainingBalance" if by_alias else "remaining_balance"): (
-                self.remaining_balance
-            ),
-        }
-        if exclude_none:
-            data = {k: v for k, v in data.items() if v is not None}
-        return data
-
-
 def make_settle_result(settle_result):
-    """Convert dict to SettleResult if needed."""
+    """Convert the tests' loose dict shorthand into a real ``SettleResponse``."""
     if settle_result is None:
-        return SettleResult()
-    if isinstance(settle_result, SettleResult):
+        # No transaction hash: the model's own "no tx" value is "", not None.
+        return make_settle_response(transaction="", payer="0x123subscriber")
+    if isinstance(settle_result, SettleResponse):
         return settle_result
     # Handle dict input
-    return SettleResult(
+    return make_settle_response(
         success=settle_result.get("success", True),
-        transaction=settle_result.get("txHash"),
+        transaction=settle_result.get("txHash") or "",
         credits_redeemed=settle_result.get("data", {}).get("creditsBurned", "1"),
+        error_reason=settle_result.get("error"),
+        payer="0x123subscriber",
     )
 
 
@@ -100,7 +68,7 @@ class PaymentsMock:
                     elif isinstance(payment_required, dict):
                         plan_id = payment_required.get("accepts", [{}])[0].get("planId")
                 self._parent.calls.append(("verify", plan_id, x402_access_token))
-                return VerifyResult(is_valid=True)
+                return make_verify_response(is_valid=True)
 
             def settle_permissions(
                 self,
@@ -179,8 +147,11 @@ def test_adds_metadata_to_result_after_successful_redemption():
     nvm = out["_meta"]["nevermined/credits"]
     assert nvm.get("success") is True
     assert nvm.get("creditsRedeemed") == "3"
-    # txHash should be None since our mock doesn't return it
-    assert nvm.get("txHash") is None
+    # No transaction hash, because the stub settle response does not carry one.
+    # ``SettleResponse.transaction`` is a non-Optional ``str`` defaulting to "",
+    # so "no tx" reaches the caller as "" — the old attribute-bag double claimed
+    # ``None`` here, a value the real model cannot hold (payments-py#273).
+    assert nvm.get("txHash") == ""
 
 
 @patch("payments_py.mcp.core.auth.decode_access_token", mock_decode_token)
@@ -342,7 +313,7 @@ def test_propagates_error_on_settle_when_configured():
                 def verify_permissions(
                     self, payment_required=None, max_amount=None, x402_access_token=None
                 ):
-                    return VerifyResult(is_valid=True)
+                    return make_verify_response(is_valid=True)
 
                 def settle_permissions(
                     self,
@@ -548,7 +519,7 @@ class PaymentsMockWithX402Context:
                     elif isinstance(payment_required, dict):
                         plan_id = payment_required.get("accepts", [{}])[0].get("planId")
                 self._parent.calls.append(("verify", plan_id, x402_access_token))
-                return VerifyResult(is_valid=True)
+                return make_verify_response(is_valid=True)
 
             def settle_permissions(
                 self,
@@ -740,15 +711,6 @@ MOCK_AGENT_REQUEST = {
 }
 
 
-class VerifyResultWithAgentRequest:
-    """Mock verify result that includes agent_request (as returned by the backend)."""
-
-    def __init__(self, is_valid=True, agent_request=None, agent_request_id=None):
-        self.is_valid = is_valid
-        self.agent_request = agent_request
-        self.agent_request_id = agent_request_id
-
-
 class PaymentsMockWithAgentRequest:
     """Mock that returns agent_request from verify_permissions."""
 
@@ -765,7 +727,7 @@ class PaymentsMockWithAgentRequest:
                 self, payment_required=None, max_amount=None, x402_access_token=None
             ):
                 self._parent.calls.append(("verify", x402_access_token))
-                return VerifyResultWithAgentRequest(
+                return make_verify_response(
                     is_valid=True,
                     agent_request=self._parent._agent_request,
                     agent_request_id=self._parent._agent_request_id,

--- a/tests/unit/test_x402_response_doubles.py
+++ b/tests/unit/test_x402_response_doubles.py
@@ -1,0 +1,120 @@
+"""Guards for the x402 response factories, and against the drift they replaced.
+
+payments-py#273: every one of the suite's 12 settle/verify test doubles was a
+hand-rolled attribute bag carrying only the fields the production code happened
+to read the day it was written. Adding two fields to ``SettleResponse`` turned
+28 unrelated tests red with ``AttributeError``, and a double missing ``network``
+could never have caught a regression in anything reading ``network``.
+
+The fix was to build the real Pydantic models (``tests/x402_responses.py``).
+These tests pin the two properties that keeps it fixed.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+from payments_py.x402.types import SettleResponse, VerifyResponse
+from tests.x402_responses import make_settle_response, make_verify_response
+
+TESTS_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class TestFactories:
+    def test_settle_factory_carries_every_model_field(self):
+        response = make_settle_response()
+        assert isinstance(response, SettleResponse)
+        for field in SettleResponse.model_fields:
+            # Not a tautology about Pydantic: the point is that a *new* field on
+            # the model is present on every double the day it is added, rather
+            # than raising AttributeError in whichever test first reads it.
+            assert hasattr(response, field)
+
+    def test_verify_factory_carries_every_model_field(self):
+        response = make_verify_response()
+        assert isinstance(response, VerifyResponse)
+        for field in VerifyResponse.model_fields:
+            assert hasattr(response, field)
+
+    def test_overrides_win_over_defaults(self):
+        assert make_settle_response(transaction="0xfeed").transaction == "0xfeed"
+        assert make_verify_response(is_valid=False).is_valid is False
+
+    @pytest.mark.parametrize(
+        "factory",
+        [make_settle_response, make_verify_response],
+        ids=["settle", "verify"],
+    )
+    def test_unknown_override_is_rejected(self, factory):
+        # Both models use Pydantic's default extra="ignore", so constructing them
+        # directly would silently DROP a typo'd or since-removed field name. The
+        # factory has to supply that half of the guarantee itself.
+        with pytest.raises(TypeError, match="has no field"):
+            factory(no_such_field="x")
+
+    def test_alias_spelling_is_rejected(self):
+        # Call sites use the Python names; the camelCase wire alias would be
+        # silently ignored by the model, so reject it loudly.
+        with pytest.raises(TypeError, match="has no field"):
+            make_settle_response(creditsRedeemed="5")
+
+
+def _self_assigned_attrs(node: ast.ClassDef) -> set[str]:
+    """Attribute names a class sets on instances (class body + ``__init__``)."""
+    attrs: set[str] = set()
+    for stmt in node.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            attrs.add(stmt.target.id)
+        elif isinstance(stmt, ast.Assign):
+            attrs.update(t.id for t in stmt.targets if isinstance(t, ast.Name))
+        elif isinstance(stmt, ast.FunctionDef) and stmt.name == "__init__":
+            for sub in ast.walk(stmt):
+                targets = (
+                    sub.targets
+                    if isinstance(sub, ast.Assign)
+                    else [sub.target] if isinstance(sub, ast.AnnAssign) else []
+                )
+                attrs.update(
+                    t.attr
+                    for t in targets
+                    if isinstance(t, ast.Attribute)
+                    and isinstance(t.value, ast.Name)
+                    and t.value.id == "self"
+                )
+    return attrs
+
+
+def test_no_hand_rolled_settle_or_verify_doubles():
+    """No test class may stand in for a settle/verify response by hand.
+
+    This is the regression guard for the whole class of defect, not for the 12
+    instances that existed when it was written: a new attribute bag is caught on
+    the PR that adds it rather than by the next person to touch either model.
+
+    If this fails, use ``make_settle_response`` / ``make_verify_response`` from
+    ``tests/x402_responses.py`` instead of declaring a class.
+    """
+    settle_fields = set(SettleResponse.model_fields)
+    offenders = []
+
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            attrs = _self_assigned_attrs(node)
+            # "success" alone is far too common to key on; require it to look
+            # like a settle response. "is_valid" is specific enough on its own.
+            if ("success" in attrs and len(attrs & settle_fields) >= 2) or (
+                "is_valid" in attrs
+            ):
+                rel = path.relative_to(TESTS_ROOT.parent)
+                offenders.append(f"{rel}:{node.lineno} {node.name} {sorted(attrs)}")
+
+    assert not offenders, (
+        "Hand-rolled settle/verify response double(s) found; build the real "
+        "model with tests.x402_responses instead (payments-py#273):\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/unit/test_x402_response_doubles.py
+++ b/tests/unit/test_x402_response_doubles.py
@@ -11,6 +11,7 @@ These tests pin the two properties that keeps it fixed.
 """
 
 import ast
+import importlib
 import pathlib
 
 import pytest
@@ -54,10 +55,25 @@ class TestFactories:
             factory(no_such_field="x")
 
     def test_alias_spelling_is_rejected(self):
-        # Call sites use the Python names; the camelCase wire alias would be
-        # silently ignored by the model, so reject it loudly.
+        # NOT because the model would ignore it — populate_by_name=True means
+        # SettleResponse(creditsRedeemed="5") is accepted and sets
+        # credits_redeemed. The reason is the defaults/overrides dict merge:
+        # two spellings of one field survive as two keys and Pydantic resolves
+        # the alias in preference to the field name whatever the dict order, so
+        # a mixed-spelling merge silently drops one of them.
         with pytest.raises(TypeError, match="has no field"):
             make_settle_response(creditsRedeemed="5")
+
+    @pytest.mark.parametrize("defaults_name", ["SETTLE_DEFAULTS", "VERIFY_DEFAULTS"])
+    def test_defaults_are_validated_too(self, defaults_name):
+        # The overrides check alone left the factory carrying this PR's own
+        # defect: a typo'd default key is dropped by extra="ignore", every
+        # double degrades to the model's default, and the suite stays green.
+        module = importlib.import_module("tests.x402_responses")
+        model = SettleResponse if defaults_name == "SETTLE_DEFAULTS" else VerifyResponse
+        assert not set(getattr(module, defaults_name)) - set(model.model_fields)
+        with pytest.raises(TypeError, match="has no field"):
+            module._reject_unknown(model, {"remainingBalanceTYPO": 1}, "in defaults")
 
 
 def _self_assigned_attrs(node: ast.ClassDef) -> set[str]:
@@ -85,6 +101,62 @@ def _self_assigned_attrs(node: ast.ClassDef) -> set[str]:
     return attrs
 
 
+def _looks_like_a_double(attrs: set[str]) -> bool:
+    # "success" alone is far too common to key on; require it to look like a
+    # settle response. "is_valid" is specific enough on its own.
+    settle_fields = set(SettleResponse.model_fields)
+    return ("success" in attrs and len(attrs & settle_fields) >= 2) or (
+        "is_valid" in attrs
+    )
+
+
+def _sweep(paths):
+    """Return ``(offenders, scanned)`` over an iterable of .py paths."""
+    offenders, scanned = [], 0
+    for path in sorted(paths):
+        if "__pycache__" in path.parts:
+            continue
+        scanned += 1
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, ast.ClassDef) and _looks_like_a_double(
+                _self_assigned_attrs(node)
+            ):
+                offenders.append(f"{path.name}:{node.lineno} {node.name}")
+    return offenders, scanned
+
+
+HAND_ROLLED_FIXTURES = {
+    "settle": (
+        "class ReintroducedSettleBag:\n"
+        "    def __init__(self, success=True, transaction='0xdead'):\n"
+        "        self.success = success\n"
+        "        self.transaction = transaction\n"
+    ),
+    "verify": (
+        "class ReintroducedVerifyBag:\n"
+        "    def __init__(self, is_valid=True):\n"
+        "        self.is_valid = is_valid\n"
+    ),
+}
+
+
+@pytest.mark.parametrize("shape", sorted(HAND_ROLLED_FIXTURES))
+def test_sweep_detects_a_hand_rolled_double(tmp_path, shape):
+    """Positive control: the detector below must actually detect.
+
+    Without this, neutering ``_self_assigned_attrs`` to ``return set()`` leaves
+    the whole suite green — a guard that has silently stopped guarding is
+    indistinguishable from a clean tree, which is the failure mode this PR is
+    about, one level up again.
+    """
+    probe = tmp_path / "probe.py"
+    probe.write_text(HAND_ROLLED_FIXTURES[shape])
+    offenders, scanned = _sweep([probe])
+    assert scanned == 1
+    assert len(offenders) == 1, offenders
+    assert "Reintroduced" in offenders[0]
+
+
 def test_no_hand_rolled_settle_or_verify_doubles():
     """No test class may stand in for a settle/verify response by hand.
 
@@ -95,24 +167,10 @@ def test_no_hand_rolled_settle_or_verify_doubles():
     If this fails, use ``make_settle_response`` / ``make_verify_response`` from
     ``tests/x402_responses.py`` instead of declaring a class.
     """
-    settle_fields = set(SettleResponse.model_fields)
-    offenders = []
+    offenders, scanned = _sweep(TESTS_ROOT.rglob("*.py"))
 
-    for path in sorted(TESTS_ROOT.rglob("*.py")):
-        if "__pycache__" in path.parts:
-            continue
-        for node in ast.walk(ast.parse(path.read_text())):
-            if not isinstance(node, ast.ClassDef):
-                continue
-            attrs = _self_assigned_attrs(node)
-            # "success" alone is far too common to key on; require it to look
-            # like a settle response. "is_valid" is specific enough on its own.
-            if ("success" in attrs and len(attrs & settle_fields) >= 2) or (
-                "is_valid" in attrs
-            ):
-                rel = path.relative_to(TESTS_ROOT.parent)
-                offenders.append(f"{rel}:{node.lineno} {node.name} {sorted(attrs)}")
-
+    # A path change that walked the wrong tree would find zero files and pass.
+    assert scanned > 50, f"only scanned {scanned} files under {TESTS_ROOT}"
     assert not offenders, (
         "Hand-rolled settle/verify response double(s) found; build the real "
         "model with tests.x402_responses instead (payments-py#273):\n  "

--- a/tests/unit/test_x402_response_doubles.py
+++ b/tests/unit/test_x402_response_doubles.py
@@ -104,6 +104,18 @@ def _self_assigned_attrs(node: ast.ClassDef) -> set[str]:
 def _looks_like_a_double(attrs: set[str]) -> bool:
     # "success" alone is far too common to key on; require it to look like a
     # settle response. "is_valid" is specific enough on its own.
+    #
+    # ⚠️ KNOWN BLIND SPOT, deliberate. Because "success" is itself a field of
+    # SettleResponse, the `>= 2` below means "success plus at least one OTHER
+    # settle field" — so a class carrying ONLY `success` is not detected. That
+    # is asymmetric with `is_valid`, which is caught on its own, and it is the
+    # price of not flagging every unrelated class in the tree that happens to
+    # have a `success` attribute. Such a bag is also close to unusable in
+    # practice: production reads `.transaction` / `.credits_redeemed` off a
+    # settle result and would AttributeError on the first access.
+    #
+    # Widening this predicate is NOT the fix — measure the false positives
+    # first. The other blind spots are listed in the module docstring.
     settle_fields = set(SettleResponse.model_fields)
     return ("success" in attrs and len(attrs & settle_fields) >= 2) or (
         "is_valid" in attrs

--- a/tests/x402_responses.py
+++ b/tests/x402_responses.py
@@ -1,0 +1,98 @@
+"""Factories for the x402 facilitator response models used across the suite.
+
+Tests that stub ``facilitator.verify_permissions`` / ``settle_permissions`` need
+something to hand back. Historically every such test hand-rolled an attribute
+bag::
+
+    class SettleResult:
+        def __init__(self, success=True, transaction="0x123"):
+            self.success = success
+            self.transaction = transaction
+
+Those bags drift. They only ever carry the fields the production code happened
+to read on the day they were written, so the first code path to read a field the
+bag never had blows up with ``AttributeError`` — and adding a field to
+:class:`~payments_py.x402.types.SettleResponse` turns a wall of unrelated tests
+red for a reason that has nothing to do with the change (payments-py#273, where
+all 12 doubles in the suite had drifted).
+
+Building the *real* Pydantic model instead removes the failure mode: every field
+the model declares exists on the double, populated by the model's own defaults,
+so a new field is inert in tests that do not care about it. The factories below
+keep call sites as short as the bags were.
+
+Note the model itself cannot supply the other half of the guarantee: both
+response models use Pydantic's default ``extra="ignore"``, so a typo'd or
+removed field would be silently dropped rather than raised. ``_build`` therefore
+validates override names against ``model_fields`` — a stale keyword is a
+``TypeError`` at the call site, which is where it can be understood.
+"""
+
+from typing import Any, Dict, Type, TypeVar
+
+from pydantic import BaseModel
+
+from payments_py.x402.types import SettleResponse, VerifyResponse
+
+__all__ = [
+    "DEFAULT_NETWORK",
+    "DEFAULT_PAYER",
+    "SETTLE_DEFAULTS",
+    "VERIFY_DEFAULTS",
+    "make_settle_response",
+    "make_verify_response",
+]
+
+#: CAIP-2 network the rest of the suite's fixture tokens are minted against.
+DEFAULT_NETWORK = "eip155:84532"
+#: Subscriber address the fixture tokens are issued to.
+DEFAULT_PAYER = "0xTestSubscriber"
+
+#: A settle response shaped the way the facilitator really answers a successful
+#: burn: every field the backend populates is populated here too, so a test that
+#: reads one gets a value rather than an attribute error.
+SETTLE_DEFAULTS: Dict[str, Any] = {
+    "success": True,
+    "transaction": "0x123",
+    "network": DEFAULT_NETWORK,
+    "payer": DEFAULT_PAYER,
+    "credits_redeemed": "1",
+    "remaining_balance": "100",
+}
+
+#: Likewise for a successful verify. ``agent_request`` / ``agent_request_id`` /
+#: ``url_matching`` stay unset because the backend only returns them when
+#: observability is configured; tests that assert on them pass them explicitly.
+VERIFY_DEFAULTS: Dict[str, Any] = {
+    "is_valid": True,
+    "network": DEFAULT_NETWORK,
+    "payer": DEFAULT_PAYER,
+}
+
+_M = TypeVar("_M", bound=BaseModel)
+
+
+def _build(model: Type[_M], defaults: Dict[str, Any], overrides: Dict[str, Any]) -> _M:
+    unknown = sorted(set(overrides) - set(model.model_fields))
+    if unknown:
+        raise TypeError(
+            f"{model.__name__} has no field(s) {unknown}. "
+            f"Known fields: {sorted(model.model_fields)}"
+        )
+    return model(**{**defaults, **overrides})
+
+
+def make_settle_response(**overrides: Any) -> SettleResponse:
+    """Build a real :class:`SettleResponse`, overriding any subset of fields.
+
+    Field names are the Python (snake_case) ones, not the wire aliases.
+    """
+    return _build(SettleResponse, SETTLE_DEFAULTS, overrides)
+
+
+def make_verify_response(**overrides: Any) -> VerifyResponse:
+    """Build a real :class:`VerifyResponse`, overriding any subset of fields.
+
+    Field names are the Python (snake_case) ones, not the wire aliases.
+    """
+    return _build(VerifyResponse, VERIFY_DEFAULTS, overrides)

--- a/tests/x402_responses.py
+++ b/tests/x402_responses.py
@@ -72,13 +72,42 @@ VERIFY_DEFAULTS: Dict[str, Any] = {
 _M = TypeVar("_M", bound=BaseModel)
 
 
-def _build(model: Type[_M], defaults: Dict[str, Any], overrides: Dict[str, Any]) -> _M:
-    unknown = sorted(set(overrides) - set(model.model_fields))
+def _reject_unknown(model: Type[BaseModel], names: Any, what: str) -> None:
+    """Raise unless every name in ``names`` is a field of ``model``.
+
+    Both response models use Pydantic's default ``extra="ignore"``, so a name the
+    model does not know is silently dropped rather than raised — the exact drift
+    this module exists to close, one level up. It has to be caught here.
+
+    Note the check rejects the camelCase wire aliases too, even though
+    ``populate_by_name=True`` means Pydantic would happily *accept*
+    ``creditsRedeemed`` and set ``credits_redeemed`` from it. The reason is the
+    merge below: ``{**defaults, **overrides}`` keys on the string, so two
+    spellings of one field survive as two separate keys, and Pydantic then
+    resolves the alias in preference to the field name *regardless of dict
+    order*. A mixed-spelling merge therefore silently ignores one of the two —
+    and in the direction that matters (an aliased default, an override in the
+    Python name) it is the override that loses. One spelling per field is what
+    makes "overrides win" actually true.
+    """
+    unknown = sorted(set(names) - set(model.model_fields))
     if unknown:
         raise TypeError(
-            f"{model.__name__} has no field(s) {unknown}. "
+            f"{model.__name__} has no field(s) {unknown} ({what}). "
             f"Known fields: {sorted(model.model_fields)}"
         )
+
+
+# Validate the defaults at import time. Without this the factory reintroduces
+# the PR's own defect: a typo'd or renamed default key is dropped by
+# extra="ignore", every double silently degrades to the model's own default, and
+# the suite stays green while testing less than it claims to.
+_reject_unknown(SettleResponse, SETTLE_DEFAULTS, "in SETTLE_DEFAULTS")
+_reject_unknown(VerifyResponse, VERIFY_DEFAULTS, "in VERIFY_DEFAULTS")
+
+
+def _build(model: Type[_M], defaults: Dict[str, Any], overrides: Dict[str, Any]) -> _M:
+    _reject_unknown(model, overrides, "passed as an override")
     return model(**{**defaults, **overrides})
 
 


### PR DESCRIPTION
Closes #273.

> ⚠️ **This body replaces an incorrect one.** The original was the TypeScript sibling's (nevermined-io/payments#437) — it described `pnpm build`, `tsc`, `tests/tsconfig.json` and a `typecheck:tests` CI step, none of which exist in this repo, and its `Closes #433` is a 404 here. Caught in review. The correct issue is #273; see the note at the bottom on how it happened.

## The defect

Every test that stubs `facilitator.verify_permissions` / `settle_permissions` hand-rolled an attribute bag:

```python
class SettleResult:
    def __init__(self, success=True, transaction="0x123"):
        self.success = success
        self.transaction = transaction
```

Those bags carry only the fields the production code happened to read on the day they were written. All **12** in the suite had drifted from `SettleResponse` / `VerifyResponse`. The failure mode is asymmetric and nasty: the first code path to read a field a bag never had blows up with `AttributeError`, and adding a field to the real model turns a wall of unrelated tests red for a reason that has nothing to do with the change.

## The fix

Build the **real Pydantic model** instead, via `tests/x402_responses.py`. Every field the model declares exists on the double, populated by the model's own defaults, so a new field is inert in tests that do not care about it.

**The model alone cannot supply the other half of the guarantee.** Both response models use Pydantic's default `extra="ignore"`, so a typo'd or removed field is *silently dropped* rather than raised:

```python
SettleResponse(success=True, creditsRedeemd='9').credits_redeemed   # -> None, no raise
```

So `_reject_unknown` validates override names against `model_fields` — **and runs over the defaults dicts at import time**, which is the hole that would otherwise let the factory reintroduce the very bug it exists to fix. A bad default is then a collection error across every importing file, not one quiet degradation.

It also rejects the camelCase wire aliases, deliberately: `populate_by_name=True` means Pydantic *accepts* `creditsRedeemed`, and `{**defaults, **overrides}` keys on the string — so two spellings of one field survive as two keys and Pydantic prefers the alias **whatever the dict order**, silently dropping the override. Verified in both orders on pydantic 2.12.5.

An AST sweep (`tests/unit/test_x402_response_doubles.py`) fails if a hand-rolled bag reappears.

## Verification

Runner: **pytest via the payments-py poetry venv** (not testmcp).

- `poetry run pytest -m "not slow"` — **1080 passed**, 1 skipped, 102 deselected
- `poetry run black --check .` — 191 files unchanged
- `poetry run mkdocs build` — clean

### Mutation results — which tests die

| mutant | killed |
| --- | --- |
| sweep detector → `return set()` | `test_sweep_detects_a_hand_rolled_double[settle]`, `[verify]` |
| typo a key in `SETTLE_DEFAULTS` | **12 collection errors** (import-time) |
| `TESTS_ROOT` → nonexistent path | `test_no_hand_rolled_…` (`assert 0 > 50`) |
| strip the name check from `_reject_unknown` | `test_unknown_override_is_rejected[settle]`, `[verify]`, `test_alias_spelling_is_rejected`, `test_defaults_are_validated_too[SETTLE_DEFAULTS]`, `[VERIFY_DEFAULTS]` |
| unmutated control | 1080 passed |

Mutating `DEFAULT_NETWORK`, `DEFAULT_PAYER`, `transaction`, `credits_redeemed` and `remaining_balance` each leaves 1080 passing — no assertion is pinned to a factory value. `success: True` **is** load-bearing (16 red), correctly: it is the "this is the success shape" default that bare `make_settle_response()` call sites depend on.

## Known blind spot, stated rather than implied

The sweep parses `ast.ClassDef` only, so dict / `Mock` / `SimpleNamespace` stubs are invisible to it. The tree is clean of those now, and `CLAUDE.md` says so explicitly rather than implying coverage it lacks.

## How the wrong body happened

Several agents in one session shared a scratchpad directory, and a PR-body file was overwritten by another agent working in a different repo. That near-miss was recorded earlier in the same session on another PR and caught before pushing; here it was not. The lesson is namespacing per agent, not "check more carefully" — `$CLAUDE_JOB_DIR/tmp` is shared by every agent in a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVpimo1dBXnTJo9tQSy8SA
